### PR TITLE
Composer: Allow all supported PHP versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     },
     "require": {
-        "php": "~8.3 || ~8.4",
+        "php": "~8.1 || ~8.2 || ~8.3 || ~8.4",
         "composer-plugin-api": "^2.6"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6470d3df500823de3a39a7023ce58aef",
+    "content-hash": "3b800a325bfb7f43844e76d69b733933",
     "packages": [],
     "packages-dev": [
         {
@@ -2137,7 +2137,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.3 || ~8.4",
+        "php": "~8.1 || ~8.2 || ~8.3 || ~8.4",
         "composer-plugin-api": "^2.6"
     },
     "platform-dev": {},


### PR DESCRIPTION
This pull request includes a change to the `composer.json` file to update the PHP version requirements.

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L16-R16): Updated the [PHP version](https://www.php.net/supported-versions.php) requirements to include versions 8.1 and 8.2 in addition to the previously supported versions 8.3 and 8.4.