### PR TITLE
Make composer plugin compatible with PHP 8.1

### DIFF
--- a/composer/MagoPlugin.php
+++ b/composer/MagoPlugin.php
@@ -16,9 +16,9 @@ use Composer\Plugin\PluginInterface;
 use Composer\Util\ProcessExecutor;
 use Symfony\Component\Process\PhpExecutableFinder;
 
-final readonly class MagoPlugin implements PluginInterface, EventSubscriberInterface, Capable
+final class MagoPlugin implements PluginInterface, EventSubscriberInterface, Capable
 {
-    public const string PACKAGE_NAME = 'carthage-software/mago';
+    public const PACKAGE_NAME = 'carthage-software/mago';
 
     /**
      * @inheritDoc


### PR DESCRIPTION
The code of the composer plugin is not compatible with PHP 8.1.
Now it is.

![Screenshot 2025-01-27 at 08 40 32](https://github.com/user-attachments/assets/13e8be6b-c826-499f-bb75-f3034f75c678)
