### PR TITLE
Add preliminary support for PHP 5.4

### DIFF
--- a/crates/linter/src/plugin/compatibility/mod.rs
+++ b/crates/linter/src/plugin/compatibility/mod.rs
@@ -1,4 +1,5 @@
 use crate::definition::PluginDefinition;
+use crate::plugin::compatibility::rules::php55::finally_feature::FinallyFeatureRule;
 use crate::plugin::compatibility::rules::php56::variadic_functions_feature::VariadicFunctionsFeatureRule;
 use crate::plugin::compatibility::rules::php74::null_coalesce_assignment_feature::NullCoalesceAssignmentFeatureRule;
 use crate::plugin::compatibility::rules::php80::named_arguments_feature::NamedArgumentsFeatureRule;
@@ -26,6 +27,8 @@ impl Plugin for CompatibilityPlugin {
 
     fn get_rules(&self) -> Vec<Box<dyn Rule>> {
         vec![
+            // PHP 5.5
+            Box::new(FinallyFeatureRule),
             // PHP 5.6
             Box::new(VariadicFunctionsFeatureRule),
             // PHP 7.4

--- a/crates/linter/src/plugin/compatibility/mod.rs
+++ b/crates/linter/src/plugin/compatibility/mod.rs
@@ -1,4 +1,5 @@
 use crate::definition::PluginDefinition;
+use crate::plugin::compatibility::rules::php56::variadic_functions_feature::VariadicFunctionsFeatureRule;
 use crate::plugin::compatibility::rules::php74::null_coalesce_assignment_feature::NullCoalesceAssignmentFeatureRule;
 use crate::plugin::compatibility::rules::php80::named_arguments_feature::NamedArgumentsFeatureRule;
 use crate::plugin::compatibility::rules::php80::promoted_properties_feature::PromotedPropertiesFeatureRule;
@@ -25,6 +26,8 @@ impl Plugin for CompatibilityPlugin {
 
     fn get_rules(&self) -> Vec<Box<dyn Rule>> {
         vec![
+            // PHP 5.6
+            Box::new(VariadicFunctionsFeatureRule),
             // PHP 7.4
             Box::new(NullCoalesceAssignmentFeatureRule),
             // PHP 8.0

--- a/crates/linter/src/plugin/compatibility/rules/mod.rs
+++ b/crates/linter/src/plugin/compatibility/rules/mod.rs
@@ -1,3 +1,7 @@
+pub mod php55 {
+    pub mod finally_feature;
+}
+
 pub mod php56 {
     pub mod variadic_functions_feature;
 }

--- a/crates/linter/src/plugin/compatibility/rules/mod.rs
+++ b/crates/linter/src/plugin/compatibility/rules/mod.rs
@@ -1,3 +1,7 @@
+pub mod php56 {
+    pub mod variadic_functions_feature;
+}
+
 pub mod php74 {
     pub mod null_coalesce_assignment_feature;
 }

--- a/crates/linter/src/plugin/compatibility/rules/php55/finally_feature.rs
+++ b/crates/linter/src/plugin/compatibility/rules/php55/finally_feature.rs
@@ -1,0 +1,71 @@
+use indoc::indoc;
+
+use mago_ast::ast::*;
+use mago_php_version::PHPVersion;
+use mago_reporting::*;
+use mago_span::*;
+use mago_walker::Walker;
+
+use crate::context::LintContext;
+use crate::definition::RuleDefinition;
+use crate::definition::RuleUsageExample;
+use crate::rule::Rule;
+
+#[derive(Clone, Copy, Debug)]
+pub struct FinallyFeatureRule;
+
+impl Rule for FinallyFeatureRule {
+    fn get_definition(&self) -> RuleDefinition {
+        RuleDefinition::enabled("Finally Feature", Level::Error)
+            .with_maximum_supported_php_version(PHPVersion::PHP54)
+            .with_description(indoc! {"
+                Flags any usage of the `finally` keyword, which was introduced in PHP 5.5.
+
+                In environments running older versions of PHP, you can use a `try`/`catch` block without a `finally` block instead.
+            "})
+            .with_example(RuleUsageExample::valid(
+                "Using a `try`/`catch` block without a `finally` block",
+                indoc! {r#"
+                    <?php
+
+                    try {
+                        // Code that might throw an exception.
+                    } catch (Exception $e) {
+                        // Handle the exception.
+                    }
+                "#},
+            ))
+            .with_example(RuleUsageExample::invalid(
+                "Using a `try`/`catch` block with a `finally` block",
+                indoc! {r#"
+                    <?php
+
+                    try {
+                        // Code that might throw an exception.
+                    } catch (Exception $e) {
+                        // Handle the exception.
+                    } finally {
+                        // Code that should always run.
+                    }
+                "#},
+            ))
+    }
+}
+
+impl<'a> Walker<LintContext<'a>> for FinallyFeatureRule {
+    fn walk_in_try<'ast>(&self, r#try: &'ast Try, context: &mut LintContext<'a>) {
+        let Some(finally) = r#try.finally_clause.as_ref() else {
+            return;
+        };
+
+        let issue = Issue::new(
+            context.level(),
+            "The `finally` block is only available in PHP 5.5 and later.",
+        )
+        .with_annotation(
+            Annotation::primary(finally.span()).with_message("Finally block used here."),
+        );
+
+        context.report(issue);
+    }
+}

--- a/crates/linter/src/plugin/compatibility/rules/php56/variadic_functions_feature.rs
+++ b/crates/linter/src/plugin/compatibility/rules/php56/variadic_functions_feature.rs
@@ -1,0 +1,73 @@
+use indoc::indoc;
+
+use mago_ast::ast::*;
+use mago_php_version::PHPVersion;
+use mago_reporting::*;
+use mago_span::*;
+use mago_walker::Walker;
+
+use crate::context::LintContext;
+use crate::definition::RuleDefinition;
+use crate::definition::RuleUsageExample;
+use crate::rule::Rule;
+
+#[derive(Clone, Copy, Debug)]
+pub struct VariadicFunctionsFeatureRule;
+
+impl Rule for VariadicFunctionsFeatureRule {
+    fn get_definition(&self) -> RuleDefinition {
+        RuleDefinition::enabled("Variadic Functions Feature", Level::Error)
+            .with_maximum_supported_php_version(PHPVersion::PHP55)
+            .with_description(indoc! {"
+                Flags any usage of variadic functions, which were introduced in PHP 5.6.
+
+                In environments running older versions of PHP, you can use the `func_get_args()` function instead.
+            "})
+            .with_example(RuleUsageExample::valid(
+                "Using `func_get_args()` instead of variadic functions",
+                indoc! {r#"
+                    <?php
+
+                    function sum() {
+                        $args = func_get_args();
+                        return array_sum($args);
+                    }
+
+                    echo sum(1, 2, 3);
+                "#},
+            ))
+            .with_example(RuleUsageExample::invalid(
+                "Using variadic functions",
+                indoc! {r#"
+                    <?php
+
+                    function sum(...$args) {
+                        return array_sum($args);
+                    }
+
+                    echo sum(1, 2, 3);
+                "#},
+            ))
+    }
+}
+
+impl<'a> Walker<LintContext<'a>> for VariadicFunctionsFeatureRule {
+    fn walk_in_function<'ast>(&self, function: &'ast Function, context: &mut LintContext<'a>) {
+        for param in function.parameters.parameters.iter() {
+            if param.ellipsis.is_none() {
+                continue;
+            }
+
+            let issue = Issue::new(
+                context.level(),
+                "Variadic functions are only available in PHP 5.6 and later.",
+            )
+            .with_annotation(
+                Annotation::primary(param.span()).with_message("Variadic parameter used here."),
+            )
+            .with_note("Use `func_get_args()` if you need compatibility with older PHP versions.");
+
+            context.report(issue);
+        }
+    }
+}

--- a/crates/php-version/src/lib.rs
+++ b/crates/php-version/src/lib.rs
@@ -31,6 +31,9 @@ pub mod feature;
 pub struct PHPVersion(u32);
 
 impl PHPVersion {
+    /// The PHP 5.5 version.
+    pub const PHP55: PHPVersion = PHPVersion::new(5, 5, 0);
+
     /// The PHP 7.0 version.
     pub const PHP70: PHPVersion = PHPVersion::new(7, 0, 0);
 

--- a/crates/php-version/src/lib.rs
+++ b/crates/php-version/src/lib.rs
@@ -31,6 +31,9 @@ pub mod feature;
 pub struct PHPVersion(u32);
 
 impl PHPVersion {
+    /// The PHP 5.4 version.
+    pub const PHP54: PHPVersion = PHPVersion::new(5, 4, 0);
+
     /// The PHP 5.5 version.
     pub const PHP55: PHPVersion = PHPVersion::new(5, 5, 0);
 

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -49,7 +49,7 @@ pub const MAXIMUM_STACK_SIZE: usize = 256 * 1024 * 1024;
 pub const DEFAULT_PHP_VERSION: PHPVersion = PHPVersion::PHP83;
 
 /// The minimum supported PHP version.
-pub const MINIMUM_PHP_VERSION: PHPVersion = PHPVersion::PHP74;
+pub const MINIMUM_PHP_VERSION: PHPVersion = PHPVersion::PHP54;
 
 /// The maximum supported PHP version.
 pub const MAXIMUM_PHP_VERSION: PHPVersion = PHPVersion::PHP84;


### PR DESCRIPTION
I'm using an absolute ancient version of PHP at work (got handed a 10+ year old project I now need to maintain 🙈) and are constantly running into problems with me using features that aren't implemented. So this linter is actually great for me!

This PR adds the ability to configure the `php_version` all the way down to `"5.4"`.

There is still some rules missing in order to cover 100% of the features introduced between 5.4 and 7.3, but I think that this is a good start! 🐎 

Please let me know if I'm doing anything wrong, which I probably am 😅 

Here is a screenshot of it in action:

<img width="1019" alt="Screenshot 2025-01-18 at 16 50 34" src="https://github.com/user-attachments/assets/85d4a568-42cc-4f87-8235-6675b29c374d" />
