### PR TITLE
Add support for `protected(set)` and `public(set)`

### DIFF
--- a/crates/ast/src/ast/modifier.rs
+++ b/crates/ast/src/ast/modifier.rs
@@ -24,7 +24,9 @@ pub enum Modifier {
     Abstract(Keyword),
     Readonly(Keyword),
     Public(Keyword),
+    PublicSet(Keyword),
     Protected(Keyword),
+    ProtectedSet(Keyword),
     Private(Keyword),
     PrivateSet(Keyword),
 }
@@ -37,7 +39,9 @@ impl Modifier {
             Modifier::Abstract(k) => k,
             Modifier::Readonly(k) => k,
             Modifier::Public(k) => k,
+            Modifier::PublicSet(k) => k,
             Modifier::Protected(k) => k,
+            Modifier::ProtectedSet(k) => k,
             Modifier::Private(k) => k,
             Modifier::PrivateSet(k) => k,
         }
@@ -47,7 +51,12 @@ impl Modifier {
     pub fn is_visibility(&self) -> bool {
         matches!(
             self,
-            Modifier::Public(..) | Modifier::Protected(..) | Modifier::Private(..) | Modifier::PrivateSet(..)
+            Modifier::Public(..)
+                | Modifier::Protected(..)
+                | Modifier::Private(..)
+                | Modifier::PrivateSet(..)
+                | Modifier::ProtectedSet(..)
+                | Modifier::PublicSet(..)
         )
     }
 
@@ -58,7 +67,7 @@ impl Modifier {
 
     /// Returns `true` if the modifier is a write visibility modifier.
     pub fn is_write_visibility(&self) -> bool {
-        matches!(self, Modifier::PrivateSet(..))
+        matches!(self, Modifier::PrivateSet(..) | Modifier::ProtectedSet(..) | Modifier::PublicSet(..))
     }
 
     pub fn as_str<'a>(&self, interner: &'a ThreadedInterner) -> &'a str {
@@ -71,6 +80,8 @@ impl Modifier {
             Modifier::Protected(k) => interner.lookup(&k.value),
             Modifier::Private(k) => interner.lookup(&k.value),
             Modifier::PrivateSet(k) => interner.lookup(&k.value),
+            Modifier::ProtectedSet(k) => interner.lookup(&k.value),
+            Modifier::PublicSet(k) => interner.lookup(&k.value),
         }
     }
 }
@@ -85,7 +96,9 @@ impl HasSpan for Modifier {
             | Modifier::Public(value)
             | Modifier::Protected(value)
             | Modifier::Private(value)
-            | Modifier::PrivateSet(value) => value.span(),
+            | Modifier::PrivateSet(value)
+            | Modifier::ProtectedSet(value)
+            | Modifier::PublicSet(value) => value.span(),
         }
     }
 }
@@ -135,7 +148,12 @@ impl Sequence<Modifier> {
         self.iter().find(|modifier| {
             matches!(
                 modifier,
-                Modifier::Public(..) | Modifier::Protected(..) | Modifier::Private(..) | Modifier::PrivateSet(..)
+                Modifier::Public(..)
+                    | Modifier::Protected(..)
+                    | Modifier::Private(..)
+                    | Modifier::PrivateSet(..)
+                    | Modifier::ProtectedSet(..)
+                    | Modifier::PublicSet(..)
             )
         })
     }
@@ -146,7 +164,9 @@ impl Sequence<Modifier> {
     }
 
     pub fn get_first_write_visibility(&self) -> Option<&Modifier> {
-        self.iter().find(|modifier| matches!(modifier, Modifier::PrivateSet(..)))
+        self.iter().find(|modifier| {
+            matches!(modifier, Modifier::PrivateSet(..) | Modifier::ProtectedSet(..) | Modifier::PublicSet(..))
+        })
     }
 
     /// Returns `true` if the sequence contains a visibility modifier for reading or writing.
@@ -187,5 +207,21 @@ impl Sequence<Modifier> {
 
     pub fn contains_private_set(&self) -> bool {
         self.iter().any(|modifier| matches!(modifier, Modifier::PrivateSet(..)))
+    }
+
+    pub fn get_protected_set(&self) -> Option<&Modifier> {
+        self.iter().find(|modifier| matches!(modifier, Modifier::ProtectedSet(..)))
+    }
+
+    pub fn contains_protected_set(&self) -> bool {
+        self.iter().any(|modifier| matches!(modifier, Modifier::ProtectedSet(..)))
+    }
+
+    pub fn get_public_set(&self) -> Option<&Modifier> {
+        self.iter().find(|modifier| matches!(modifier, Modifier::PublicSet(..)))
+    }
+
+    pub fn contains_public_set(&self) -> bool {
+        self.iter().any(|modifier| matches!(modifier, Modifier::PublicSet(..)))
     }
 }

--- a/crates/ast/src/node.rs
+++ b/crates/ast/src/node.rs
@@ -1615,6 +1615,8 @@ impl<'a> Node<'a> {
                 Modifier::Static(node) => Node::Keyword(node),
                 Modifier::Readonly(node) => Node::Keyword(node),
                 Modifier::PrivateSet(node) => Node::Keyword(node),
+                Modifier::ProtectedSet(node) => Node::Keyword(node),
+                Modifier::PublicSet(node) => Node::Keyword(node),
             }],
             Node::Namespace(node) => {
                 let mut children = vec![Node::Keyword(&node.r#namespace)];

--- a/crates/formatter/src/format/mod.rs
+++ b/crates/formatter/src/format/mod.rs
@@ -1439,6 +1439,8 @@ impl<'a> Format<'a> for Modifier {
                 Modifier::Protected(keyword) => keyword.format(f),
                 Modifier::Private(keyword) => keyword.format(f),
                 Modifier::PrivateSet(keyword) => keyword.format(f),
+                Modifier::ProtectedSet(keyword) => keyword.format(f),
+                Modifier::PublicSet(keyword) => keyword.format(f),
             }
         })
     }

--- a/crates/lexer/src/lib.rs
+++ b/crates/lexer/src/lib.rs
@@ -433,6 +433,22 @@ impl<'a, 'i> Lexer<'a, 'i> {
 
                                     break;
                                 }
+                                // special case for `public(set)`
+                                [b'(', ..] if length == 6 => {
+                                    if self.input.is_at(b"public(set)", true) {
+                                        break 'identifier (TokenKind::PublicSet, 6 + 5);
+                                    }
+
+                                    break;
+                                }
+                                // special case for `protected(set)`
+                                [b'(', ..] if length == 9 => {
+                                    if self.input.is_at(b"protected(set)", true) {
+                                        break 'identifier (TokenKind::ProtectedSet, 9 + 5);
+                                    }
+
+                                    break;
+                                }
                                 _ => {
                                     break;
                                 }

--- a/crates/linter/src/plugin/redundancy/mod.rs
+++ b/crates/linter/src/plugin/redundancy/mod.rs
@@ -1,3 +1,5 @@
+use rules::redundant_write_visibility::RedundantWriteVisibilityRule;
+
 use crate::plugin::redundancy::rules::redundant_block::RedundantBlockRule;
 use crate::plugin::redundancy::rules::redundant_closing_tag::RedudnantClosingTagRule;
 use crate::plugin::redundancy::rules::redundant_continue::RedundantContinueRule;
@@ -37,6 +39,7 @@ impl Plugin for RedundancyPlugin {
             Box::new(RedundantFinalMethodModifierRule),
             Box::new(RedundantLabelRule),
             Box::new(RedundantIfStatementRule),
+            Box::new(RedundantWriteVisibilityRule),
         ]
     }
 }

--- a/crates/linter/src/plugin/redundancy/rules/mod.rs
+++ b/crates/linter/src/plugin/redundancy/rules/mod.rs
@@ -8,3 +8,4 @@ pub mod redundant_method_override;
 pub mod redundant_noop;
 pub mod redundant_parentheses;
 pub mod redundant_string_concat;
+pub mod redundant_write_visibility;

--- a/crates/linter/src/plugin/redundancy/rules/redundant_write_visibility.rs
+++ b/crates/linter/src/plugin/redundancy/rules/redundant_write_visibility.rs
@@ -1,0 +1,62 @@
+use mago_ast::Modifier;
+use mago_ast::Property;
+use mago_fixer::SafetyClassification;
+use mago_reporting::Annotation;
+use mago_reporting::Issue;
+use mago_reporting::Level;
+use mago_span::HasSpan;
+use mago_walker::Walker;
+
+use crate::context::LintContext;
+use crate::rule::Rule;
+
+#[derive(Clone, Debug)]
+pub struct RedundantWriteVisibilityRule;
+
+impl Rule for RedundantWriteVisibilityRule {
+    fn get_name(&self) -> &'static str {
+        "redundant-write-visibility"
+    }
+
+    fn get_default_level(&self) -> Option<Level> {
+        Some(Level::Help)
+    }
+}
+
+impl<'a> Walker<LintContext<'a>> for RedundantWriteVisibilityRule {
+    fn walk_in_property(&self, property: &Property, context: &mut LintContext<'a>) {
+        let modifiers = property.modifiers();
+
+        if modifiers.is_empty() {
+            return;
+        }
+
+        let Some(write_visibility) = modifiers.get_first_write_visibility() else {
+            return;
+        };
+
+        let Some(read_visibility) = modifiers.get_first_read_visibility() else {
+            return;
+        };
+
+        match (read_visibility, write_visibility) {
+            (Modifier::Public(_), Modifier::PublicSet(_))
+            | (Modifier::Protected(_), Modifier::ProtectedSet(_))
+            | (Modifier::Private(_), Modifier::PrivateSet(_)) => {
+                let issue = Issue::new(context.level(), "Identical write visibility has no effect.")
+                    .with_help("Remove the redundant write visibility modifier.")
+                    .with_annotations(vec![
+                        Annotation::primary(write_visibility.span()).with_message("Redundant write visibility."),
+                        Annotation::secondary(read_visibility.span()).with_message("Read visibility."),
+                    ]);
+
+                context.report_with_fix(issue, |plan| {
+                    let range = write_visibility.span().to_range();
+
+                    plan.delete(range, SafetyClassification::PotentiallyUnsafe)
+                });
+            }
+            _ => {}
+        }
+    }
+}

--- a/crates/parser/src/internal/modifier.rs
+++ b/crates/parser/src/internal/modifier.rs
@@ -36,6 +36,8 @@ pub fn parse_optional_modifier(stream: &mut TokenStream<'_, '_>) -> Result<Optio
         Some(T!["abstract"]) => Modifier::Abstract(utils::expect_any_keyword(stream)?),
         Some(T!["readonly"]) => Modifier::Readonly(utils::expect_any_keyword(stream)?),
         Some(T!["private(set)"]) => Modifier::PrivateSet(utils::expect_any_keyword(stream)?),
+        Some(T!["protected(set)"]) => Modifier::ProtectedSet(utils::expect_any_keyword(stream)?),
+        Some(T!["public(set)"]) => Modifier::PublicSet(utils::expect_any_keyword(stream)?),
         _ => return Ok(None),
     }))
 }

--- a/crates/token/src/lib.rs
+++ b/crates/token/src/lib.rs
@@ -222,7 +222,9 @@ pub enum TokenKind {
     Private,                     // `private`
     PrivateSet,                  // `private(set)`
     Protected,                   // `protected`
+    ProtectedSet,                // `protected(set)`
     Public,                      // `public`
+    PublicSet,                   // `public(set)`
     QualifiedIdentifier,         // `Namespace\Class`
     Question,                    // `?`
     QuestionColon,               // `?:`
@@ -488,14 +490,23 @@ impl TokenKind {
 
     #[inline(always)]
     pub fn is_visibility_modifier(&self) -> bool {
-        matches!(self, T!["public" | "protected" | "private" | "private(set)"])
+        matches!(self, T!["public" | "protected" | "private" | "private(set)" | "protected(set)" | "public(set)"])
     }
 
     #[inline(always)]
     pub fn is_modifier(&self) -> bool {
         matches!(
             self,
-            T!["public" | "protected" | "private" | "private(set)" | "static" | "final" | "abstract" | "readonly"]
+            T!["public"
+                | "protected"
+                | "private"
+                | "private(set)"
+                | "protected(set)"
+                | "public(set)"
+                | "static"
+                | "final"
+                | "abstract"
+                | "readonly"]
         )
     }
 
@@ -537,7 +548,9 @@ impl TokenKind {
                 | "private"
                 | "private(set)"
                 | "protected"
+                | "protected(set)"
                 | "public"
+                | "public(set)"
                 | "include"
                 | "include_once"
                 | "eval"
@@ -1158,8 +1171,14 @@ macro_rules! T {
     ("protected") => {
         $crate::TokenKind::Protected
     };
+    ("protected(set)") => {
+        $crate::TokenKind::ProtectedSet
+    };
     ("public") => {
         $crate::TokenKind::Public
+    };
+    ("public(set)") => {
+        $crate::TokenKind::PublicSet
     };
     ("Qualified\\Identifier") => {
         $crate::TokenKind::QualifiedIdentifier


### PR DESCRIPTION
`protected(set)` and `public(set)` are semantically valid.  `public public(set)` is silly but valid PHP code. PHP doesn't warn or error because of the identical visibilities.

I've added a new linter rule to tell you that the additional write visibility is redundant too:

![image](https://github.com/user-attachments/assets/15210613-1606-4389-a268-4e2490e064c5)

Side note - I've marked the fix as potentially unsafe since there could be a reason for having identical read/write visibilities, but also happy to change that to a safe fix since it doesn't really have an effect.
