### PR TITLE
Update directory walking to be multithreaded

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,6 +520,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +556,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1346,6 +1377,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56"
+dependencies = [
+ "crossbeam",
+ "rayon",
+]
+
+[[package]]
 name = "lasso"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,6 +1459,7 @@ dependencies = [
  "diffy",
  "futures",
  "glob-match",
+ "jwalk",
  "mago-ast",
  "mago-feedback",
  "mago-fixer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,6 +138,7 @@ config = { workspace = true }
 toml = { workspace = true }
 num_cpus = { workspace = true }
 diffy = { workspace = true }
+jwalk = "0.8.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 openssl = { workspace = true }

--- a/src/source.rs
+++ b/src/source.rs
@@ -10,7 +10,7 @@ use crate::error::Error;
 /// Load the source manager by scanning and processing the sources
 /// as per the given configuration.
 ///
-/// #_Arguments
+/// # Arguments
 ///
 /// * `interner` - The interner to use for string interning.
 /// * `configuration` - The configuration to use for loading the sources.

--- a/src/source.rs
+++ b/src/source.rs
@@ -2,7 +2,6 @@ use ahash::HashSet;
 use mago_interner::ThreadedInterner;
 use mago_source::SourceManager;
 use std::path::Path;
-use tracing::debug;
 
 use crate::config::source::SourceConfiguration;
 use crate::consts::PHP_STUBS;


### PR DESCRIPTION
Hello,

 I try to test most cases and it seems that the behaviour is the same or even improved. For example in the excludes now both `**/vendor/composer/*` and `vendor/composer/*` works.

Regarding the dir walking:
-  | am using new added jwalk crate which works in async and on mutiple cores.
-  I ignore before walking down directories that starts with a `.` and node_modules folders. This folder it's something new but I can't really think of a reason why we shouldn't ignore it, it's pretty common, has a huge amount of dirs and files, and it's not PHP.

I am fairly new rust so hopefully this looks good enough

 