### PR TITLE
fix(composer): make composer PHP files v8.1 compatible

### DIFF
--- a/composer/MagoPlugin.php
+++ b/composer/MagoPlugin.php
@@ -16,9 +16,12 @@ use Composer\Plugin\PluginInterface;
 use Composer\Util\ProcessExecutor;
 use Symfony\Component\Process\PhpExecutableFinder;
 
-final readonly class MagoPlugin implements PluginInterface, EventSubscriberInterface, Capable
+final class MagoPlugin implements PluginInterface, EventSubscriberInterface, Capable
 {
-    public const string PACKAGE_NAME = 'carthage-software/mago';
+    /**
+     * @var string
+     */
+    public const PACKAGE_NAME = 'carthage-software/mago';
 
     /**
      * @inheritDoc


### PR DESCRIPTION
This pull request includes a small change to the `composer/MagoPlugin.php` file. The change removes the `readonly` keyword from the `MagoPlugin` class definition and adjusts the `PACKAGE_NAME` constant to include a docblock for type annotation.

* [`composer/MagoPlugin.php`](diffhunk://#diff-b24e73aa91a5b3c5faa41e2756e7ab7051011b2c741c4a3e6b9a5951042d8879L19-R24): Removed the `readonly` keyword from the `MagoPlugin` class and added a docblock for the `PACKAGE_NAME` constant.

The following rector config was used:
```php
<?php

declare(strict_types=1);

use Rector\Config\RectorConfig;

return RectorConfig::configure()
    ->withPaths([__DIR__ . '/composer'])
    ->withBootstrapFiles([__DIR__ . '/vendor/autoload.php'])
    ->withDowngradeSets(php81: true);
```