### PR TITLE
Add compatibility/arrow-functions-feature lint

### DIFF
--- a/crates/linter/src/plugin/compatibility/mod.rs
+++ b/crates/linter/src/plugin/compatibility/mod.rs
@@ -1,4 +1,5 @@
 use crate::definition::PluginDefinition;
+use crate::plugin::compatibility::rules::php74::arrow_functions_feature::ArrowFunctionsFeatureRule;
 use crate::plugin::compatibility::rules::php74::null_coalesce_assignment_feature::NullCoalesceAssignmentFeatureRule;
 use crate::plugin::compatibility::rules::php80::named_arguments_feature::NamedArgumentsFeatureRule;
 use crate::plugin::compatibility::rules::php80::promoted_properties_feature::PromotedPropertiesFeatureRule;
@@ -26,6 +27,7 @@ impl Plugin for CompatibilityPlugin {
     fn get_rules(&self) -> Vec<Box<dyn Rule>> {
         vec![
             // PHP 7.4
+            Box::new(ArrowFunctionsFeatureRule),
             Box::new(NullCoalesceAssignmentFeatureRule),
             // PHP 8.0
             Box::new(NamedArgumentsFeatureRule),

--- a/crates/linter/src/plugin/compatibility/rules/mod.rs
+++ b/crates/linter/src/plugin/compatibility/rules/mod.rs
@@ -1,4 +1,5 @@
 pub mod php74 {
+    pub mod arrow_functions_feature;
     pub mod null_coalesce_assignment_feature;
 }
 

--- a/crates/linter/src/plugin/compatibility/rules/php74/arrow_functions_feature.rs
+++ b/crates/linter/src/plugin/compatibility/rules/php74/arrow_functions_feature.rs
@@ -1,0 +1,63 @@
+use indoc::indoc;
+
+use mago_ast::ast::*;
+use mago_php_version::PHPVersion;
+use mago_reporting::*;
+use mago_span::*;
+use mago_walker::Walker;
+
+use crate::context::LintContext;
+use crate::definition::RuleDefinition;
+use crate::definition::RuleUsageExample;
+use crate::rule::Rule;
+
+#[derive(Clone, Copy, Debug)]
+pub struct ArrowFunctionsFeatureRule;
+
+impl Rule for ArrowFunctionsFeatureRule {
+    fn get_definition(&self) -> RuleDefinition {
+        RuleDefinition::enabled("Arrow Functions Feature", Level::Error)
+            .with_maximum_supported_php_version(PHPVersion::PHP74)
+            .with_description(indoc! {"
+                Flags any usage of the `fn` keyword for arrow functions, which was introduced in PHP 7.4.
+
+                In environments running older versions of PHP, you can use an anonymous function.
+            "})
+            .with_example(RuleUsageExample::valid(
+                "Using an anonymous function with `use` keyword",
+                indoc! {r#"
+                    <?php
+
+                    $y = 2;
+
+                    // Works in all PHP versions (pre-7.4 included):
+                    $fn = function ($x) use ($y) {
+                        return $x + $y;
+                    };
+                "#},
+            ))
+            .with_example(RuleUsageExample::invalid(
+                "Using the `fn` keyword for arrow functions",
+                indoc! {r#"
+                    <?php
+
+                    $y = 2;
+
+                    // Only valid in PHP 7.4+:
+                    $fn = fn ($x) => $x + $y;
+                "#},
+            ))
+    }
+}
+
+impl<'a> Walker<LintContext<'a>> for ArrowFunctionsFeatureRule {
+    fn walk_in_arrow_function<'ast>(&self, arrow_function: &'ast ArrowFunction, context: &mut LintContext<'a>) {
+        let issue =
+            Issue::new(context.level(), "The `fn` keyword for arrow functions is only available in PHP 7.4 and later.")
+                .with_annotation(
+                    Annotation::primary(arrow_function.span()).with_message("Arrow function uses `fn` keyword."),
+                );
+
+        context.report(issue);
+    }
+}

--- a/crates/php-version/src/feature.rs
+++ b/crates/php-version/src/feature.rs
@@ -63,4 +63,5 @@ pub enum Feature {
     PropertyHooks,
     JsonValidate,
     ClosureInConstantExpressions,
+    ArrowFunctions,
 }

--- a/crates/php-version/src/lib.rs
+++ b/crates/php-version/src/lib.rs
@@ -184,7 +184,8 @@ impl PHPVersion {
             Feature::NullCoalesceAssign
             | Feature::ParameterContravariance
             | Feature::ReturnCovariance
-            | Feature::PregUnmatchedAsNull => self.0 >= 0x070400,
+            | Feature::PregUnmatchedAsNull
+            | Feature::ArrowFunctions => self.0 >= 0x070400,
             Feature::NonCapturingCatches
             | Feature::NativeUnionTypes
             | Feature::LessOverridenParametersWithVariadic


### PR DESCRIPTION
This is my first attempt at writing a lint!

In order to test it out properly, the `MINIMUM_PHP_VERSION` needs to be lowered to `PHP73` since arrow functions are available on PHP 7.4+. (note: there is currently an issue with "Null Coalesce Assignment Feature" that warns for `php_version = "7.4"` see more info here: https://github.com/carthage-software/mago/commit/95a84ce80e9d90b007190e2892fd7f6a60ab9806#r151496707)

https://github.com/carthage-software/mago/blob/dc326633ff8fdd49ca21803e1a7d3d59780fb924/src/consts.rs#L52

I have done that locally, and the lint seems to be working! 🎉 

<img width="875" alt="Screenshot 2025-01-18 at 16 05 13" src="https://github.com/user-attachments/assets/d438646d-9e6b-4605-9a93-25c4212fab01" />
