### PR TITLE
refactor: overhaul linter rule system and micro-optimize crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1647,6 +1647,7 @@ dependencies = [
  "mago-source",
  "mago-span",
  "mago-token",
+ "memchr",
  "pretty_assertions",
  "serde",
  "strum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 tempfile = "3.15.0"
 colored = "3.0.0"
 blake3 = "1.5.5"
+memchr = "2.7.4"
 
 [lints]
 workspace = true

--- a/crates/ast-utils/src/assignment.rs
+++ b/crates/ast-utils/src/assignment.rs
@@ -9,7 +9,7 @@ use mago_ast::*;
 #[inline]
 pub fn get_assignment_from_expression(expression: &Expression) -> Option<&Assignment> {
     match &expression {
-        Expression::AssignmentOperation(assignment_operation) => Some(assignment_operation),
+        Expression::Assignment(assignment_operation) => Some(assignment_operation),
         Expression::Parenthesized(parenthesized) => get_assignment_from_expression(&parenthesized.expression),
         Expression::Binary(operation) => {
             get_assignment_from_expression(&operation.lhs).or_else(|| get_assignment_from_expression(&operation.rhs))

--- a/crates/ast-utils/src/condition.rs
+++ b/crates/ast-utils/src/condition.rs
@@ -32,7 +32,7 @@ pub fn is_truthy(expression: &Expression) -> bool {
             UnaryPrefixOperator::Not(_) => is_falsy(&operation.operand),
             _ => false,
         },
-        Expression::AssignmentOperation(assignment) => is_truthy(&assignment.rhs),
+        Expression::Assignment(assignment) => is_truthy(&assignment.rhs),
         _ => false,
     }
 }
@@ -50,7 +50,7 @@ pub fn is_falsy(expression: &Expression) -> bool {
         Expression::Literal(Literal::False(_) | Literal::Null(_)) => true,
         Expression::Array(array) => array.elements.is_empty(),
         Expression::LegacyArray(array) => array.elements.is_empty(),
-        Expression::AssignmentOperation(assignment) => is_falsy(&assignment.rhs),
+        Expression::Assignment(assignment) => is_falsy(&assignment.rhs),
         Expression::Binary(operation) => match operation.operator {
             BinaryOperator::Or(_) | BinaryOperator::LowOr(_) => is_falsy(&operation.lhs) && is_falsy(&operation.rhs),
             BinaryOperator::And(_) | BinaryOperator::LowAnd(_) => is_falsy(&operation.lhs) || is_falsy(&operation.rhs),

--- a/crates/ast-utils/src/control_flow.rs
+++ b/crates/ast-utils/src/control_flow.rs
@@ -265,7 +265,7 @@ pub fn find_control_flows_in_expression(expression: &Expression) -> Vec<ControlF
                 }
             }
         }
-        Expression::AssignmentOperation(assignment) => {
+        Expression::Assignment(assignment) => {
             controls.extend(find_control_flows_in_expression(&assignment.lhs));
             controls.extend(find_control_flows_in_expression(&assignment.rhs));
         }

--- a/crates/ast-utils/src/lib.rs
+++ b/crates/ast-utils/src/lib.rs
@@ -208,7 +208,7 @@ pub fn expression_has_yield(expression: &Expression) -> bool {
         Expression::Binary(operation) => expression_has_yield(&operation.lhs) || expression_has_yield(&operation.rhs),
         Expression::UnaryPrefix(operation) => expression_has_yield(&operation.operand),
         Expression::UnaryPostfix(operation) => expression_has_yield(&operation.operand),
-        Expression::AssignmentOperation(assignment_operation) => {
+        Expression::Assignment(assignment_operation) => {
             expression_has_yield(&assignment_operation.lhs) || expression_has_yield(&assignment_operation.rhs)
         }
         Expression::Conditional(conditional) => {

--- a/crates/ast-utils/src/reference.rs
+++ b/crates/ast-utils/src/reference.rs
@@ -275,7 +275,7 @@ where
         Expression::Parenthesized(parenthesized) => {
             find_method_references_in_expression(parenthesized.expression.as_ref(), predicate)
         }
-        Expression::AssignmentOperation(assignment) => {
+        Expression::Assignment(assignment) => {
             let mut references = vec![];
             references.extend(find_method_references_in_expression(assignment.lhs.as_ref(), predicate));
             references.extend(find_method_references_in_expression(assignment.rhs.as_ref(), predicate));

--- a/crates/ast/src/ast/class_like/member.rs
+++ b/crates/ast/src/ast/class_like/member.rs
@@ -13,6 +13,7 @@ use crate::ast::class_like::trait_use::TraitUse;
 use crate::ast::expression::Expression;
 use crate::ast::identifier::LocalIdentifier;
 use crate::ast::variable::Variable;
+use crate::Sequence;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, PartialOrd, Ord, Display)]
 pub enum ClassLikeMember {
@@ -43,6 +44,28 @@ pub struct ClassLikeMemberExpressionSelector {
     pub left_brace: Span,
     pub expression: Box<Expression>,
     pub right_brace: Span,
+}
+
+impl Sequence<ClassLikeMember> {
+    pub fn contains_trait_uses(&self) -> bool {
+        self.iter().any(|member| matches!(member, ClassLikeMember::TraitUse(_)))
+    }
+
+    pub fn contains_constants(&self) -> bool {
+        self.iter().any(|member| matches!(member, ClassLikeMember::Constant(_)))
+    }
+
+    pub fn contains_properties(&self) -> bool {
+        self.iter().any(|member| matches!(member, ClassLikeMember::Property(_)))
+    }
+
+    pub fn contains_enum_cases(&self) -> bool {
+        self.iter().any(|member| matches!(member, ClassLikeMember::EnumCase(_)))
+    }
+
+    pub fn contains_methods(&self) -> bool {
+        self.iter().any(|member| matches!(member, ClassLikeMember::Method(_)))
+    }
 }
 
 impl HasSpan for ClassLikeMember {

--- a/crates/ast/src/ast/expression.rs
+++ b/crates/ast/src/ast/expression.rs
@@ -62,7 +62,7 @@ pub enum Expression {
     Parenthesized(Parenthesized),
     Literal(Literal),
     CompositeString(CompositeString),
-    AssignmentOperation(Assignment),
+    Assignment(Assignment),
     Conditional(Conditional),
     Array(Array),
     LegacyArray(LegacyArray),
@@ -154,7 +154,7 @@ impl Expression {
                     && conditional.then.as_ref().map(|e| e.is_constant(version, initilization)).unwrap_or(true)
                     && conditional.r#else.is_constant(version, initilization)
             }
-            Self::Array(array) => array.elements.inner.iter().all(|element| match &element {
+            Self::Array(array) => array.elements.nodes.iter().all(|element| match &element {
                 ArrayElement::KeyValue(key_value_array_element) => {
                     key_value_array_element.key.is_constant(version, initilization)
                         && key_value_array_element.value.is_constant(version, initilization)
@@ -167,7 +167,7 @@ impl Expression {
                 }
                 ArrayElement::Missing(_) => false,
             }),
-            Self::LegacyArray(array) => array.elements.inner.iter().all(|element| match &element {
+            Self::LegacyArray(array) => array.elements.nodes.iter().all(|element| match &element {
                 ArrayElement::KeyValue(key_value_array_element) => {
                     key_value_array_element.key.is_constant(version, initilization)
                         && key_value_array_element.value.is_constant(version, initilization)
@@ -213,16 +213,17 @@ impl Expression {
     }
 
     #[inline]
-    pub fn is_literal(&self) -> bool {
+    pub const fn is_literal(&self) -> bool {
         matches!(self, Expression::Literal(_))
     }
 
     #[inline]
-    pub fn is_string_literal(&self) -> bool {
+    pub const fn is_string_literal(&self) -> bool {
         matches!(self, Expression::Literal(Literal::String(_)))
     }
 
-    pub fn node_kind(&self) -> NodeKind {
+    #[inline]
+    pub const fn node_kind(&self) -> NodeKind {
         match &self {
             Expression::Binary(_) => NodeKind::Binary,
             Expression::ConstantAccess(_) => NodeKind::ConstantAccess,
@@ -231,7 +232,7 @@ impl Expression {
             Expression::Parenthesized(_) => NodeKind::Parenthesized,
             Expression::Literal(_) => NodeKind::Literal,
             Expression::CompositeString(_) => NodeKind::CompositeString,
-            Expression::AssignmentOperation(_) => NodeKind::Assignment,
+            Expression::Assignment(_) => NodeKind::Assignment,
             Expression::Conditional(_) => NodeKind::Conditional,
             Expression::Array(_) => NodeKind::Array,
             Expression::LegacyArray(_) => NodeKind::LegacyArray,
@@ -276,7 +277,7 @@ impl HasSpan for Expression {
             Expression::Parenthesized(expression) => expression.span(),
             Expression::Literal(expression) => expression.span(),
             Expression::CompositeString(expression) => expression.span(),
-            Expression::AssignmentOperation(expression) => expression.span(),
+            Expression::Assignment(expression) => expression.span(),
             Expression::Conditional(expression) => expression.span(),
             Expression::Array(expression) => expression.span(),
             Expression::LegacyArray(expression) => expression.span(),

--- a/crates/ast/src/lib.rs
+++ b/crates/ast/src/lib.rs
@@ -9,7 +9,7 @@ use mago_span::Position;
 use mago_span::Span;
 
 pub use crate::ast::*;
-pub use crate::node::Node;
+pub use crate::node::*;
 pub use crate::sequence::Sequence;
 pub use crate::trivia::Trivia;
 pub use crate::trivia::TriviaKind;

--- a/crates/ast/src/node.rs
+++ b/crates/ast/src/node.rs
@@ -386,7 +386,7 @@ pub enum Node<'a> {
     Namespace(&'a Namespace),
     NamespaceBody(&'a NamespaceBody),
     NamespaceImplicitBody(&'a NamespaceImplicitBody),
-    AssignmentOperation(&'a Assignment),
+    Assignment(&'a Assignment),
     AssignmentOperator(&'a AssignmentOperator),
     Conditional(&'a Conditional),
     DoWhile(&'a DoWhile),
@@ -684,7 +684,7 @@ impl<'a> Node<'a> {
             Self::Namespace(_) => NodeKind::Namespace,
             Self::NamespaceBody(_) => NodeKind::NamespaceBody,
             Self::NamespaceImplicitBody(_) => NodeKind::NamespaceImplicitBody,
-            Self::AssignmentOperation(_) => NodeKind::Assignment,
+            Self::Assignment(_) => NodeKind::Assignment,
             Self::AssignmentOperator(_) => NodeKind::AssignmentOperator,
             Self::Conditional(_) => NodeKind::Conditional,
             Self::DoWhile(_) => NodeKind::DoWhile,
@@ -1380,7 +1380,7 @@ impl<'a> Node<'a> {
                 Expression::Parenthesized(node) => Node::Parenthesized(node),
                 Expression::Literal(node) => Node::Literal(node),
                 Expression::CompositeString(node) => Node::CompositeString(node),
-                Expression::AssignmentOperation(node) => Node::AssignmentOperation(node),
+                Expression::Assignment(node) => Node::Assignment(node),
                 Expression::Conditional(node) => Node::Conditional(node),
                 Expression::Array(node) => Node::Array(node),
                 Expression::LegacyArray(node) => Node::LegacyArray(node),
@@ -1444,35 +1444,10 @@ impl<'a> Node<'a> {
             Node::UnaryPrefix(node) => {
                 vec![Node::UnaryPrefixOperator(&node.operator), Node::Expression(&node.operand)]
             }
-            Node::UnaryPrefixOperator(operator) => match operator {
-                UnaryPrefixOperator::ErrorControl(_) => vec![],
-                UnaryPrefixOperator::Reference(_) => vec![],
-                UnaryPrefixOperator::ArrayCast(_, _) => vec![],
-                UnaryPrefixOperator::BoolCast(_, _) => vec![],
-                UnaryPrefixOperator::BooleanCast(_, _) => vec![],
-                UnaryPrefixOperator::DoubleCast(_, _) => vec![],
-                UnaryPrefixOperator::RealCast(_, _) => vec![],
-                UnaryPrefixOperator::FloatCast(_, _) => vec![],
-                UnaryPrefixOperator::IntCast(_, _) => vec![],
-                UnaryPrefixOperator::IntegerCast(_, _) => vec![],
-                UnaryPrefixOperator::ObjectCast(_, _) => vec![],
-                UnaryPrefixOperator::UnsetCast(_, _) => vec![],
-                UnaryPrefixOperator::StringCast(_, _) => vec![],
-                UnaryPrefixOperator::BinaryCast(_, _) => vec![],
-                UnaryPrefixOperator::BitwiseNot(_) => vec![],
-                UnaryPrefixOperator::Not(_) => vec![],
-                UnaryPrefixOperator::PreIncrement(_) => vec![],
-                UnaryPrefixOperator::PreDecrement(_) => vec![],
-                UnaryPrefixOperator::Plus(_) => vec![],
-                UnaryPrefixOperator::Negation(_) => vec![],
-            },
             Node::UnaryPostfix(node) => {
                 vec![Node::Expression(&node.operand), Node::UnaryPostfixOperator(&node.operator)]
             }
-            Node::UnaryPostfixOperator(operator) => match operator {
-                UnaryPostfixOperator::PostIncrement(_) => vec![],
-                UnaryPostfixOperator::PostDecrement(_) => vec![],
-            },
+            Node::UnaryPrefixOperator(_) | Node::UnaryPostfixOperator(_) => vec![],
             Node::ArrowFunction(node) => {
                 let mut children = vec![];
 
@@ -1643,7 +1618,7 @@ impl<'a> Node<'a> {
 
                 children
             }
-            Node::AssignmentOperation(node) => {
+            Node::Assignment(node) => {
                 vec![Node::Expression(&node.lhs), Node::AssignmentOperator(&node.operator), Node::Expression(&node.rhs)]
             }
             Node::AssignmentOperator(_) => vec![],
@@ -1716,12 +1691,7 @@ impl<'a> Node<'a> {
                 children
             }
             Node::While(node) => {
-                let mut children = vec![Node::Keyword(&node.r#while)];
-
-                children.push(Node::Expression(&node.condition));
-                children.push(Node::WhileBody(&node.body));
-
-                children
+                vec![Node::Keyword(&node.r#while), Node::Expression(&node.condition), Node::WhileBody(&node.body)]
             }
             Node::WhileBody(node) => match node {
                 WhileBody::Statement(statement) => vec![Node::Statement(statement)],
@@ -1800,9 +1770,7 @@ impl<'a> Node<'a> {
                 children
             }
             Node::TryCatchClause(node) => {
-                let mut children = vec![Node::Keyword(&node.r#catch)];
-
-                children.push(Node::Hint(&node.hint));
+                let mut children = vec![Node::Keyword(&node.r#catch), Node::Hint(&node.hint)];
                 if let Some(variable) = &node.variable {
                     children.push(Node::DirectVariable(variable));
                 }
@@ -2156,7 +2124,7 @@ impl HasSpan for Node<'_> {
             Self::Namespace(node) => node.span(),
             Self::NamespaceBody(node) => node.span(),
             Self::NamespaceImplicitBody(node) => node.span(),
-            Self::AssignmentOperation(node) => node.span(),
+            Self::Assignment(node) => node.span(),
             Self::AssignmentOperator(node) => node.span(),
             Self::Conditional(node) => node.span(),
             Self::DoWhile(node) => node.span(),

--- a/crates/ast/src/sequence.rs
+++ b/crates/ast/src/sequence.rs
@@ -15,8 +15,9 @@ use mago_token::Token;
 ///
 /// i.e. `public` and `static` in `public static function foo() {}`.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
+#[repr(transparent)]
 pub struct Sequence<T> {
-    pub(crate) inner: Vec<T>,
+    pub nodes: Vec<T>,
 }
 
 /// Represents a sequence of nodes separated by a token.
@@ -26,92 +27,116 @@ pub struct Sequence<T> {
 /// i.e. `1`, `2` and `3` in `foo(1, 2, 3)`.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
 pub struct TokenSeparatedSequence<T> {
-    pub(crate) inner: Vec<T>,
+    pub nodes: Vec<T>,
     pub tokens: Vec<Token>,
 }
 
 impl<T: HasSpan> Sequence<T> {
-    pub fn new(inner: Vec<T>) -> Self {
-        Self { inner }
+    #[inline]
+    pub const fn new(inner: Vec<T>) -> Self {
+        Self { nodes: inner }
     }
 
-    pub fn empty() -> Self {
-        Self { inner: vec![] }
-    }
-
-    pub fn len(&self) -> usize {
-        self.inner.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.inner.is_empty()
-    }
-
-    pub fn get(&self, index: usize) -> Option<&T> {
-        self.inner.get(index)
-    }
-
-    pub fn first(&self) -> Option<&T> {
-        self.inner.first()
-    }
-
-    pub fn first_span(&self) -> Option<Span> {
-        self.inner.first().map(|node| node.span())
-    }
-
-    pub fn last(&self) -> Option<&T> {
-        self.inner.last()
-    }
-
-    pub fn last_span(&self) -> Option<Span> {
-        self.inner.last().map(|node| node.span())
-    }
-
-    pub fn span(&self, from: Position) -> Span {
-        self.last_span().map_or(Span::new(from, from), |span| Span::new(from, span.end))
-    }
-
-    pub fn iter(&self) -> Iter<'_, T> {
-        self.inner.iter()
-    }
-
-    pub fn as_slice(&self) -> &[T] {
-        self.inner.as_slice()
-    }
-}
-
-impl<T: HasSpan> TokenSeparatedSequence<T> {
-    pub fn new(inner: Vec<T>, tokens: Vec<Token>) -> Self {
-        Self { inner, tokens }
-    }
-
-    pub fn empty() -> Self {
-        Self { inner: vec![], tokens: vec![] }
+    #[inline]
+    pub const fn empty() -> Self {
+        Self { nodes: vec![] }
     }
 
     #[inline]
     pub fn len(&self) -> usize {
-        self.inner.len()
+        self.nodes.len()
     }
 
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.inner.is_empty()
+        self.nodes.is_empty()
     }
 
     #[inline]
+    #[must_use]
     pub fn get(&self, index: usize) -> Option<&T> {
-        self.inner.get(index)
+        self.nodes.get(index)
     }
 
     #[inline]
     #[must_use]
     pub fn first(&self) -> Option<&T> {
-        self.inner.first()
+        self.nodes.first()
     }
 
+    #[inline]
+    #[must_use]
     pub fn first_span(&self) -> Option<Span> {
-        match (self.tokens.first(), self.inner.first()) {
+        self.nodes.first().map(|node| node.span())
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn last(&self) -> Option<&T> {
+        self.nodes.last()
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn last_span(&self) -> Option<Span> {
+        self.nodes.last().map(|node| node.span())
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn span(&self, from: Position) -> Span {
+        self.last_span().map_or(Span::new(from, from), |span| Span::new(from, span.end))
+    }
+
+    #[inline]
+    pub fn iter(&self) -> Iter<'_, T> {
+        self.nodes.iter()
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn as_slice(&self) -> &[T] {
+        self.nodes.as_slice()
+    }
+}
+
+impl<T: HasSpan> TokenSeparatedSequence<T> {
+    #[inline]
+    #[must_use]
+    pub const fn new(inner: Vec<T>, tokens: Vec<Token>) -> Self {
+        Self { nodes: inner, tokens }
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self { nodes: vec![], tokens: vec![] }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+
+    #[inline]
+    pub fn get(&self, index: usize) -> Option<&T> {
+        self.nodes.get(index)
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn first(&self) -> Option<&T> {
+        self.nodes.first()
+    }
+
+    #[inline]
+    pub fn first_span(&self) -> Option<Span> {
+        match (self.tokens.first(), self.nodes.first()) {
             (Some(token), Some(node)) => {
                 // check if the token comes before the node
                 if token.span.end <= node.span().start {
@@ -126,12 +151,14 @@ impl<T: HasSpan> TokenSeparatedSequence<T> {
         }
     }
 
+    #[inline]
     pub fn last(&self) -> Option<&T> {
-        self.inner.last()
+        self.nodes.last()
     }
 
+    #[inline]
     pub fn last_span(&self) -> Option<Span> {
-        match (self.tokens.last(), self.inner.last()) {
+        match (self.tokens.last(), self.nodes.last()) {
             (Some(token), Some(node)) => {
                 // check if the token comes after the node
                 if token.span.start >= node.span().end {
@@ -146,27 +173,32 @@ impl<T: HasSpan> TokenSeparatedSequence<T> {
         }
     }
 
+    #[inline]
     pub fn span(&self, from: Position) -> Span {
         self.last_span().map_or(Span::new(from, from), |span| Span::new(from, span.end))
     }
 
+    #[inline]
     pub fn has_trailing_token(&self) -> bool {
         self.tokens.last().is_some_and(|token| token.span.start >= self.last_span().unwrap().end)
     }
 
+    #[inline]
     pub fn get_trailing_token(&self) -> Option<&Token> {
         self.tokens.last().filter(|token| token.span.start >= self.last_span().unwrap().end)
     }
 
+    #[inline]
     pub fn iter(&self) -> Iter<'_, T> {
-        self.inner.iter()
+        self.nodes.iter()
     }
 
     /// Returns an iterator over the sequence, where each item includes
     /// the index of the element, the element and the token following it.
     /// The token is `None` only for the last element if it has no trailing token.
+    #[inline]
     pub fn iter_with_tokens(&self) -> impl Iterator<Item = (usize, &T, Option<&Token>)> {
-        self.inner.iter().enumerate().map(move |(i, item)| {
+        self.nodes.iter().enumerate().map(move |(i, item)| {
             let token = self.tokens.get(i);
 
             (i, item, token)
@@ -175,13 +207,13 @@ impl<T: HasSpan> TokenSeparatedSequence<T> {
 
     #[inline]
     pub fn as_slice(&self) -> &[T] {
-        self.inner.as_slice()
+        self.nodes.as_slice()
     }
 }
 
 impl<T: HasSpan> FromIterator<T> for Sequence<T> {
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
-        Self { inner: iter.into_iter().collect() }
+        Self { nodes: iter.into_iter().collect() }
     }
 }
 
@@ -190,7 +222,7 @@ impl<T: HasSpan> IntoIterator for Sequence<T> {
     type IntoIter = IntoIter<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.inner.into_iter()
+        self.nodes.into_iter()
     }
 }
 
@@ -199,7 +231,7 @@ impl<T: HasSpan> IntoIterator for TokenSeparatedSequence<T> {
     type IntoIter = IntoIter<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.inner.into_iter()
+        self.nodes.into_iter()
     }
 }
 

--- a/crates/ast/src/trivia.rs
+++ b/crates/ast/src/trivia.rs
@@ -30,7 +30,8 @@ pub struct Trivia {
 
 impl TriviaKind {
     /// Returns `true` if the trivia kind is a comment.
-    pub fn is_comment(&self) -> bool {
+    #[inline]
+    pub const fn is_comment(&self) -> bool {
         matches!(
             self,
             TriviaKind::SingleLineComment
@@ -40,11 +41,13 @@ impl TriviaKind {
         )
     }
 
-    pub fn is_block_comment(&self) -> bool {
+    #[inline]
+    pub const fn is_block_comment(&self) -> bool {
         matches!(self, TriviaKind::MultiLineComment | TriviaKind::DocBlockComment)
     }
 
-    pub fn is_single_line_comment(&self) -> bool {
+    #[inline]
+    pub const fn is_single_line_comment(&self) -> bool {
         matches!(self, TriviaKind::HashComment | TriviaKind::SingleLineComment)
     }
 }

--- a/crates/formatter/src/format/assignment.rs
+++ b/crates/formatter/src/format/assignment.rs
@@ -131,7 +131,7 @@ fn choose_layout<'a, 'b>(
     let is_tail = !is_assignment(rhs_expression);
 
     let should_use_chain_formatting = matches!(assignment_like_node, AssignmentLikeNode::AssignmentOperation(_))
-        && matches!(f.parent_node(), Node::AssignmentOperation(_))
+        && matches!(f.parent_node(), Node::Assignment(_))
         && (!is_tail || !matches!(f.grandparent_node(), Some(Node::ExpressionStatement(_))));
 
     if should_use_chain_formatting {
@@ -187,7 +187,7 @@ fn choose_layout<'a, 'b>(
 }
 
 fn is_assignment(expression: &Expression) -> bool {
-    matches!(expression, Expression::AssignmentOperation(_))
+    matches!(expression, Expression::Assignment(_))
 }
 
 /// Returns whether the given assignment-like node is complex destruction assignment.

--- a/crates/formatter/src/format/binaryish.rs
+++ b/crates/formatter/src/format/binaryish.rs
@@ -68,7 +68,7 @@ pub(super) fn print_binaryish_expression<'a>(
             && !is_at_call_like_expression(f));
 
     let should_indent_if_inlining =
-        matches!(grandparent, Some(Node::AssignmentOperation(_) | Node::PropertyItem(_) | Node::ConstantItem(_)))
+        matches!(grandparent, Some(Node::Assignment(_) | Node::PropertyItem(_) | Node::ConstantItem(_)))
             || matches!(grandparent, Some(Node::KeyValueArrayElement(_)));
 
     let same_precedence_sub_expression =

--- a/crates/formatter/src/format/call.rs
+++ b/crates/formatter/src/format/call.rs
@@ -118,7 +118,7 @@ fn base_needs_parerns(base: &Expression) -> bool {
         Expression::Binary(_)
         | Expression::UnaryPrefix(_)
         | Expression::UnaryPostfix(_)
-        | Expression::AssignmentOperation(_)
+        | Expression::Assignment(_)
         | Expression::Conditional(_)
         | Expression::AnonymousClass(_)
         | Expression::Closure(_)

--- a/crates/formatter/src/format/expression.rs
+++ b/crates/formatter/src/format/expression.rs
@@ -42,7 +42,7 @@ impl<'a> Format<'a> for Expression {
                 Expression::UnaryPostfix(op) => op.format(f),
                 Expression::Literal(literal) => literal.format(f),
                 Expression::CompositeString(c) => c.format(f),
-                Expression::AssignmentOperation(op) => op.format(f),
+                Expression::Assignment(op) => op.format(f),
                 Expression::Conditional(op) => op.format(f),
                 Expression::Array(array) => array.format(f),
                 Expression::LegacyArray(legacy_array) => legacy_array.format(f),
@@ -462,7 +462,7 @@ impl<'a> Format<'a> for NamedArgument {
 
 impl<'a> Format<'a> for Assignment {
     fn format(&'a self, f: &mut Formatter<'a>) -> Document<'a> {
-        wrap!(f, self, AssignmentOperation, {
+        wrap!(f, self, Assignment, {
             let lhs = self.lhs.format(f);
 
             let operator = match self.operator {

--- a/crates/formatter/src/parens.rs
+++ b/crates/formatter/src/parens.rs
@@ -33,7 +33,7 @@ impl<'a> Formatter<'a> {
     }
 
     fn conditional_or_assignment_needs_parenthesis(&self, node: Node<'a>) -> bool {
-        if !matches!(node, Node::AssignmentOperation(_) | Node::Conditional(_)) {
+        if !matches!(node, Node::Assignment(_) | Node::Conditional(_)) {
             return false;
         }
 

--- a/crates/formatter/src/utils.rs
+++ b/crates/formatter/src/utils.rs
@@ -9,7 +9,7 @@ pub const fn has_naked_left_side(expression: &Expression) -> bool {
         expression,
         Expression::Binary(_)
             | Expression::UnaryPostfix(_)
-            | Expression::AssignmentOperation(_)
+            | Expression::Assignment(_)
             | Expression::Conditional(_)
             | Expression::ArrayAccess(_)
             | Expression::ArrayAppend(_)
@@ -23,7 +23,7 @@ pub const fn get_left_side(expression: &Expression) -> Option<&Expression> {
     match expression {
         Expression::Binary(binary) => Some(&binary.lhs),
         Expression::UnaryPostfix(unary) => Some(&unary.operand),
-        Expression::AssignmentOperation(assignment) => Some(&assignment.lhs),
+        Expression::Assignment(assignment) => Some(&assignment.lhs),
         Expression::Conditional(conditional) => Some(&conditional.condition),
         Expression::ArrayAccess(array_access) => Some(&array_access.array),
         Expression::ArrayAppend(array_append) => Some(&array_append.array),

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -22,15 +22,14 @@ pub fn test_format(code: impl AsRef<str>, expected: &str, settings: FormatSettin
     let interner = ThreadedInterner::new();
     let manager = SourceManager::new(interner.clone());
 
-    let code_id = manager.insert_content("code.php".to_string(), code.as_ref().to_string(), SourceCategory::default());
+    let code_id = manager.insert_content("code.php", code.as_ref(), SourceCategory::default());
     let code_source = manager.load(&code_id).expect("Failed to load code source");
     let (code_program, error) = parse_source(&interner, &code_source);
     assert_eq!(error, None, "Error parsing code");
     let formatted_code = mago_formatter::format(&interner, &code_source, &code_program, settings);
     pretty_assertions::assert_eq!(expected, formatted_code, "Formatted code does not match expected");
 
-    let formatted_code_id =
-        manager.insert_content("formatted_code.php".to_string(), formatted_code, SourceCategory::default());
+    let formatted_code_id = manager.insert_content("formatted_code.php", formatted_code, SourceCategory::default());
     let formatted_code_source = manager.load(&formatted_code_id).expect("Failed to load formatted code source");
     let (formatted_code_program, error) = parse_source(&interner, &formatted_code_source);
     assert_eq!(error, None, "Error parsing formatted code");

--- a/crates/interner/src/lib.rs
+++ b/crates/interner/src/lib.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use lasso::Key;
@@ -13,6 +14,7 @@ pub struct StringIdentifier(pub(crate) usize);
 
 impl StringIdentifier {
     /// Creates a new empty `StringIdentifier`.
+    #[inline(always)]
     pub const fn empty() -> Self {
         Self(0)
     }
@@ -22,8 +24,9 @@ impl StringIdentifier {
     /// # Arguments
     ///
     /// * `val` - The value of the string identifier.
-    pub const fn new(val: usize) -> Self {
-        Self(val)
+    #[inline(always)]
+    pub const fn new(val: NonZeroUsize) -> Self {
+        Self(val.get())
     }
 
     /// Returns `true` if the string is empty.
@@ -40,12 +43,14 @@ impl StringIdentifier {
 }
 
 unsafe impl Key for StringIdentifier {
+    #[inline(always)]
     fn into_usize(self) -> usize {
         self.0 - 1
     }
 
+    #[inline(always)]
     fn try_from_usize(int: usize) -> Option<Self> {
-        Some(Self(int + 1))
+        Some(Self::new(NonZeroUsize::new(int + 1)?))
     }
 }
 
@@ -62,11 +67,13 @@ impl Interner {
     }
 
     /// Returns the number of strings stored in the interner.
+    #[inline]
     pub fn len(&self) -> usize {
         self.rodeo.len()
     }
 
     /// Returns `true` if the interner is empty.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.rodeo.is_empty()
     }
@@ -76,6 +83,7 @@ impl Interner {
     /// # Arguments
     ///
     /// * string - The interned string.
+    #[inline]
     pub fn get(&self, string: impl AsRef<str>) -> Option<StringIdentifier> {
         let str = string.as_ref();
         if str.is_empty() {
@@ -92,6 +100,7 @@ impl Interner {
     /// # Arguments
     ///
     /// * string - The string to intern.
+    #[inline]
     pub fn intern(&mut self, string: impl AsRef<str>) -> StringIdentifier {
         let str = string.as_ref();
         if str.is_empty() {
@@ -118,6 +127,7 @@ impl Interner {
     /// This method will panic if it encounters an invalid identifier. This should never
     /// occur unless there is an issue with the identifier or the interner is used
     /// incorrectly.
+    #[inline]
     pub fn interned_str(&mut self, string: impl AsRef<str>) -> &str {
         let str = string.as_ref();
         if str.is_empty() {
@@ -142,6 +152,7 @@ impl Interner {
     /// # Returns
     ///
     /// The identifier of the string with all characters in lowercase.
+    #[inline]
     pub fn lowered(&mut self, identifier: &StringIdentifier) -> StringIdentifier {
         let string = self.lookup(identifier);
 
@@ -157,6 +168,7 @@ impl Interner {
     /// # Panics
     ///
     /// Panics if the identifier is invalid
+    #[inline]
     pub fn lookup(&self, identifier: &StringIdentifier) -> &str {
         if identifier.is_empty() {
             return "";
@@ -177,16 +189,19 @@ pub struct ThreadedInterner {
 
 impl ThreadedInterner {
     /// Creates a new `ThreadedInterner`.
+    #[inline]
     pub fn new() -> Self {
         Self { rodeo: Arc::new(ThreadedRodeo::new()) }
     }
 
     /// Returns the number of strings stored in the interner.
+    #[inline]
     pub fn len(&self) -> usize {
         self.rodeo.len()
     }
 
     /// Returns `true` if the interner is empty.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.rodeo.is_empty()
     }
@@ -198,6 +213,7 @@ impl ThreadedInterner {
     /// # Arguments
     ///
     /// * `string` - The string to intern.
+    #[inline]
     pub fn intern(&self, string: impl AsRef<str>) -> StringIdentifier {
         let str = string.as_ref();
         if str.is_empty() {
@@ -224,6 +240,7 @@ impl ThreadedInterner {
     /// This method will panic if it encounters an invalid identifier. This should never
     /// occur unless there is an issue with the identifier or the interner is used
     /// incorrectly.
+    #[inline]
     pub fn interned_str(&self, string: impl AsRef<str>) -> &str {
         let str = string.as_ref();
         if str.is_empty() {
@@ -248,6 +265,7 @@ impl ThreadedInterner {
     /// # Returns
     ///
     /// The identifier of the string with all characters in lowercase.
+    #[inline]
     pub fn lowered(&self, identifier: &StringIdentifier) -> StringIdentifier {
         let string = self.lookup(identifier);
 
@@ -265,6 +283,7 @@ impl ThreadedInterner {
     /// This method will panic if it encounters an invalid identifier. This should never
     /// occur unless there is an issue with the identifier or the interner is used
     /// incorrectly.
+    #[inline]
     pub fn lookup(&self, identifier: &StringIdentifier) -> &str {
         if identifier.is_empty() {
             return "";
@@ -277,6 +296,7 @@ impl ThreadedInterner {
     }
 
     /// Returns all interned strings and their identifiers as a hashmap.
+    #[inline]
     pub fn all(&self) -> HashSet<(StringIdentifier, &str)> {
         self.rodeo.iter().collect()
     }
@@ -292,12 +312,14 @@ unsafe impl Send for ThreadedInterner {}
 unsafe impl Sync for ThreadedInterner {}
 
 impl std::default::Default for Interner {
+    #[inline]
     fn default() -> Self {
         Self::new()
     }
 }
 
 impl std::default::Default for ThreadedInterner {
+    #[inline]
     fn default() -> Self {
         Self::new()
     }

--- a/crates/lexer/Cargo.toml
+++ b/crates/lexer/Cargo.toml
@@ -20,6 +20,7 @@ mago-reporting = { workspace = true }
 mago-interner = { workspace = true }
 serde = { workspace = true }
 strum = { workspace = true }
+memchr = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/lexer/tests/tokenizer.rs
+++ b/crates/lexer/tests/tokenizer.rs
@@ -10,6 +10,16 @@ use mago_lexer::error::SyntaxError;
 use mago_lexer::Lexer;
 
 #[test]
+fn test_shebang() -> Result<(), SyntaxError> {
+    let code = b"#!/usr/bin/env php\n<?php";
+    let expected = vec![TokenKind::InlineShebang, TokenKind::OpenTag];
+
+    test_lexer(code, expected).map_err(|err| {
+        panic!("unexpected error: {}", err);
+    })
+}
+
+#[test]
 fn test_casts() -> Result<(), SyntaxError> {
     let code = b"hello <?= ( string ) + - / ??= ?-> ... ( int   ) (integer    ) (    double) &&  ?> world";
     let expected = vec![

--- a/crates/linter/src/context.rs
+++ b/crates/linter/src/context.rs
@@ -16,41 +16,6 @@ use mago_span::HasPosition;
 use crate::rule::ConfiguredRule;
 
 #[derive(Debug)]
-pub struct Context<'a> {
-    pub php_version: PHPVersion,
-    pub interner: &'a ThreadedInterner,
-    pub codebase: &'a CodebaseReflection,
-    pub semantics: &'a Semantics,
-    pub issues: IssueCollection,
-}
-
-impl<'a> Context<'a> {
-    pub fn new(
-        php_version: PHPVersion,
-        interner: &'a ThreadedInterner,
-        codebase: &'a CodebaseReflection,
-        semantics: &'a Semantics,
-    ) -> Self {
-        Self { php_version, interner, codebase, semantics, issues: IssueCollection::default() }
-    }
-
-    pub fn for_rule<'b>(&'b mut self, rule: &'b ConfiguredRule) -> LintContext<'b> {
-        LintContext {
-            php_version: self.php_version,
-            rule,
-            interner: self.interner,
-            codebase: self.codebase,
-            semantics: self.semantics,
-            issues: &mut self.issues,
-        }
-    }
-
-    pub fn take_issue_collection(self) -> IssueCollection {
-        self.issues
-    }
-}
-
-#[derive(Debug)]
 pub struct LintContext<'a> {
     pub php_version: PHPVersion,
     pub rule: &'a ConfiguredRule,

--- a/crates/linter/src/directive.rs
+++ b/crates/linter/src/directive.rs
@@ -1,0 +1,48 @@
+/// A directive that instructs the linter on how to proceed after inspecting a node.
+///
+/// When a rule inspects a node using the `lint_node` method, it returns a `LintDirective`
+/// to control the subsequent linting flow:
+///
+/// - **`Continue`**:
+///   Process the current node as usual and then inspect its children. This is the default behavior.
+///
+/// - **`Prune`**:
+///   Process the current node but do not inspect its children. Use this when the rule has fully
+///   handled the node and further linting of its descendants is unnecessary.
+///
+/// - **`Abort`**:
+///   Immediately stop the entire linting process. Use this when a critical condition is met and
+///   no further analysis is required.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LintDirective {
+    /// Continue processing the node and its children.
+    Continue,
+    /// Process the node but prune (skip) its children.
+    Prune,
+    /// Abort the entire linting process immediately.
+    Abort,
+}
+
+impl LintDirective {
+    /// Returns `true` if the directive is `Continue`.
+    pub fn is_continue(self) -> bool {
+        matches!(self, LintDirective::Continue)
+    }
+
+    /// Returns `true` if the directive is `Prune`.
+    pub fn is_prune(self) -> bool {
+        matches!(self, LintDirective::Prune)
+    }
+
+    /// Returns `true` if the directive is `Abort`.
+    pub fn is_abort(self) -> bool {
+        matches!(self, LintDirective::Abort)
+    }
+}
+
+impl Default for LintDirective {
+    #[inline]
+    fn default() -> Self {
+        LintDirective::Continue
+    }
+}

--- a/crates/linter/src/plugin/analysis/rules/instantiation.rs
+++ b/crates/linter/src/plugin/analysis/rules/instantiation.rs
@@ -3,11 +3,11 @@ use indoc::indoc;
 use mago_ast::*;
 use mago_reporting::*;
 use mago_span::*;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
 use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
 use crate::rule::Rule;
 
 #[derive(Clone, Debug)]
@@ -79,12 +79,14 @@ impl Rule for InstantiationRule {
                 "#},
             ))
     }
-}
 
-impl<'a> Walker<LintContext<'a>> for InstantiationRule {
-    fn walk_in_instantiation(&self, instantiation: &Instantiation, context: &mut LintContext<'a>) {
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let Node::Instantiation(instantiation) = node else {
+            return LintDirective::Continue;
+        };
+
         let Expression::Identifier(class_identifier) = instantiation.class.as_ref() else {
-            return;
+            return LintDirective::default();
         };
 
         let class_name_identifier = context.semantics.names.get(class_identifier);
@@ -104,7 +106,7 @@ impl<'a> Walker<LintContext<'a>> for InstantiationRule {
 
             context.report(issue);
 
-            return;
+            return LintDirective::default();
         };
 
         if reflection.is_interface() {
@@ -118,7 +120,7 @@ impl<'a> Walker<LintContext<'a>> for InstantiationRule {
 
             context.report(issue);
 
-            return;
+            return LintDirective::default();
         }
 
         if reflection.is_trait() {
@@ -132,7 +134,7 @@ impl<'a> Walker<LintContext<'a>> for InstantiationRule {
 
             context.report(issue);
 
-            return;
+            return LintDirective::default();
         }
 
         if reflection.is_enum() {
@@ -146,7 +148,7 @@ impl<'a> Walker<LintContext<'a>> for InstantiationRule {
 
             context.report(issue);
 
-            return;
+            return LintDirective::default();
         }
 
         if reflection.is_abstract {
@@ -160,5 +162,7 @@ impl<'a> Walker<LintContext<'a>> for InstantiationRule {
 
             context.report(issue);
         }
+
+        LintDirective::default()
     }
 }

--- a/crates/linter/src/plugin/best_practices/rules/no_goto.rs
+++ b/crates/linter/src/plugin/best_practices/rules/no_goto.rs
@@ -3,10 +3,10 @@ use indoc::indoc;
 use mago_ast::*;
 use mago_reporting::*;
 use mago_span::HasSpan;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
+use crate::directive::LintDirective;
 use crate::rule::Rule;
 
 #[derive(Clone, Debug)]
@@ -20,36 +20,40 @@ impl Rule for NoGotoRule {
             of execution.
         "})
     }
-}
 
-impl<'a> Walker<LintContext<'a>> for NoGotoRule {
-    fn walk_in_goto<'ast>(&self, goto: &'ast Goto, context: &mut LintContext<'a>) {
-        let issue = Issue::new(context.level(), "Avoid using `goto`.")
-            .with_annotation(Annotation::primary(goto.goto.span()).with_message("This `goto` statement is used here."))
-            .with_annotation(Annotation::secondary(goto.label.span()))
-            .with_note("The `goto` statement can make code harder to read, understand, and maintain.")
-            .with_note("It can lead to spaghetti code and make it difficult to follow the flow of execution.")
-            .with_note(
-                "Consider using structured control flow statements like `if`, `else`, `for`, and `while` instead.",
-            )
-            .with_help("Refactor your code to avoid using `goto`.");
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        match node {
+            Node::Goto(goto) => {
+                context.report(
+                    Issue::new(context.level(), "Avoid using `goto`.")
+                        .with_annotation(Annotation::primary(goto.goto.span()).with_message("This `goto` statement is used here."))
+                        .with_annotation(Annotation::secondary(goto.label.span()))
+                        .with_note("The `goto` statement can make code harder to read, understand, and maintain.")
+                        .with_note("It can lead to spaghetti code and make it difficult to follow the flow of execution.")
+                        .with_note(
+                            "Consider using structured control flow statements like `if`, `else`, `for`, and `while` instead.",
+                        )
+                        .with_help("Refactor your code to avoid using `goto`.")
+                );
 
-        context.report(issue);
-    }
+                LintDirective::Prune
+            }
+            Node::Label(label) => {
+                context.report(
+                    Issue::new(context.level(), "Avoid using labels")
+                        .with_annotation(
+                            Annotation::primary(label.span()).with_message(format!("Label `{}` is declared here.",  context.lookup(&label.name.value))),
+                        )
+                        .with_note("Labels are often used with `goto` statements, which can make code harder to read and maintain.")
+                        .with_note(
+                            "Consider using structured control flow statements like `if`, `else`, `for`, and `while` instead.",
+                        )
+                        .with_help("Refactor your code to avoid using labels.")
+                );
 
-    fn walk_in_label<'ast>(&self, label: &'ast Label, context: &mut LintContext<'a>) {
-        let name = context.lookup(&label.name.value);
-
-        let issue = Issue::new(context.level(), "Avoid using labels")
-            .with_annotation(
-                Annotation::primary(label.span()).with_message(format!("Label `{}` is declared here.", name)),
-            )
-            .with_note("Labels are often used with `goto` statements, which can make code harder to read and maintain.")
-            .with_note(
-                "Consider using structured control flow statements like `if`, `else`, `for`, and `while` instead.",
-            )
-            .with_help("Refactor your code to avoid using labels.");
-
-        context.report(issue);
+                LintDirective::Prune
+            }
+            _ => LintDirective::default(),
+        }
     }
 }

--- a/crates/linter/src/plugin/best_practices/rules/no_multi_assignments.rs
+++ b/crates/linter/src/plugin/best_practices/rules/no_multi_assignments.rs
@@ -3,10 +3,10 @@ use indoc::indoc;
 use mago_ast::*;
 use mago_reporting::*;
 use mago_span::HasSpan;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
+use crate::directive::LintDirective;
 use crate::rule::Rule;
 
 #[derive(Clone, Debug)]
@@ -19,12 +19,12 @@ impl Rule for NoMultiAssignmentsRule {
             and unexpected behavior, and is generally considered poor practice.
         "})
     }
-}
 
-impl<'a> Walker<LintContext<'a>> for NoMultiAssignmentsRule {
-    fn walk_in_assignment(&self, assignment: &Assignment, context: &mut LintContext<'a>) {
-        let Expression::AssignmentOperation(other_assignment) = assignment.rhs.as_ref() else {
-            return;
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let Node::Assignment(assignment) = node else { return LintDirective::default() };
+
+        let Expression::Assignment(other_assignment) = assignment.rhs.as_ref() else {
+            return LintDirective::default();
         };
 
         let code = context.lookup(&context.semantics.source.content);
@@ -32,14 +32,18 @@ impl<'a> Walker<LintContext<'a>> for NoMultiAssignmentsRule {
         let b = &code[other_assignment.lhs.span().to_range()];
         let c = &code[other_assignment.rhs.span().to_range()];
 
-        let issue = Issue::new(context.level(), "Avoid using multiple assignments in a single statement.")
-            .with_annotation(
-                Annotation::primary(assignment.span())
-                    .with_message("Consider splitting this statement into multiple assignments."),
-            )
-            .with_note("Multiple assignments in a single statement can be confusing and lead to unexpected behavior.")
-            .with_help(format!("Did you mean `{a} = ({b} == {c})` instead? Ensure the intended logic is clear."));
+        context.report(
+            Issue::new(context.level(), "Avoid using multiple assignments in a single statement.")
+                .with_annotation(
+                    Annotation::primary(assignment.span())
+                        .with_message("Consider splitting this statement into multiple assignments."),
+                )
+                .with_note(
+                    "Multiple assignments in a single statement can be confusing and lead to unexpected behavior.",
+                )
+                .with_help(format!("Did you mean `{a} = ({b} == {c})` instead? Ensure the intended logic is clear.")),
+        );
 
-        context.report(issue);
+        LintDirective::default()
     }
 }

--- a/crates/linter/src/plugin/best_practices/rules/no_unused_parameter.rs
+++ b/crates/linter/src/plugin/best_practices/rules/no_unused_parameter.rs
@@ -4,10 +4,10 @@ use mago_ast::*;
 use mago_fixer::SafetyClassification;
 use mago_reporting::*;
 use mago_span::HasSpan;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
+use crate::directive::LintDirective;
 use crate::plugin::best_practices::rules::utils::expression_potentially_contains_function_call;
 use crate::plugin::best_practices::rules::utils::get_foreign_variable_names;
 use crate::plugin::best_practices::rules::utils::is_variable_used_in_expression;
@@ -26,242 +26,160 @@ impl Rule for NoUnusedParameterRule {
             Unused parameters are a sign of dead code and can be safely removed to improve code clarity.
         "})
     }
+
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let (reflection, members) = match node {
+            Node::Function(function) => {
+                if potentially_contains_function_call(&function.body, FUNC_GET_ARGS, context) {
+                    // `func_get_args` is potentially used, so we can't determine if the parameters are unused
+                    // in this case
+                    return LintDirective::default();
+                }
+
+                let foreign_variables = get_foreign_variable_names(&function.body, context);
+                for parameter in function.parameter_list.parameters.iter() {
+                    if foreign_variables.contains(&parameter.variable.name) {
+                        continue;
+                    }
+
+                    check_parameter(parameter, function, context, "function");
+                }
+
+                return LintDirective::default();
+            }
+            Node::Closure(closure) => {
+                if potentially_contains_function_call(&closure.body, FUNC_GET_ARGS, context) {
+                    // `func_get_args` is potentially used, so we can't determine if the parameters are unused
+                    // in this case
+                    return LintDirective::default();
+                }
+
+                let foreign_variables = get_foreign_variable_names(&closure.body, context);
+
+                for parameter in closure.parameter_list.parameters.iter() {
+                    if foreign_variables.contains(&parameter.variable.name) {
+                        continue;
+                    }
+
+                    check_parameter(parameter, closure, context, "closure");
+                }
+
+                return LintDirective::default();
+            }
+            Node::ArrowFunction(arrow_function) => {
+                if expression_potentially_contains_function_call(&arrow_function.expression, FUNC_GET_ARGS, context) {
+                    // `func_get_args` is potentially used, so we can't determine if the parameters are unused
+                    // in this case
+                    return LintDirective::default();
+                }
+
+                for parameter in arrow_function.parameter_list.parameters.iter() {
+                    if !is_variable_used_in_expression(&arrow_function.expression, context, parameter.variable.name) {
+                        check_parameter(parameter, arrow_function, context, "arrow function");
+                    }
+                }
+
+                return LintDirective::default();
+            }
+            Node::Class(class) => {
+                let name = context.semantics.names.get(&class.name);
+                let Some(reflection) = context.codebase.get_class(context.interner, name) else {
+                    return LintDirective::default();
+                };
+
+                (reflection, class.members.iter())
+            }
+            Node::Enum(r#enum) => {
+                let name = context.semantics.names.get(&r#enum.name);
+                let Some(reflection) = context.codebase.get_enum(context.interner, name) else {
+                    return LintDirective::default();
+                };
+
+                (reflection, r#enum.members.iter())
+            }
+            Node::Trait(r#trait) => {
+                let name = context.semantics.names.get(&r#trait.name);
+                let Some(reflection) = context.codebase.get_trait(context.interner, name) else {
+                    return LintDirective::default();
+                };
+
+                (reflection, r#trait.members.iter())
+            }
+            _ => return LintDirective::default(),
+        };
+
+        for member in members {
+            let ClassLikeMember::Method(method) = member else {
+                continue;
+            };
+
+            let MethodBody::Concrete(block) = &method.body else {
+                continue;
+            };
+
+            let Some(method_reflection) = reflection.get_method(&method.name.value) else {
+                continue;
+            };
+
+            if method_reflection.is_overriding {
+                // This method is overriding a method from a parent class.
+                continue;
+            }
+
+            if potentially_contains_function_call(block, FUNC_GET_ARGS, context) {
+                // `func_get_args` is potentially used, so we can't determine if the parameters are unused
+                // in this case
+                continue;
+            }
+
+            let foreign_variables = get_foreign_variable_names(block, context);
+
+            for parameter in method.parameter_list.parameters.iter() {
+                // Skip promoted properties
+                if parameter.is_promoted_property() {
+                    continue;
+                }
+
+                if foreign_variables.contains(&parameter.variable.name) {
+                    continue;
+                }
+
+                check_parameter(parameter, method, context, "method");
+            }
+        }
+
+        LintDirective::default()
+    }
 }
 
-impl NoUnusedParameterRule {
-    fn report(
-        &self,
-        parameter: &FunctionLikeParameter,
-        function_like: &impl HasSpan,
-        context: &mut LintContext,
-        kind: &'static str,
-        should_fix: bool,
-    ) {
-        if parameter.ampersand.is_some() {
-            return;
-        }
-
-        let parameter_name = context.interner.lookup(&parameter.variable.name);
-        if parameter_name.starts_with("$_") {
-            return;
-        }
-
-        let issue = Issue::new(context.level(), format!("Parameter `{}` is never used.", parameter_name))
-            .with_annotations([
-                Annotation::primary(parameter.span()).with_message(format!("Parameter `{}` is declared here.", parameter_name)),
-                Annotation::secondary(function_like.span()),
-            ])
-            .with_note(format!("This parameter is declared but not used within the {}.", kind))
-            .with_help("Consider prefixing the parameter with an underscore (`_`) to indicate that it is intentionally unused, or remove it if it is not needed.");
-
-        if !should_fix {
-            context.report(issue);
-
-            return;
-        }
-
-        context.report_with_fix(issue, |plan| {
-            plan.insert(
-                parameter.variable.span().start.offset + 1, // skip the leading `$`
-                "_",
-                SafetyClassification::PotentiallyUnsafe,
-            );
-        });
-    }
-}
-
-impl<'a> Walker<LintContext<'a>> for NoUnusedParameterRule {
-    fn walk_in_function<'ast>(&self, function: &'ast Function, context: &mut LintContext<'a>) {
-        if potentially_contains_function_call(&function.body, FUNC_GET_ARGS, context) {
-            // `func_get_args` is potentially used, so we can't determine if the parameters are unused
-            // in this case
-
-            return;
-        }
-
-        let foreign_variables = get_foreign_variable_names(&function.body, context);
-
-        for parameter in function.parameter_list.parameters.iter() {
-            if foreign_variables.contains(&parameter.variable.name) {
-                continue;
-            }
-
-            self.report(parameter, function, context, "function", true);
-        }
+fn check_parameter(
+    parameter: &FunctionLikeParameter,
+    function_like: &impl HasSpan,
+    context: &mut LintContext,
+    kind: &'static str,
+) {
+    if parameter.ampersand.is_some() {
+        return;
     }
 
-    fn walk_in_closure<'ast>(&self, closure: &'ast Closure, context: &mut LintContext<'a>) {
-        if potentially_contains_function_call(&closure.body, FUNC_GET_ARGS, context) {
-            // `func_get_args` is potentially used, so we can't determine if the parameters are unused
-            // in this case
-
-            return;
-        }
-
-        let foreign_variables = get_foreign_variable_names(&closure.body, context);
-
-        for parameter in closure.parameter_list.parameters.iter() {
-            if foreign_variables.contains(&parameter.variable.name) {
-                continue;
-            }
-
-            self.report(parameter, closure, context, "closure", true);
-        }
+    let parameter_name = context.interner.lookup(&parameter.variable.name);
+    if parameter_name.starts_with("$_") {
+        return;
     }
 
-    fn walk_in_class(&self, class: &Class, context: &mut LintContext<'a>) {
-        let name = context.semantics.names.get(&class.name);
-        let Some(reflection) = context.codebase.get_class(context.interner, name) else {
-            return;
-        };
+    let issue = Issue::new(context.level(), format!("Parameter `{}` is never used.", parameter_name))
+        .with_annotations([
+            Annotation::primary(parameter.span()).with_message(format!("Parameter `{}` is declared here.", parameter_name)),
+            Annotation::secondary(function_like.span()),
+        ])
+        .with_note(format!("This parameter is declared but not used within the {}.", kind))
+        .with_help("Consider prefixing the parameter with an underscore (`_`) to indicate that it is intentionally unused, or remove it if it is not needed.");
 
-        for member in class.members.iter() {
-            let ClassLikeMember::Method(method) = member else {
-                continue;
-            };
-
-            let MethodBody::Concrete(block) = &method.body else {
-                continue;
-            };
-
-            let Some(method_reflection) = reflection.get_method(&method.name.value) else {
-                continue;
-            };
-
-            if method_reflection.is_overriding {
-                // This method is overriding a method from a parent class.
-                continue;
-            }
-
-            if potentially_contains_function_call(block, FUNC_GET_ARGS, context) {
-                // `func_get_args` is potentially used, so we can't determine if the parameters are unused
-                // in this case
-                continue;
-            }
-
-            let foreign_variables = get_foreign_variable_names(block, context);
-
-            for parameter in method.parameter_list.parameters.iter() {
-                // Skip promoted properties
-                if parameter.is_promoted_property() {
-                    continue;
-                }
-
-                if foreign_variables.contains(&parameter.variable.name) {
-                    continue;
-                }
-
-                self.report(parameter, method, context, "method", true);
-            }
-        }
-    }
-
-    fn walk_in_enum(&self, r#enum: &Enum, context: &mut LintContext<'a>) {
-        let name = context.semantics.names.get(&r#enum.name);
-        let Some(reflection) = context.codebase.get_enum(context.interner, name) else {
-            return;
-        };
-
-        for member in r#enum.members.iter() {
-            let ClassLikeMember::Method(method) = member else {
-                continue;
-            };
-
-            let MethodBody::Concrete(block) = &method.body else {
-                continue;
-            };
-
-            let Some(method_reflection) = reflection.get_method(&method.name.value) else {
-                continue;
-            };
-
-            if method_reflection.is_overriding {
-                // This method is overriding a method from a parent class.
-                continue;
-            }
-
-            if potentially_contains_function_call(block, FUNC_GET_ARGS, context) {
-                // `func_get_args` is potentially used, so we can't determine if the parameters are unused
-                // in this case
-                continue;
-            }
-
-            let foreign_variables = get_foreign_variable_names(block, context);
-
-            for parameter in method.parameter_list.parameters.iter() {
-                // Skip promoted properties
-                if parameter.is_promoted_property() {
-                    continue;
-                }
-
-                if foreign_variables.contains(&parameter.variable.name) {
-                    continue;
-                }
-
-                self.report(parameter, method, context, "method", true);
-            }
-        }
-    }
-
-    fn walk_in_trait(&self, r#trait: &Trait, context: &mut LintContext<'a>) {
-        let name = context.semantics.names.get(&r#trait.name);
-        let Some(reflection) = context.codebase.get_trait(context.interner, name) else {
-            return;
-        };
-
-        for member in r#trait.members.iter() {
-            let ClassLikeMember::Method(method) = member else {
-                continue;
-            };
-
-            let MethodBody::Concrete(block) = &method.body else {
-                continue;
-            };
-
-            let Some(method_reflection) = reflection.get_method(&method.name.value) else {
-                continue;
-            };
-
-            if method_reflection.is_overriding {
-                // This method is overriding a method from a parent class.
-                continue;
-            }
-
-            if potentially_contains_function_call(block, FUNC_GET_ARGS, context) {
-                // `func_get_args` is potentially used, so we can't determine if the parameters are unused
-                // in this case
-                continue;
-            }
-
-            let foreign_variables = get_foreign_variable_names(block, context);
-
-            for parameter in method.parameter_list.parameters.iter() {
-                // Skip promoted properties
-                if parameter.is_promoted_property() {
-                    continue;
-                }
-
-                if foreign_variables.contains(&parameter.variable.name) {
-                    continue;
-                }
-
-                self.report(parameter, method, context, "method", true);
-            }
-        }
-    }
-
-    fn walk_in_arrow_function<'ast>(&self, arrow_function: &'ast ArrowFunction, context: &mut LintContext<'a>) {
-        if expression_potentially_contains_function_call(&arrow_function.expression, FUNC_GET_ARGS, context) {
-            // `func_get_args` is potentially used, so we can't determine if the parameters are unused
-            // in this case
-
-            return;
-        }
-
-        for parameter in arrow_function.parameter_list.parameters.iter() {
-            if !is_variable_used_in_expression(&arrow_function.expression, context, parameter.variable.name) {
-                self.report(parameter, arrow_function, context, "arrow function", true);
-            }
-        }
-    }
+    context.report_with_fix(issue, |plan| {
+        plan.insert(
+            parameter.variable.span().start.offset + 1, // skip the leading `$`
+            "_",
+            SafetyClassification::PotentiallyUnsafe,
+        );
+    });
 }

--- a/crates/linter/src/plugin/best_practices/rules/use_while_instead_of_for.rs
+++ b/crates/linter/src/plugin/best_practices/rules/use_while_instead_of_for.rs
@@ -4,10 +4,10 @@ use mago_ast::*;
 use mago_fixer::SafetyClassification;
 use mago_reporting::*;
 use mago_span::HasSpan;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
+use crate::directive::LintDirective;
 use crate::rule::Rule;
 
 #[derive(Clone, Debug)]
@@ -20,12 +20,12 @@ impl Rule for UseWhileInsteadOfForRule {
             initializations or increments. This can make the code more readable and concise.
         "})
     }
-}
 
-impl<'a> Walker<LintContext<'a>> for UseWhileInsteadOfForRule {
-    fn walk_in_for<'ast>(&self, r#for: &'ast For, context: &mut LintContext<'a>) {
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let Node::For(r#for) = node else { return LintDirective::default() };
+
         if !r#for.initializations.is_empty() || !r#for.increments.is_empty() {
-            return;
+            return LintDirective::default();
         }
 
         let issue = Issue::new(
@@ -54,5 +54,7 @@ impl<'a> Walker<LintContext<'a>> for UseWhileInsteadOfForRule {
                 plan.replace(for_colon_delimited_body.end_for.span.to_range(), "endwhile", SafetyClassification::Safe);
             }
         });
+
+        LintDirective::default()
     }
 }

--- a/crates/linter/src/plugin/best_practices/rules/utils.rs
+++ b/crates/linter/src/plugin/best_practices/rules/utils.rs
@@ -3,6 +3,7 @@ use mago_interner::StringIdentifier;
 use mago_walker::Walker;
 
 use crate::context::LintContext;
+use crate::plugin::best_practices::rules::utils::internal::FunctionCallWalker;
 
 /// Determine if a variable is a super global variable.
 pub fn is_super_global_variable(name: &str) -> bool {
@@ -58,8 +59,6 @@ pub fn is_predefined_variable(name: &str) -> bool {
 ///
 /// This function will return true when called with `baz` as the function name.
 pub fn potentially_contains_function_call(block: &Block, function_name: &str, context: &LintContext<'_>) -> bool {
-    use crate::plugin::best_practices::rules::utils::internal::FunctionCallWalker;
-
     let mut context = (false, context);
 
     FunctionCallWalker(function_name).walk_block(block, &mut context);
@@ -75,8 +74,6 @@ pub fn expression_potentially_contains_function_call(
     function_name: &str,
     context: &LintContext<'_>,
 ) -> bool {
-    use crate::plugin::best_practices::rules::utils::internal::FunctionCallWalker;
-
     let mut context = (false, context);
 
     FunctionCallWalker(function_name).walk_expression(expression, &mut context);

--- a/crates/linter/src/plugin/comment/rules/no_empty_comments.rs
+++ b/crates/linter/src/plugin/comment/rules/no_empty_comments.rs
@@ -1,14 +1,14 @@
 use indoc::indoc;
 use toml::Value;
 
-use mago_ast::Program;
+use mago_ast::*;
 use mago_fixer::SafetyClassification;
 use mago_reporting::*;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
 use crate::definition::RuleOptionDefinition;
+use crate::directive::LintDirective;
 use crate::plugin::comment::rules::utils::comment_content;
 use crate::rule::Rule;
 
@@ -32,10 +32,10 @@ impl Rule for NoEmptyCommentsRule {
                 default: Value::Boolean(PRESERVE_SINGLE_LINE_DEFAULT),
             })
     }
-}
 
-impl<'a> Walker<LintContext<'a>> for NoEmptyCommentsRule {
-    fn walk_program<'ast>(&self, program: &'ast Program, context: &mut LintContext<'a>) {
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let Node::Program(program) = node else { return LintDirective::Abort };
+
         let preseve_single_line =
             context.option(PRESERVE_SINGLE_LINE).and_then(|c| c.as_bool()).unwrap_or(PRESERVE_SINGLE_LINE_DEFAULT);
 
@@ -59,5 +59,7 @@ impl<'a> Walker<LintContext<'a>> for NoEmptyCommentsRule {
                 });
             }
         }
+
+        LintDirective::Abort
     }
 }

--- a/crates/linter/src/plugin/comment/rules/no_shell_style.rs
+++ b/crates/linter/src/plugin/comment/rules/no_shell_style.rs
@@ -4,10 +4,10 @@ use mago_ast::*;
 use mago_fixer::SafetyClassification;
 use mago_reporting::*;
 use mago_span::*;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
+use crate::directive::LintDirective;
 use crate::rule::Rule;
 
 #[derive(Clone, Debug)]
@@ -20,10 +20,10 @@ impl Rule for NoShellStyleRule {
             in PHP, as they are more consistent with the language's syntax and are easier to read.
         "})
     }
-}
 
-impl<'a> Walker<LintContext<'a>> for NoShellStyleRule {
-    fn walk_program<'ast>(&self, program: &'ast Program, context: &mut LintContext<'a>) {
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let Node::Program(program) = node else { return LintDirective::Abort };
+
         for trivia in program.trivia.iter() {
             if let TriviaKind::HashComment = trivia.kind {
                 let comment_span = trivia.span();
@@ -38,5 +38,7 @@ impl<'a> Walker<LintContext<'a>> for NoShellStyleRule {
                 });
             }
         }
+
+        LintDirective::Abort
     }
 }

--- a/crates/linter/src/plugin/comment/rules/no_trailing_whitespace.rs
+++ b/crates/linter/src/plugin/comment/rules/no_trailing_whitespace.rs
@@ -1,15 +1,15 @@
 use indoc::indoc;
 
-use mago_ast::Program;
+use mago_ast::*;
 use mago_fixer::FixPlan;
 use mago_fixer::SafetyClassification;
 use mago_reporting::*;
 use mago_source::*;
 use mago_span::*;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
+use crate::directive::LintDirective;
 use crate::rule::Rule;
 
 #[derive(Clone, Debug)]
@@ -22,57 +22,58 @@ impl Rule for NoTrailingWhitespaceRule {
             diffs and formatting issues, so it is recommended to remove it.
         "})
     }
-}
 
-impl<'a> Walker<LintContext<'a>> for NoTrailingWhitespaceRule {
-    fn walk_program<'ast>(&self, program: &'ast Program, context: &mut LintContext<'a>) {
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let Node::Program(program) = node else { return LintDirective::Abort };
+
         let mut issues = vec![];
         for trivia in program.trivia.iter() {
-            if trivia.kind.is_comment() {
-                let comment_span = trivia.span();
-                let value = context.lookup(&trivia.value);
-                let lines = value.lines().collect::<Vec<_>>();
+            if !trivia.kind.is_comment() {
+                continue;
+            }
 
-                let mut offset = 0;
+            let comment_span = trivia.span();
+            let value = context.lookup(&trivia.value);
+            let lines = value.lines().collect::<Vec<_>>();
 
-                for line in lines.iter() {
-                    let trimmed = line.trim_end();
-                    let trimmed_length = trimmed.len();
-                    let trailing_whitespace_length = line.len() - trimmed_length;
+            let mut offset = 0;
+            for line in lines.iter() {
+                let trimmed = line.trim_end();
+                let trimmed_length = trimmed.len();
+                let trailing_whitespace_length = line.len() - trimmed_length;
+                if trailing_whitespace_length > 0 {
+                    let whitespace_start = offset + trimmed_length;
 
-                    if trailing_whitespace_length > 0 {
-                        let whitespace_start = offset + trimmed_length;
+                    let whitespace_span = Span::new(
+                        comment_span.start.forward(whitespace_start),
+                        comment_span.start.forward(whitespace_start + trailing_whitespace_length),
+                    );
 
-                        let whitespace_span = Span::new(
-                            comment_span.start.forward(whitespace_start),
-                            comment_span.start.forward(whitespace_start + trailing_whitespace_length),
-                        );
+                    issues.push(
+                        Issue::new(context.level(), "Trailing whitespace detected in comment.")
+                            .with_annotations([
+                                Annotation::primary(whitespace_span).with_message("Trailing whitespace detected."),
+                                Annotation::secondary(comment_span).with_message("Comment with trailing whitespace."),
+                            ])
+                            .with_note("Trailing whitespaces can cause unnecessary diffs and formatting issues.")
+                            .with_help("Remove the extra whitespace.")
+                            .with_suggestion(whitespace_span.source(), {
+                                let mut plan = FixPlan::new();
 
-                        issues.push(
-                            Issue::new(context.level(), "Trailing whitespace detected in comment.")
-                                .with_annotations([
-                                    Annotation::primary(whitespace_span).with_message("Trailing whitespace detected."),
-                                    Annotation::secondary(comment_span)
-                                        .with_message("Comment with trailing whitespace."),
-                                ])
-                                .with_note("Trailing whitespaces can cause unnecessary diffs and formatting issues.")
-                                .with_help("Remove the extra whitespace.")
-                                .with_suggestion(whitespace_span.source(), {
-                                    let mut plan = FixPlan::new();
-
-                                    plan.delete(whitespace_span.to_range(), SafetyClassification::Safe);
-                                    plan
-                                }),
-                        );
-                    }
-
-                    offset += line.len() + 1;
+                                plan.delete(whitespace_span.to_range(), SafetyClassification::Safe);
+                                plan
+                            }),
+                    );
                 }
+
+                offset += line.len() + 1;
             }
         }
 
         for issue in issues {
             context.report(issue);
         }
+
+        LintDirective::Abort
     }
 }

--- a/crates/linter/src/plugin/comment/rules/no_untagged_fixme.rs
+++ b/crates/linter/src/plugin/comment/rules/no_untagged_fixme.rs
@@ -3,13 +3,13 @@ use std::sync::LazyLock;
 use indoc::indoc;
 use regex::Regex;
 
-use mago_ast::Program;
+use mago_ast::*;
 use mago_reporting::*;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
 use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
 use crate::plugin::comment::rules::utils::comment_content;
 use crate::rule::Rule;
 
@@ -45,38 +45,42 @@ impl Rule for NoUntaggedFixmeRule {
                 "#},
             ))
     }
-}
 
-impl<'a> Walker<LintContext<'a>> for NoUntaggedFixmeRule {
-    fn walk_program<'ast>(&self, program: &'ast Program, context: &mut LintContext<'a>) {
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let Node::Program(program) = node else { return LintDirective::Abort };
+
         for trivia in program.trivia.iter() {
-            if let Some(content) = comment_content(trivia, context) {
-                let content = content.to_lowercase();
-                if !content.contains("fixme") {
+            let Some(content) = comment_content(trivia, context) else {
+                continue;
+            };
+
+            let content = content.to_lowercase();
+            if !content.contains("fixme") {
+                continue;
+            }
+
+            for line in content.lines() {
+                let trimmied = line.trim_start();
+                if !trimmied.starts_with("fixme") {
                     continue;
                 }
 
-                for line in content.lines() {
-                    let trimmied = line.trim_start();
-                    if !trimmied.starts_with("fixme") {
-                        continue;
-                    }
-
-                    if (*TAGGED_FIXME_REGEX).is_match(trimmied) {
-                        continue;
-                    }
-
-                    context.report(
-                        Issue::new(context.level(), "FIXME comment should be tagged with (@username) or (#issue).")
-                            .with_annotation(Annotation::primary(trivia.span))
-                            .with_help(
-                                "Add a user tag or issue reference to the FIXME comment, e.g. FIXME(@azjezz), FIXME(azjezz), FIXME(#123).",
-                            )
-                    );
-
-                    break;
+                if (*TAGGED_FIXME_REGEX).is_match(trimmied) {
+                    continue;
                 }
+
+                context.report(
+                    Issue::new(context.level(), "FIXME comment should be tagged with (@username) or (#issue).")
+                        .with_annotation(Annotation::primary(trivia.span))
+                        .with_help(
+                            "Add a user tag or issue reference to the FIXME comment, e.g. FIXME(@azjezz), FIXME(azjezz), FIXME(#123).",
+                        )
+                );
+
+                break;
             }
         }
+
+        LintDirective::Abort
     }
 }

--- a/crates/linter/src/plugin/consistency/rules/array_syntax.rs
+++ b/crates/linter/src/plugin/consistency/rules/array_syntax.rs
@@ -5,21 +5,21 @@ use mago_ast::*;
 use mago_fixer::SafetyClassification;
 use mago_reporting::*;
 use mago_span::HasSpan;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
 use crate::definition::RuleOptionDefinition;
 use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
 use crate::rule::Rule;
 
 #[derive(Clone, Debug)]
 pub struct ArraySyntaxRule;
 
-const SYNTAX_OPTION: &str = "syntax";
-const SYNTAX_OPTION_LONG: &str = "long";
-const SYNTAX_OPTION_SHORT: &str = "short";
-const SYNTAX_OPTION_DEFAULT: &str = SYNTAX_OPTION_SHORT;
+const SYNTAX: &str = "syntax";
+const SYNTAX_LONG: &str = "long";
+const SYNTAX_SHORT: &str = "short";
+const SYNTAX_DEFAULT: &str = SYNTAX_SHORT;
 
 impl Rule for ArraySyntaxRule {
     fn get_definition(&self) -> RuleDefinition {
@@ -30,10 +30,10 @@ impl Rule for ArraySyntaxRule {
             is the preferred way to define arrays in PHP.
         "})
             .with_option(RuleOptionDefinition {
-                name: SYNTAX_OPTION,
+                name: SYNTAX,
                 r#type: "string",
                 description: "The array syntax to enforce. Can be either `short` or `long`.",
-                default: Value::String(SYNTAX_OPTION_DEFAULT.to_string()),
+                default: Value::String(SYNTAX_DEFAULT.to_string()),
             })
             .with_example({
                 RuleUsageExample::valid(
@@ -56,7 +56,7 @@ impl Rule for ArraySyntaxRule {
                         $arr = array(1, 2, 3);
                     "#},
                 )
-                .with_option(SYNTAX_OPTION, Value::String(SYNTAX_OPTION_LONG.to_string())),
+                .with_option(SYNTAX, Value::String(SYNTAX_LONG.to_string())),
             )
             .with_example({
                 RuleUsageExample::invalid(
@@ -79,45 +79,50 @@ impl Rule for ArraySyntaxRule {
                         $arr = [1, 2, 3];
                     "#},
                 )
-                .with_option(SYNTAX_OPTION, Value::String(SYNTAX_OPTION_LONG.to_string())),
+                .with_option(SYNTAX, Value::String(SYNTAX_LONG.to_string())),
             )
     }
-}
 
-impl<'a> Walker<LintContext<'a>> for ArraySyntaxRule {
-    fn walk_in_legacy_array<'ast>(&self, arr: &'ast LegacyArray, context: &mut LintContext<'a>) {
-        let preferred_syntax = context.option(SYNTAX_OPTION).and_then(|o| o.as_str()).unwrap_or(SYNTAX_OPTION_DEFAULT);
-        if !preferred_syntax.eq_ignore_ascii_case(SYNTAX_OPTION_SHORT) {
-            return;
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        match node {
+            Node::LegacyArray(arr) => {
+                let preferred_syntax = context.option(SYNTAX).and_then(|o| o.as_str()).unwrap_or(SYNTAX_DEFAULT);
+                if !preferred_syntax.eq_ignore_ascii_case(SYNTAX_SHORT) {
+                    return LintDirective::default();
+                }
+
+                let issue = Issue::new(context.level(), "Short array syntax `[..]` is preferred over `array(..)`.")
+                    .with_annotation(
+                        Annotation::primary(arr.span())
+                            .with_message("This array uses the long array syntax `array(..)`."),
+                    )
+                    .with_help("Use the short array syntax `[..]` instead");
+
+                context.report_with_fix(issue, |plan| {
+                    plan.replace(arr.array.span.join(arr.left_parenthesis).to_range(), "[", SafetyClassification::Safe);
+                    plan.replace(arr.right_parenthesis.to_range(), "]", SafetyClassification::Safe);
+                });
+            }
+            Node::Array(arr) => {
+                let preferred_syntax = context.option(SYNTAX).and_then(|o| o.as_str()).unwrap_or(SYNTAX_DEFAULT);
+                if !preferred_syntax.eq_ignore_ascii_case(SYNTAX_LONG) {
+                    return LintDirective::default();
+                }
+
+                let issue = Issue::new(context.level(), "Long array syntax `array(..)` is preferred over `[..]`.")
+                    .with_annotation(
+                        Annotation::primary(arr.span()).with_message("This array uses the short array syntax `[..]`."),
+                    )
+                    .with_help("Use the long array syntax `array(..)` instead");
+
+                context.report_with_fix(issue, |plan| {
+                    plan.replace(arr.left_bracket.to_range(), "array(", SafetyClassification::Safe);
+                    plan.replace(arr.right_bracket.to_range(), ")", SafetyClassification::Safe)
+                });
+            }
+            _ => {}
         }
 
-        let issue = Issue::new(context.level(), "Short array syntax `[..]` is preferred over `array(..)`.")
-            .with_annotation(
-                Annotation::primary(arr.span()).with_message("This array uses the long array syntax `array(..)`."),
-            )
-            .with_help("Use the short array syntax `[..]` instead");
-
-        context.report_with_fix(issue, |plan| {
-            plan.replace(arr.array.span.join(arr.left_parenthesis).to_range(), "[", SafetyClassification::Safe);
-            plan.replace(arr.right_parenthesis.to_range(), "]", SafetyClassification::Safe);
-        });
-    }
-
-    fn walk_in_array<'ast>(&self, arr: &'ast Array, context: &mut LintContext<'a>) {
-        let preferred_syntax = context.option(SYNTAX_OPTION).and_then(|o| o.as_str()).unwrap_or(SYNTAX_OPTION_DEFAULT);
-        if !preferred_syntax.eq_ignore_ascii_case(SYNTAX_OPTION_LONG) {
-            return;
-        }
-
-        let issue = Issue::new(context.level(), "Long array syntax `array(..)` is preferred over `[..]`.")
-            .with_annotation(
-                Annotation::primary(arr.span()).with_message("This array uses the short array syntax `[..]`."),
-            )
-            .with_help("Use the long array syntax `array(..)` instead");
-
-        context.report_with_fix(issue, |plan| {
-            plan.replace(arr.left_bracket.to_range(), "array(", SafetyClassification::Safe);
-            plan.replace(arr.right_bracket.to_range(), ")", SafetyClassification::Safe)
-        });
+        LintDirective::default()
     }
 }

--- a/crates/linter/src/plugin/consistency/rules/lowercase_hint.rs
+++ b/crates/linter/src/plugin/consistency/rules/lowercase_hint.rs
@@ -1,14 +1,14 @@
 use indoc::indoc;
 
-use mago_ast::ast::*;
+use mago_ast::*;
 use mago_fixer::SafetyClassification;
 use mago_reporting::*;
 use mago_span::*;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
 use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
 use crate::rule::Rule;
 
 #[derive(Clone, Copy, Debug)]
@@ -18,10 +18,10 @@ impl Rule for LowercaseHintRule {
     fn get_definition(&self) -> RuleDefinition {
         RuleDefinition::enabled("Lowercase Hint", Level::Help)
             .with_description(indoc! {"
-                    Enforces that PHP type hints (like `void`, `bool`, `int`, `float`, etc.) be written
-                    in lowercase. Using uppercase or mixed case is discouraged for consistency
-                    and readability.
-                "})
+                Enforces that PHP type hints (like `void`, `bool`, `int`, `float`, etc.) be written
+                in lowercase. Using uppercase or mixed case is discouraged for consistency
+                and readability.
+            "})
             .with_example(RuleUsageExample::valid(
                 "Using lowercase type hints",
                 indoc! {r#"
@@ -43,30 +43,43 @@ impl Rule for LowercaseHintRule {
                 "#},
             ))
     }
-}
 
-impl<'a> Walker<LintContext<'a>> for LowercaseHintRule {
-    fn walk_in_hint<'ast>(&self, hint: &'ast Hint, context: &mut LintContext<'a>) {
-        if let Hint::Void(identifier)
-        | Hint::Never(identifier)
-        | Hint::Float(identifier)
-        | Hint::Bool(identifier)
-        | Hint::Integer(identifier)
-        | Hint::String(identifier)
-        | Hint::Object(identifier)
-        | Hint::Mixed(identifier)
-        | Hint::Iterable(identifier) = hint
-        {
-            let name = context.interner.lookup(&identifier.value);
-            let lowered = name.to_ascii_lowercase();
-            if !lowered.eq(&name) {
-                let issue = Issue::new(context.level(), format!("Type hint `{}` should be in lowercase.", name))
-                    .with_annotation(Annotation::primary(identifier.span()))
-                    .with_help(format!("Consider using `{}` instead of `{}`.", lowered, name));
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let Node::Hint(hint) = node else { return LintDirective::default() };
 
-                context.report_with_fix(issue, |p| {
-                    p.replace(identifier.span.to_range(), lowered, SafetyClassification::Safe)
-                });
+        match hint {
+            Hint::Void(identifier)
+            | Hint::Never(identifier)
+            | Hint::Float(identifier)
+            | Hint::Bool(identifier)
+            | Hint::Integer(identifier)
+            | Hint::String(identifier)
+            | Hint::Object(identifier)
+            | Hint::Mixed(identifier)
+            | Hint::Iterable(identifier) => {
+                let name = context.interner.lookup(&identifier.value);
+                let lowered = name.to_ascii_lowercase();
+                if !lowered.eq(&name) {
+                    let issue = Issue::new(context.level(), format!("Type hint `{}` should be in lowercase.", name))
+                        .with_annotation(Annotation::primary(identifier.span()))
+                        .with_help(format!("Consider using `{}` instead of `{}`.", lowered, name));
+
+                    context.report_with_fix(issue, |p| {
+                        p.replace(identifier.span.to_range(), lowered, SafetyClassification::Safe)
+                    });
+                }
+
+                // No need to continue linting the children of this node.
+                LintDirective::Prune
+            }
+            _ => {
+                if hint.is_complex() {
+                    // These are compound hints, so we need to continue linting the children.
+                    LintDirective::Continue
+                } else {
+                    // We don't care about other hints.
+                    LintDirective::Prune
+                }
             }
         }
     }

--- a/crates/linter/src/plugin/consistency/rules/require_block_statement_body.rs
+++ b/crates/linter/src/plugin/consistency/rules/require_block_statement_body.rs
@@ -4,11 +4,11 @@ use mago_ast::*;
 use mago_fixer::SafetyClassification;
 use mago_reporting::*;
 use mago_span::HasSpan;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
 use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
 use crate::rule::Rule;
 
 #[derive(Clone, Debug)]
@@ -49,54 +49,57 @@ impl Rule for RequireBlockStatementBodyRule {
                 "#},
             ))
     }
-}
 
-impl RequireBlockStatementBodyRule {
-    fn report(&self, r#loop: &impl HasSpan, statement: &Statement, context: &mut LintContext<'_>) {
-        if matches!(statement, Statement::Block(_)) {
-            return;
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        match node {
+            Node::For(r#for) => {
+                let ForBody::Statement(statement) = &r#for.body else {
+                    return LintDirective::default();
+                };
+
+                check_loop(r#for, statement, context);
+            }
+            Node::While(r#while) => {
+                let WhileBody::Statement(statement) = &r#while.body else {
+                    return LintDirective::default();
+                };
+
+                check_loop(r#while, statement, context);
+            }
+            Node::Foreach(foreach) => {
+                let ForeachBody::Statement(statement) = &foreach.body else {
+                    return LintDirective::default();
+                };
+
+                check_loop(foreach, statement, context);
+            }
+            _ => {}
         }
 
-        let issue = Issue::new(context.level(), "Loop body should be enclosed in a block.")
-            .with_annotations([Annotation::primary(statement.span()), Annotation::secondary(r#loop.span())])
-            .with_note(
-                "Enclosing the loop body in a block improves readability and prevents potential errors \
-                when adding or modifying statements within the loop.",
-            )
-            .with_help("Enclose the loop body in a block for clarity and error prevention.");
-
-        context.report_with_fix(issue, |plan| {
-            if matches!(statement, Statement::Noop(_)) {
-                plan.replace(statement.span().to_range(), "{}", SafetyClassification::Safe);
-            } else {
-                plan.insert(statement.span().start.offset, "{", SafetyClassification::Safe);
-                plan.insert(statement.span().end.offset, "}", SafetyClassification::Safe);
-            }
-        });
+        LintDirective::default()
     }
 }
-impl<'a> Walker<LintContext<'a>> for RequireBlockStatementBodyRule {
-    fn walk_in_for<'ast>(&self, r#for: &'ast For, context: &mut LintContext<'a>) {
-        let ForBody::Statement(statement) = &r#for.body else {
-            return;
-        };
 
-        self.report(r#for, statement, context);
+#[inline]
+fn check_loop(r#loop: &impl HasSpan, statement: &Statement, context: &mut LintContext<'_>) {
+    if matches!(statement, Statement::Block(_)) {
+        return;
     }
 
-    fn walk_in_while<'ast>(&self, r#while: &'ast While, context: &mut LintContext<'a>) {
-        let WhileBody::Statement(statement) = &r#while.body else {
-            return;
-        };
+    let issue = Issue::new(context.level(), "Loop body should be enclosed in a block.")
+        .with_annotations([Annotation::primary(statement.span()), Annotation::secondary(r#loop.span())])
+        .with_note(
+            "Enclosing the loop body in a block improves readability and prevents potential errors \
+            when adding or modifying statements within the loop.",
+        )
+        .with_help("Enclose the loop body in a block for clarity and error prevention.");
 
-        self.report(r#while, statement, context);
-    }
-
-    fn walk_in_foreach<'ast>(&self, foreach: &'ast Foreach, context: &mut LintContext<'a>) {
-        let ForeachBody::Statement(statement) = &foreach.body else {
-            return;
-        };
-
-        self.report(foreach, statement, context);
-    }
+    context.report_with_fix(issue, |plan| {
+        if matches!(statement, Statement::Noop(_)) {
+            plan.replace(statement.span().to_range(), "{}", SafetyClassification::Safe);
+        } else {
+            plan.insert(statement.span().start.offset, "{", SafetyClassification::Safe);
+            plan.insert(statement.span().end.offset, "}", SafetyClassification::Safe);
+        }
+    });
 }

--- a/crates/linter/src/plugin/deprecation/rules/php82/return_by_reference_from_void_function.rs
+++ b/crates/linter/src/plugin/deprecation/rules/php82/return_by_reference_from_void_function.rs
@@ -1,15 +1,15 @@
 use indoc::indoc;
 
-use mago_ast::ast::*;
+use mago_ast::*;
 use mago_fixer::SafetyClassification;
 use mago_php_version::PHPVersion;
 use mago_reporting::*;
 use mago_span::*;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
 use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
 use crate::rule::Rule;
 
 #[derive(Clone, Copy, Debug)]
@@ -93,100 +93,85 @@ impl Rule for ReturnByReferenceFromVoidFunctionRule {
                 "#},
             ))
     }
-}
 
-impl<'a> Walker<LintContext<'a>> for ReturnByReferenceFromVoidFunctionRule {
-    fn walk_in_function(&self, function: &Function, context: &mut LintContext<'a>) {
-        let Some(amperstand) = function.ampersand.as_ref() else {
-            return;
-        };
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        match node {
+            Node::Function(function) => {
+                let Some(amperstand) = function.ampersand.as_ref() else {
+                    return LintDirective::default();
+                };
 
-        let Some(return_type) = function.return_type_hint.as_ref() else {
-            return;
-        };
+                let Some(return_type) = function.return_type_hint.as_ref() else {
+                    return LintDirective::default();
+                };
 
-        if !matches!(return_type.hint, Hint::Void(_)) {
-            return;
+                if !matches!(return_type.hint, Hint::Void(_)) {
+                    return LintDirective::default();
+                }
+
+                report(context, "function", function.span(), amperstand, false);
+            }
+            Node::Method(method) => {
+                let Some(amperstand) = method.ampersand.as_ref() else {
+                    return LintDirective::default();
+                };
+
+                let Some(return_type) = method.return_type_hint.as_ref() else {
+                    return LintDirective::default();
+                };
+
+                if !matches!(return_type.hint, Hint::Void(_)) {
+                    return LintDirective::default();
+                }
+
+                report(context, "method", method.span(), amperstand, false);
+            }
+            Node::Closure(closure) => {
+                let Some(amperstand) = closure.ampersand.as_ref() else {
+                    return LintDirective::default();
+                };
+
+                let Some(return_type) = closure.return_type_hint.as_ref() else {
+                    return LintDirective::default();
+                };
+
+                if !matches!(return_type.hint, Hint::Void(_)) {
+                    return LintDirective::default();
+                }
+
+                report(context, "closure", closure.span(), amperstand, false);
+            }
+            Node::ArrowFunction(arrow_function) => {
+                let Some(amperstand) = arrow_function.ampersand.as_ref() else {
+                    return LintDirective::default();
+                };
+
+                let Some(return_type) = arrow_function.return_type_hint.as_ref() else {
+                    return LintDirective::default();
+                };
+
+                if !matches!(return_type.hint, Hint::Void(_)) {
+                    return LintDirective::default();
+                }
+
+                report(context, "arrow function", arrow_function.span(), amperstand, false);
+            }
+            Node::PropertyHook(property_hook) => {
+                let name = context.lookup(&property_hook.name.value);
+                if "set" != name {
+                    return LintDirective::default();
+                }
+
+                let Some(amperstand) = property_hook.ampersand.as_ref() else {
+                    return LintDirective::default();
+                };
+
+                report(context, "set property hook", property_hook.span(), amperstand, true);
+            }
+            _ => (),
         }
 
-        report(context, "function", function.span(), amperstand, false);
-    }
-
-    fn walk_in_method(&self, method: &Method, context: &mut LintContext<'a>) {
-        if context.php_version < PHPVersion::PHP82 {
-            return;
-        }
-
-        let Some(amperstand) = method.ampersand.as_ref() else {
-            return;
-        };
-
-        let Some(return_type) = method.return_type_hint.as_ref() else {
-            return;
-        };
-
-        if !matches!(return_type.hint, Hint::Void(_)) {
-            return;
-        }
-
-        report(context, "method", method.span(), amperstand, false);
-    }
-
-    fn walk_in_closure(&self, closure: &Closure, context: &mut LintContext<'a>) {
-        if context.php_version < PHPVersion::PHP82 {
-            return;
-        }
-
-        let Some(amperstand) = closure.ampersand.as_ref() else {
-            return;
-        };
-
-        let Some(return_type) = closure.return_type_hint.as_ref() else {
-            return;
-        };
-
-        if !matches!(return_type.hint, Hint::Void(_)) {
-            return;
-        }
-
-        report(context, "closure", closure.span(), amperstand, false);
-    }
-
-    fn walk_in_arrow_function(&self, arrow_function: &ArrowFunction, context: &mut LintContext<'a>) {
-        if context.php_version < PHPVersion::PHP82 {
-            return;
-        }
-
-        let Some(amperstand) = arrow_function.ampersand.as_ref() else {
-            return;
-        };
-
-        let Some(return_type) = arrow_function.return_type_hint.as_ref() else {
-            return;
-        };
-
-        if !matches!(return_type.hint, Hint::Void(_)) {
-            return;
-        }
-
-        report(context, "arrow function", arrow_function.span(), amperstand, false);
-    }
-
-    fn walk_in_property_hook(&self, property_hook: &PropertyHook, context: &mut LintContext<'a>) {
-        if context.php_version < PHPVersion::PHP82 {
-            return;
-        }
-
-        let name = context.lookup(&property_hook.name.value);
-        if "set" != name {
-            return;
-        }
-
-        let Some(amperstand) = property_hook.ampersand.as_ref() else {
-            return;
-        };
-
-        report(context, "set property hook", property_hook.span(), amperstand, true);
+        LintDirective::default()
     }
 }
 

--- a/crates/linter/src/plugin/deprecation/rules/php84/underscore_classname.rs
+++ b/crates/linter/src/plugin/deprecation/rules/php84/underscore_classname.rs
@@ -4,11 +4,11 @@ use mago_ast::*;
 use mago_php_version::PHPVersion;
 use mago_reporting::*;
 use mago_span::HasSpan;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
 use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
 use crate::rule::Rule;
 
 #[derive(Clone, Debug)]
@@ -39,80 +39,78 @@ impl Rule for UnderscoreClassNameRule {
                 "#},
             ))
     }
-}
 
-impl<'a> Walker<LintContext<'a>> for UnderscoreClassNameRule {
-    fn walk_in_class(&self, class: &Class, context: &mut LintContext<'a>) {
-        let class_name = context.lookup(&class.name.value);
-        if class_name != "_" {
-            return;
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        match node {
+            Node::Class(class) => {
+                let class_name = context.lookup(&class.name.value);
+                if class_name != "_" {
+                    return LintDirective::default();
+                }
+
+                context.report(
+                    Issue::new(context.level(), "Using `_` as a class name is deprecated.")
+                        .with_annotation(
+                            Annotation::primary(class.name.span())
+                                .with_message("Rename the class to something more descriptive."),
+                        )
+                        .with_note(
+                            "Class names consisting only of `_` are deprecated. consider using a meaningful name.",
+                        ),
+                );
+            }
+            Node::Interface(interface) => {
+                let interface_name = context.lookup(&interface.name.value);
+                if interface_name != "_" {
+                    return LintDirective::default();
+                }
+
+                context.report(
+                    Issue::new(context.level(), "Using `_` as an interface name is deprecated.")
+                        .with_annotation(
+                            Annotation::primary(interface.name.span())
+                                .with_message("Rename the interface to something more descriptive."),
+                        )
+                        .with_note(
+                            "Interface names consisting only of `_` are deprecated. consider using a meaningful name.",
+                        ),
+                );
+            }
+            Node::Trait(r#trait) => {
+                let trait_name = context.lookup(&r#trait.name.value);
+                if trait_name != "_" {
+                    return LintDirective::default();
+                }
+
+                context.report(
+                    Issue::new(context.level(), "Using `_` as a trait name is deprecated.")
+                        .with_annotation(
+                            Annotation::primary(r#trait.name.span())
+                                .with_message("Rename the trait to something more descriptive."),
+                        )
+                        .with_note(
+                            "Trait names consisting only of `_` are deprecated. consider using a meaningful name.",
+                        ),
+                );
+            }
+            Node::Enum(r#enum) => {
+                let enum_name = context.lookup(&r#enum.name.value);
+                if enum_name != "_" {
+                    return LintDirective::default();
+                }
+
+                let issue = Issue::new(context.level(), "Using `_` as an enum name is deprecated.")
+                    .with_annotation(
+                        Annotation::primary(r#enum.name.span())
+                            .with_message("Rename the enum to something more descriptive."),
+                    )
+                    .with_note("Enum names consisting only of `_` are deprecated. consider using a meaningful name.");
+
+                context.report(issue);
+            }
+            _ => {}
         }
 
-        let issue = Issue::new(context.level(), "Using `_` as a class name is deprecated.")
-            .with_annotation(
-                Annotation::primary(class.name.span()).with_message("Rename the class to something more descriptive."),
-            )
-            .with_note("Class names consisting only of `_` are deprecated. consider using a meaningful name.");
-
-        context.report(issue);
-    }
-
-    fn walk_in_interface(&self, interface: &Interface, context: &mut LintContext<'a>) {
-        if context.php_version < PHPVersion::PHP84 {
-            return;
-        }
-
-        let interface_name = context.lookup(&interface.name.value);
-        if interface_name != "_" {
-            return;
-        }
-
-        let issue = Issue::new(context.level(), "Using `_` as an interface name is deprecated.")
-            .with_annotation(
-                Annotation::primary(interface.name.span())
-                    .with_message("Rename the interface to something more descriptive."),
-            )
-            .with_note("Interface names consisting only of `_` are deprecated. consider using a meaningful name.");
-
-        context.report(issue);
-    }
-
-    fn walk_in_trait(&self, r#trait: &Trait, context: &mut LintContext<'a>) {
-        if context.php_version < PHPVersion::PHP84 {
-            return;
-        }
-
-        let trait_name = context.lookup(&r#trait.name.value);
-        if trait_name != "_" {
-            return;
-        }
-
-        let issue = Issue::new(context.level(), "Using `_` as a trait name is deprecated.")
-            .with_annotation(
-                Annotation::primary(r#trait.name.span())
-                    .with_message("Rename the trait to something more descriptive."),
-            )
-            .with_note("Trait names consisting only of `_` are deprecated. consider using a meaningful name.");
-
-        context.report(issue);
-    }
-
-    fn walk_in_enum(&self, r#enum: &Enum, context: &mut LintContext<'a>) {
-        if context.php_version < PHPVersion::PHP84 {
-            return;
-        }
-
-        let enum_name = context.lookup(&r#enum.name.value);
-        if enum_name != "_" {
-            return;
-        }
-
-        let issue = Issue::new(context.level(), "Using `_` as an enum name is deprecated.")
-            .with_annotation(
-                Annotation::primary(r#enum.name.span()).with_message("Rename the enum to something more descriptive."),
-            )
-            .with_note("Enum names consisting only of `_` are deprecated. consider using a meaningful name.");
-
-        context.report(issue);
+        LintDirective::default()
     }
 }

--- a/crates/linter/src/plugin/laravel/rules/safety/no_request_all.rs
+++ b/crates/linter/src/plugin/laravel/rules/safety/no_request_all.rs
@@ -4,11 +4,11 @@ use mago_ast::*;
 use mago_ast_utils::reference::*;
 use mago_reporting::*;
 use mago_span::HasSpan;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
 use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
 use crate::rule::Rule;
 
 const REQUEST_CLASS: &str = "Request";
@@ -102,10 +102,10 @@ impl Rule for NoRequestAllRule {
                 "#},
             ))
     }
-}
 
-impl<'a> Walker<LintContext<'a>> for NoRequestAllRule {
-    fn walk_block(&self, block: &Block, context: &mut LintContext<'a>) {
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let Node::Block(block) = node else { return LintDirective::default() };
+
         let request_all_references = find_method_references_in_block(block, &|reference| {
             let ClassLikeMemberSelector::Identifier(method) = reference.get_selector() else {
                 return false;
@@ -161,5 +161,7 @@ impl<'a> Walker<LintContext<'a>> for NoRequestAllRule {
 
             context.report(issue);
         }
+
+        LintDirective::Prune
     }
 }

--- a/crates/linter/src/plugin/maintainability/rules/too_many_methods.rs
+++ b/crates/linter/src/plugin/maintainability/rules/too_many_methods.rs
@@ -1,15 +1,14 @@
 use indoc::indoc;
 use toml::Value;
 
-use mago_ast::ast::*;
-use mago_ast::Node;
+use mago_ast::*;
 use mago_reporting::*;
 use mago_span::HasSpan;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
 use crate::definition::RuleOptionDefinition;
+use crate::directive::LintDirective;
 use crate::rule::Rule;
 
 use crate::plugin::maintainability::rules::utils::is_method_setter_or_getter;
@@ -54,67 +53,59 @@ impl Rule for TooManyMethodsRule {
                 default: Value::Boolean(COUNT_HOOKS_DEFAULT),
             })
     }
-}
 
-impl<'a> Walker<LintContext<'a>> for TooManyMethodsRule {
-    fn walk_in_class(&self, class: &Class, context: &mut LintContext<'a>) {
-        check("Class", Node::Class(class), class.members.as_slice(), context);
-    }
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let (kind, members) = match node {
+            Node::Class(class) => ("Class", class.members.as_slice()),
+            Node::Trait(r#trait) => ("Trait", r#trait.members.as_slice()),
+            Node::AnonymousClass(anonymous_class) => ("Class", anonymous_class.members.as_slice()),
+            Node::Enum(r#enum) => ("Enum", r#enum.members.as_slice()),
+            Node::Interface(interface) => ("Interface", interface.members.as_slice()),
+            _ => {
+                return LintDirective::default();
+            }
+        };
 
-    fn walk_in_trait(&self, r#trait: &Trait, context: &mut LintContext<'a>) {
-        check("Trait", Node::Trait(r#trait), r#trait.members.as_slice(), context);
-    }
+        let threshold = context.option(THRESHOLD).and_then(|o| o.as_integer()).unwrap_or(THRESHOLD_DEFAULT) as usize;
+        let count_hooks = context.option(COUNT_HOOKS).and_then(|o| o.as_bool()).unwrap_or(COUNT_HOOKS_DEFAULT);
+        let count_setters_and_getters = context
+            .option(COUNT_SETTERS_AND_GETTERS)
+            .and_then(|o| o.as_bool())
+            .unwrap_or(COUNT_SETTERS_AND_GETTERS_DEFAULT);
 
-    fn walk_in_interface(&self, interface: &Interface, context: &mut LintContext<'a>) {
-        check("Interface", Node::Interface(interface), interface.members.as_slice(), context);
-    }
+        let mut methods = 0;
+        for member in members {
+            match member {
+                ClassLikeMember::Method(method) => {
+                    if !count_setters_and_getters && is_method_setter_or_getter(method, context) {
+                        continue;
+                    }
 
-    fn walk_in_enum(&self, r#enum: &Enum, context: &mut LintContext<'a>) {
-        check("Enum", Node::Enum(r#enum), r#enum.members.as_slice(), context);
-    }
-
-    fn walk_in_anonymous_class(&self, anonymous_class: &AnonymousClass, context: &mut LintContext<'a>) {
-        check("Class", Node::AnonymousClass(anonymous_class), anonymous_class.members.as_slice(), context);
-    }
-}
-
-#[inline]
-fn check(kind: &'static str, node: Node<'_>, members: &[ClassLikeMember], context: &mut LintContext<'_>) {
-    let threshold = context.option(THRESHOLD).and_then(|o| o.as_integer()).unwrap_or(THRESHOLD_DEFAULT) as usize;
-    let count_hooks = context.option(COUNT_HOOKS).and_then(|o| o.as_bool()).unwrap_or(COUNT_HOOKS_DEFAULT);
-    let count_setters_and_getters = context
-        .option(COUNT_SETTERS_AND_GETTERS)
-        .and_then(|o| o.as_bool())
-        .unwrap_or(COUNT_SETTERS_AND_GETTERS_DEFAULT);
-
-    let mut methods = 0;
-    for member in members {
-        match member {
-            ClassLikeMember::Method(method) => {
-                if !count_setters_and_getters && is_method_setter_or_getter(method, context) {
-                    continue;
+                    methods += 1;
                 }
-
-                methods += 1;
+                ClassLikeMember::Property(Property::Hooked(hooked_property)) if count_hooks => {
+                    methods += hooked_property.hooks.hooks.len();
+                }
+                _ => (),
             }
-            ClassLikeMember::Property(Property::Hooked(hooked_property)) if count_hooks => {
-                methods += hooked_property.hooks.hooks.len();
-            }
-            _ => (),
         }
-    }
 
-    if methods > threshold {
-        let issue = Issue::new(context.level(), format!("{} has too many methods.", kind))
-            .with_annotation(Annotation::primary(node.span()).with_message(format!(
-                "{} has {} methods, which exceeds the threshold of {}.",
-                kind, methods, threshold
-            )))
-            .with_note("Having a large number of methods can make classes harder to understand and maintain.")
-            .with_help(
-                "Try reducing the number of methods, or consider splitting the structure into smaller, more focused structures.",
-            );
+        if methods > threshold {
+            context.report(Issue::new(context.level(), format!("{} has too many methods.", kind))
+                .with_annotation(Annotation::primary(node.span()).with_message(format!(
+                    "{} has {} methods, which exceeds the threshold of {}.",
+                    kind, methods, threshold
+                )))
+                .with_note("Having a large number of methods can make classes harder to understand and maintain.")
+                .with_help(
+                    "Try reducing the number of methods, or consider splitting the structure into smaller, more focused structures.",
+                ));
 
-        context.report(issue);
+            // If this structure has too many methods, we don't need to check the nested structures.
+            LintDirective::Prune
+        } else {
+            // Continue checking nested structures, if any.
+            LintDirective::Continue
+        }
     }
 }

--- a/crates/linter/src/plugin/maintainability/rules/too_many_properties.rs
+++ b/crates/linter/src/plugin/maintainability/rules/too_many_properties.rs
@@ -5,11 +5,11 @@ use mago_ast::ast::*;
 use mago_ast::Node;
 use mago_reporting::*;
 use mago_span::HasSpan;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
 use crate::definition::RuleOptionDefinition;
+use crate::directive::LintDirective;
 use crate::rule::Rule;
 
 const THRESHOLD: &str = "threshold";
@@ -34,56 +34,52 @@ impl Rule for TooManyPropertiesRule {
                 default: Value::Integer(THRESHOLD_DEFAULT),
             })
     }
-}
-
-impl<'a> Walker<LintContext<'a>> for TooManyPropertiesRule {
-    fn walk_in_class(&self, class: &Class, context: &mut LintContext<'a>) {
-        check("Class", Node::Class(class), class.members.as_slice(), context);
-    }
-
-    fn walk_in_trait(&self, r#trait: &Trait, context: &mut LintContext<'a>) {
-        check("Trait", Node::Trait(r#trait), r#trait.members.as_slice(), context);
-    }
-
-    fn walk_in_interface(&self, interface: &Interface, context: &mut LintContext<'a>) {
-        check("Interface", Node::Interface(interface), interface.members.as_slice(), context);
-    }
-
-    fn walk_in_anonymous_class(&self, anonymous_class: &AnonymousClass, context: &mut LintContext<'a>) {
-        check("Class", Node::AnonymousClass(anonymous_class), anonymous_class.members.as_slice(), context);
-    }
-}
-
-#[inline]
-fn check(kind: &'static str, node: Node<'_>, members: &[ClassLikeMember], context: &mut LintContext<'_>) {
-    let threshold = context.option(THRESHOLD).and_then(|o| o.as_integer()).unwrap_or(THRESHOLD_DEFAULT) as usize;
-    let mut properties = 0;
-    for member in members {
-        let ClassLikeMember::Property(property) = member else {
-            continue;
+    fn lint_node(&self, node: mago_ast::Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let (kind, members) = match node {
+            Node::Class(class) => ("Class", class.members.as_slice()),
+            Node::Trait(r#trait) => ("Trait", r#trait.members.as_slice()),
+            Node::AnonymousClass(anonymous_class) => ("Class", anonymous_class.members.as_slice()),
+            Node::Interface(interface) => ("Interface", interface.members.as_slice()),
+            _ => {
+                return LintDirective::default();
+            }
         };
 
-        match property {
-            Property::Plain(plain_property) => {
-                properties += plain_property.items.len();
-            }
-            Property::Hooked(_) => {
-                properties += 1;
+        let threshold = context.option(THRESHOLD).and_then(|o| o.as_integer()).unwrap_or(THRESHOLD_DEFAULT) as usize;
+        let mut properties = 0;
+        for member in members {
+            let ClassLikeMember::Property(property) = member else {
+                continue;
+            };
+
+            match property {
+                Property::Plain(plain_property) => {
+                    properties += plain_property.items.len();
+                }
+                Property::Hooked(_) => {
+                    properties += 1;
+                }
             }
         }
-    }
 
-    if properties > threshold {
-        let issue = Issue::new(context.level(), format!("{} has too many properties.", kind))
-            .with_annotation(Annotation::primary(node.span()).with_message(format!(
-                "{} has {} properties, which exceeds the threshold of {}.",
-                kind, properties, threshold
-            )))
-            .with_note("Having a large number of properties can make classes harder to understand and maintain.")
-            .with_help(
-                "Try reducing the number of properties, or consider grouping related properties into a single object.",
+        if properties > threshold {
+            context.report(
+                Issue::new(context.level(), format!("{} has too many properties.", kind))
+                    .with_annotation(Annotation::primary(node.span()).with_message(format!(
+                        "{} has {} properties, which exceeds the threshold of {}.",
+                        kind, properties, threshold
+                    )))
+                    .with_note("Having a large number of properties can make classes harder to understand and maintain.")
+                    .with_help(
+                        "Try reducing the number of properties, or consider grouping related properties into a single object.",
+                    )
             );
 
-        context.report(issue);
+            // If this structure has too many props, we don't need to check the nested structures.
+            LintDirective::Prune
+        } else {
+            // Continue checking nested structures, if any.
+            LintDirective::Continue
+        }
     }
 }

--- a/crates/linter/src/plugin/maintainability/rules/utils.rs
+++ b/crates/linter/src/plugin/maintainability/rules/utils.rs
@@ -29,7 +29,7 @@ pub fn is_method_setter_or_getter(method: &Method, context: &LintContext<'_>) ->
             statements_len == 1
         }
         Statement::Expression(expression_statement) if method.parameter_list.parameters.len() == 1 => {
-            let Expression::AssignmentOperation(assignment) = expression_statement.expression.as_ref() else {
+            let Expression::Assignment(assignment) = expression_statement.expression.as_ref() else {
                 return false;
             };
 

--- a/crates/linter/src/plugin/naming/rules/constant.rs
+++ b/crates/linter/src/plugin/naming/rules/constant.rs
@@ -1,13 +1,13 @@
 use indoc::indoc;
 
-use mago_ast::ast::*;
+use mago_ast::*;
 use mago_reporting::*;
 use mago_span::*;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
 use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
 use crate::rule::Rule;
 
 #[derive(Clone, Copy, Debug)]
@@ -49,51 +49,65 @@ impl Rule for ConstantRule {
                 "#},
             ))
     }
-}
 
-impl<'a> Walker<LintContext<'a>> for ConstantRule {
-    fn walk_in_constant<'ast>(&self, constant: &'ast Constant, context: &mut LintContext<'a>) {
-        for item in constant.items.iter() {
-            let name = context.lookup(&item.name.value);
-            if !mago_casing::is_constant_case(name) {
-                context.report(
-                    Issue::new(context.level(), format!("Constant name `{}` should be in constant case.", name))
-                        .with_annotation(
-                            Annotation::primary(item.name.span())
-                                .with_message(format!("Constant item `{}` is declared here.", name)),
-                        )
-                        .with_note(format!("The constant name `{}` does not follow constant naming convention.", name))
-                        .with_help(format!(
-                            "Consider renaming it to `{}` to adhere to the naming convention.",
-                            mago_casing::to_constant_case(name)
-                        )),
-                );
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        match node {
+            Node::Constant(constant) => {
+                for item in constant.items.iter() {
+                    let name = context.lookup(&item.name.value);
+                    if !mago_casing::is_constant_case(name) {
+                        context.report(
+                            Issue::new(
+                                context.level(),
+                                format!("Constant name `{}` should be in constant case.", name),
+                            )
+                            .with_annotation(
+                                Annotation::primary(item.name.span())
+                                    .with_message(format!("Constant item `{}` is declared here.", name)),
+                            )
+                            .with_note(format!(
+                                "The constant name `{}` does not follow constant naming convention.",
+                                name
+                            ))
+                            .with_help(format!(
+                                "Consider renaming it to `{}` to adhere to the naming convention.",
+                                mago_casing::to_constant_case(name)
+                            )),
+                        );
+                    }
+                }
+
+                LintDirective::Prune
             }
-        }
-    }
+            Node::ClassLikeConstant(class_like_constant) => {
+                for item in class_like_constant.items.iter() {
+                    let name = context.lookup(&item.name.value);
 
-    fn walk_in_class_like_constant<'ast>(
-        &self,
-        class_like_constant: &'ast ClassLikeConstant,
-        context: &mut LintContext<'a>,
-    ) {
-        for item in class_like_constant.items.iter() {
-            let name = context.lookup(&item.name.value);
+                    if !mago_casing::is_constant_case(name) {
+                        context.report(
+                            Issue::new(
+                                context.level(),
+                                format!("Constant name `{}` should be in constant case.", name),
+                            )
+                            .with_annotation(
+                                Annotation::primary(item.name.span())
+                                    .with_message(format!("Constant item `{}` is declared here.", name)),
+                            )
+                            .with_note(format!(
+                                "The constant name `{}` does not follow constant naming convention.",
+                                name
+                            ))
+                            .with_help(format!(
+                                "Consider renaming it to `{}` to adhere to the naming convention.",
+                                mago_casing::to_constant_case(name)
+                            )),
+                        );
+                    }
+                }
 
-            if !mago_casing::is_constant_case(name) {
-                context.report(
-                    Issue::new(context.level(), format!("Constant name `{}` should be in constant case.", name))
-                        .with_annotation(
-                            Annotation::primary(item.name.span())
-                                .with_message(format!("Constant item `{}` is declared here.", name)),
-                        )
-                        .with_note(format!("The constant name `{}` does not follow constant naming convention.", name))
-                        .with_help(format!(
-                            "Consider renaming it to `{}` to adhere to the naming convention.",
-                            mago_casing::to_constant_case(name)
-                        )),
-                );
+                LintDirective::Prune
             }
+            _ => LintDirective::default(),
         }
     }
 }

--- a/crates/linter/src/plugin/naming/rules/interface.rs
+++ b/crates/linter/src/plugin/naming/rules/interface.rs
@@ -1,15 +1,15 @@
 use indoc::indoc;
 use toml::Value;
 
-use mago_ast::ast::*;
+use mago_ast::*;
 use mago_reporting::*;
 use mago_span::*;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
 use crate::definition::RuleOptionDefinition;
 use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
 use crate::rule::Rule;
 
 const PSR: &str = "psr";
@@ -73,12 +73,11 @@ impl Rule for InterfaceRule {
                 .with_option(PSR, Value::Boolean(true)),
             )
     }
-}
 
-impl<'a> Walker<LintContext<'a>> for InterfaceRule {
-    fn walk_in_interface<'ast>(&self, interface: &'ast Interface, context: &mut LintContext<'a>) {
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let Node::Interface(interface) = node else { return LintDirective::default() };
+
         let mut issues = vec![];
-
         let name = context.lookup(&interface.name.value);
         let fqcn = context.lookup_name(&interface.name);
 
@@ -119,5 +118,7 @@ impl<'a> Walker<LintContext<'a>> for InterfaceRule {
         for issue in issues {
             context.report(issue);
         }
+
+        LintDirective::Prune
     }
 }

--- a/crates/linter/src/plugin/naming/rules/trait.rs
+++ b/crates/linter/src/plugin/naming/rules/trait.rs
@@ -1,15 +1,15 @@
 use indoc::indoc;
 use toml::Value;
 
-use mago_ast::ast::*;
+use mago_ast::*;
 use mago_reporting::*;
 use mago_span::*;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
 use crate::definition::RuleOptionDefinition;
 use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
 use crate::rule::Rule;
 
 const PSR: &str = "psr";
@@ -72,10 +72,10 @@ impl Rule for TraitRule {
                 .with_option(PSR, Value::Boolean(true)),
             )
     }
-}
 
-impl<'a> Walker<LintContext<'a>> for TraitRule {
-    fn walk_in_trait<'ast>(&self, r#trait: &'ast Trait, context: &mut LintContext<'a>) {
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let Node::Trait(r#trait) = node else { return LintDirective::default() };
+
         let mut issues = vec![];
 
         let name = context.lookup(&r#trait.name.value);
@@ -115,5 +115,7 @@ impl<'a> Walker<LintContext<'a>> for TraitRule {
         for issue in issues {
             context.report(issue);
         }
+
+        LintDirective::default()
     }
 }

--- a/crates/linter/src/plugin/phpunit/rules/consistency/assertions_style.rs
+++ b/crates/linter/src/plugin/phpunit/rules/consistency/assertions_style.rs
@@ -6,12 +6,12 @@ use mago_ast_utils::reference::MethodReference;
 use mago_fixer::SafetyClassification;
 use mago_reporting::*;
 use mago_span::HasSpan;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
 use crate::definition::RuleOptionDefinition;
 use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
 use crate::plugin::phpunit::rules::utils::find_testing_or_assertion_references_in_method;
 use crate::rule::Rule;
 
@@ -95,13 +95,13 @@ impl Rule for AssertionsStyleRule {
                 "#},
             ))
     }
-}
 
-impl<'a> Walker<LintContext<'a>> for AssertionsStyleRule {
-    fn walk_in_method(&self, method: &Method, context: &mut LintContext<'a>) {
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let Node::Method(method) = node else { return LintDirective::default() };
+
         let name = context.lookup(&method.name.value);
         if !name.starts_with("test") || name.chars().nth(4).is_none_or(|c| c != '_' && !c.is_uppercase()) {
-            return;
+            return LintDirective::Prune;
         }
 
         let desired_style = context
@@ -168,5 +168,7 @@ impl<'a> Walker<LintContext<'a>> for AssertionsStyleRule {
                 );
             });
         }
+
+        LintDirective::Prune
     }
 }

--- a/crates/linter/src/plugin/redundancy/rules/redundant_block.rs
+++ b/crates/linter/src/plugin/redundancy/rules/redundant_block.rs
@@ -4,11 +4,11 @@ use mago_ast::*;
 use mago_fixer::SafetyClassification;
 use mago_reporting::*;
 use mago_span::HasSpan;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
 use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
 use crate::rule::Rule;
 
 #[derive(Clone, Debug)]
@@ -31,153 +31,48 @@ impl Rule for RedundantBlockRule {
                 "#},
             ))
     }
-}
 
-impl RedundantBlockRule {
-    fn report(&self, block: &Block, context: &mut LintContext<'_>) {
-        let issue = Issue::new(context.level(), "Redundant block around statements")
-            .with_annotations([
-                Annotation::primary(block.span()).with_message("Statements do not need to be wrapped within a block.")
-            ])
-            .with_help("Remove the block to simplify the code.");
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let statements = match node {
+            Node::Program(program) => program.statements.as_slice(),
+            Node::Block(block) => block.statements.as_slice(),
+            Node::Namespace(namespace) => namespace.statements().as_slice(),
+            Node::DeclareColonDelimitedBody(declare_colon_delimited_body) => {
+                declare_colon_delimited_body.statements.as_slice()
+            }
+            Node::SwitchExpressionCase(switch_expression_case) => switch_expression_case.statements.as_slice(),
+            Node::SwitchDefaultCase(switch_default_case) => switch_default_case.statements.as_slice(),
+            Node::ForeachColonDelimitedBody(foreach_colon_delimited_body) => {
+                foreach_colon_delimited_body.statements.as_slice()
+            }
+            Node::WhileColonDelimitedBody(while_colon_delimited_body) => {
+                while_colon_delimited_body.statements.as_slice()
+            }
+            Node::ForColonDelimitedBody(for_colon_delimited_body) => for_colon_delimited_body.statements.as_slice(),
+            Node::IfColonDelimitedBody(if_colon_delimited_body) => if_colon_delimited_body.statements.as_slice(),
+            Node::IfColonDelimitedBodyElseIfClause(if_colon_delimited_body_else_if_clause) => {
+                if_colon_delimited_body_else_if_clause.statements.as_slice()
+            }
+            Node::IfColonDelimitedBodyElseClause(if_colon_delimited_body_else_clause) => {
+                if_colon_delimited_body_else_clause.statements.as_slice()
+            }
+            _ => return LintDirective::default(),
+        };
 
-        context.report_with_fix(issue, |plan| {
-            plan.delete(block.left_brace.to_range(), SafetyClassification::Safe);
-            plan.delete(block.right_brace.to_range(), SafetyClassification::Safe);
-        });
-    }
-}
+        for statement in statements {
+            if let Statement::Block(block) = statement {
+                let issue = Issue::new(context.level(), "Redundant block around statements")
+                    .with_annotations([Annotation::primary(block.span())
+                        .with_message("Statements do not need to be wrapped within a block.")])
+                    .with_help("Remove the block to simplify the code.");
 
-impl<'a> Walker<LintContext<'a>> for RedundantBlockRule {
-    fn walk_in_program<'ast>(&self, program: &'ast Program, context: &mut LintContext<'a>) {
-        for statement in program.statements.iter() {
-            if let Statement::Block(inner) = statement {
-                self.report(inner, context);
+                context.report_with_fix(issue, |plan| {
+                    plan.delete(block.left_brace.to_range(), SafetyClassification::Safe);
+                    plan.delete(block.right_brace.to_range(), SafetyClassification::Safe);
+                });
             }
         }
-    }
 
-    fn walk_in_block<'ast>(&self, block: &'ast Block, context: &mut LintContext<'a>) {
-        for statement in block.statements.iter() {
-            if let Statement::Block(inner) = statement {
-                self.report(inner, context);
-            }
-        }
-    }
-
-    fn walk_in_namespace<'ast>(&self, namespace: &'ast Namespace, context: &mut LintContext<'a>) {
-        for statement in namespace.statements().iter() {
-            if let Statement::Block(inner) = statement {
-                self.report(inner, context);
-            }
-        }
-    }
-
-    fn walk_in_declare_colon_delimited_body<'ast>(
-        &self,
-        declare_colon_delimited_body: &'ast DeclareColonDelimitedBody,
-        context: &mut LintContext<'a>,
-    ) {
-        for statement in declare_colon_delimited_body.statements.iter() {
-            if let Statement::Block(inner) = statement {
-                self.report(inner, context);
-            }
-        }
-    }
-
-    fn walk_in_switch_expression_case<'ast>(
-        &self,
-        switch_expression_case: &'ast SwitchExpressionCase,
-        context: &mut LintContext<'a>,
-    ) {
-        for statement in switch_expression_case.statements.iter() {
-            if let Statement::Block(inner) = statement {
-                self.report(inner, context);
-            }
-        }
-    }
-
-    fn walk_in_switch_default_case<'ast>(
-        &self,
-        switch_default_case: &'ast SwitchDefaultCase,
-        context: &mut LintContext<'a>,
-    ) {
-        for statement in switch_default_case.statements.iter() {
-            if let Statement::Block(inner) = statement {
-                self.report(inner, context);
-            }
-        }
-    }
-
-    fn walk_in_foreach_colon_delimited_body<'ast>(
-        &self,
-        foreach_colon_delimited_body: &'ast ForeachColonDelimitedBody,
-        context: &mut LintContext<'a>,
-    ) {
-        for statement in foreach_colon_delimited_body.statements.iter() {
-            if let Statement::Block(inner) = statement {
-                self.report(inner, context);
-            }
-        }
-    }
-
-    fn walk_in_while_colon_delimited_body<'ast>(
-        &self,
-        while_colon_delimited_body: &'ast WhileColonDelimitedBody,
-        context: &mut LintContext<'a>,
-    ) {
-        for statement in while_colon_delimited_body.statements.iter() {
-            if let Statement::Block(inner) = statement {
-                self.report(inner, context);
-            }
-        }
-    }
-
-    fn walk_for_colon_delimited_body<'ast>(
-        &self,
-        for_colon_delimited_body: &'ast ForColonDelimitedBody,
-        context: &mut LintContext<'a>,
-    ) {
-        for statement in for_colon_delimited_body.statements.iter() {
-            if let Statement::Block(inner) = statement {
-                self.report(inner, context);
-            }
-        }
-    }
-
-    fn walk_if_colon_delimited_body<'ast>(
-        &self,
-        if_colon_delimited_body: &'ast IfColonDelimitedBody,
-        context: &mut LintContext<'a>,
-    ) {
-        for statement in if_colon_delimited_body.statements.iter() {
-            if let Statement::Block(inner) = statement {
-                self.report(inner, context);
-            }
-        }
-    }
-
-    fn walk_if_colon_delimited_body_else_if_clause<'ast>(
-        &self,
-        if_colon_delimited_body_else_if_clause: &'ast IfColonDelimitedBodyElseIfClause,
-        context: &mut LintContext<'a>,
-    ) {
-        for statement in if_colon_delimited_body_else_if_clause.statements.iter() {
-            if let Statement::Block(inner) = statement {
-                self.report(inner, context);
-            }
-        }
-    }
-
-    fn walk_if_colon_delimited_body_else_clause<'ast>(
-        &self,
-        if_colon_delimited_body_else_clause: &'ast IfColonDelimitedBodyElseClause,
-        context: &mut LintContext<'a>,
-    ) {
-        for statement in if_colon_delimited_body_else_clause.statements.iter() {
-            if let Statement::Block(inner) = statement {
-                self.report(inner, context);
-            }
-        }
+        LintDirective::default()
     }
 }

--- a/crates/linter/src/plugin/redundancy/rules/redundant_final_method_modifier.rs
+++ b/crates/linter/src/plugin/redundancy/rules/redundant_final_method_modifier.rs
@@ -4,11 +4,11 @@ use mago_ast::*;
 use mago_fixer::SafetyClassification;
 use mago_reporting::*;
 use mago_span::HasSpan;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
 use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
 use crate::rule::Rule;
 
 #[derive(Clone, Debug)]
@@ -52,51 +52,56 @@ impl Rule for RedundantFinalMethodModifierRule {
                 "#},
             ))
     }
-}
 
-impl RedundantFinalMethodModifierRule {
-    fn report(&self, method: &Method, context: &mut LintContext<'_>, in_enum: bool) {
-        let Some(final_modifier) = method.modifiers.get_final() else {
-            return;
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let (members, is_enum) = match node {
+            Node::Class(class) => {
+                if !class.modifiers.contains_final() {
+                    return LintDirective::default();
+                }
+
+                (&class.members, false)
+            }
+            Node::Enum(r#enum) => (&r#enum.members, true),
+            _ => return LintDirective::default(),
         };
 
-        let method_name = context.interner.lookup(&method.name.value);
-
-        let message = if in_enum {
-            format!("The `final` modifier on enum method `{}` is redundant as enums cannot be extended.", method_name,)
-        } else {
-            format!("The `final` modifier on method `{}` is redundant as the class is already final.", method_name,)
-        };
-
-        let issue = Issue::new(context.level(), message)
-            .with_annotations([
-                Annotation::primary(final_modifier.span()).with_message("This `final` modifier is redundant.")
-            ])
-            .with_help("Remove the redundant `final` modifier.");
-
-        context
-            .report_with_fix(issue, |plan| plan.delete(final_modifier.span().to_range(), SafetyClassification::Safe));
-    }
-}
-
-impl<'a> Walker<LintContext<'a>> for RedundantFinalMethodModifierRule {
-    fn walk_in_class<'ast>(&self, class: &'ast Class, context: &mut LintContext<'a>) {
-        if !class.modifiers.contains_final() {
-            return;
+        if !members.contains_methods() {
+            return LintDirective::Prune;
         }
 
-        for member in class.members.iter() {
+        for member in members.iter() {
             if let ClassLikeMember::Method(method) = member {
-                self.report(method, context, false);
+                let Some(final_modifier) = method.modifiers.get_final() else {
+                    continue;
+                };
+
+                let method_name = context.interner.lookup(&method.name.value);
+
+                let message = if is_enum {
+                    format!(
+                        "The `final` modifier on enum method `{}` is redundant as enums cannot be extended.",
+                        method_name,
+                    )
+                } else {
+                    format!(
+                        "The `final` modifier on method `{}` is redundant as the class is already final.",
+                        method_name,
+                    )
+                };
+
+                let issue = Issue::new(context.level(), message)
+                    .with_annotations([
+                        Annotation::primary(final_modifier.span()).with_message("This `final` modifier is redundant.")
+                    ])
+                    .with_help("Remove the redundant `final` modifier.");
+
+                context.report_with_fix(issue, |plan| {
+                    plan.delete(final_modifier.span().to_range(), SafetyClassification::Safe)
+                });
             }
         }
-    }
 
-    fn walk_in_enum<'ast>(&self, r#enum: &'ast Enum, context: &mut LintContext<'a>) {
-        for member in r#enum.members.iter() {
-            if let ClassLikeMember::Method(method) = member {
-                self.report(method, context, true);
-            }
-        }
+        LintDirective::default()
     }
 }

--- a/crates/linter/src/plugin/redundancy/rules/redundant_label.rs
+++ b/crates/linter/src/plugin/redundancy/rules/redundant_label.rs
@@ -4,11 +4,11 @@ use mago_ast::*;
 use mago_fixer::SafetyClassification;
 use mago_reporting::*;
 use mago_span::HasSpan;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
 use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
 use crate::rule::Rule;
 
 #[derive(Clone, Debug)]
@@ -30,11 +30,9 @@ impl Rule for RedundantLabelRule {
                 "#},
             ))
     }
-}
 
-impl<'a> Walker<LintContext<'a>> for RedundantLabelRule {
-    fn walk_program<'ast>(&self, program: &'ast Program, context: &mut LintContext<'a>) {
-        let node = Node::Program(program);
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let Node::Program(_) = node else { return LintDirective::Abort };
 
         let labels =
             node.filter_map(
@@ -63,5 +61,7 @@ impl<'a> Walker<LintContext<'a>> for RedundantLabelRule {
 
             context.report_with_fix(issue, |plan| plan.delete(label_span.to_range(), SafetyClassification::Safe));
         }
+
+        LintDirective::Abort
     }
 }

--- a/crates/linter/src/plugin/redundancy/rules/redundant_parentheses.rs
+++ b/crates/linter/src/plugin/redundancy/rules/redundant_parentheses.rs
@@ -4,11 +4,11 @@ use mago_ast::*;
 use mago_fixer::SafetyClassification;
 use mago_reporting::*;
 use mago_span::HasSpan;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
 use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
 use crate::rule::Rule;
 
 #[derive(Clone, Debug)]
@@ -29,10 +29,113 @@ impl Rule for RedundantParenthesesRule {
                 "#},
             ))
     }
-}
 
-impl RedundantParenthesesRule {
-    fn report(&self, parenthesized: &Parenthesized, context: &mut LintContext<'_>) {
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let parenthesized = match node {
+            Node::Parenthesized(parenthesized) => {
+                if let Expression::Parenthesized(inner) = parenthesized.expression.as_ref() {
+                    inner
+                } else {
+                    return LintDirective::default();
+                }
+            }
+            Node::ExpressionStatement(expression_statement) => match expression_statement.expression.as_ref() {
+                Expression::Parenthesized(parenthesized) => parenthesized,
+                Expression::Assignment(assignment) => {
+                    if let Expression::Parenthesized(rhs) = assignment.rhs.as_ref() {
+                        if rhs.expression.is_binary() {
+                            return LintDirective::default(); // Allow parentheses around binary expressions on the right-hand side of an assignment.
+                        }
+
+                        rhs
+                    } else {
+                        return LintDirective::default();
+                    }
+                }
+                _ => return LintDirective::default(),
+            },
+            Node::PositionalArgument(positional_argument) => {
+                if positional_argument.ellipsis.is_some() {
+                    return LintDirective::default();
+                }
+
+                if let Expression::Parenthesized(value) = &positional_argument.value {
+                    value
+                } else {
+                    return LintDirective::default();
+                }
+            }
+            Node::NamedArgument(named_argument) => {
+                if named_argument.ellipsis.is_some() {
+                    return LintDirective::default();
+                }
+
+                if let Expression::Parenthesized(value) = &named_argument.value {
+                    value
+                } else {
+                    return LintDirective::default();
+                }
+            }
+            Node::If(r#if) => {
+                if let Expression::Parenthesized(condition) = r#if.condition.as_ref() {
+                    condition
+                } else {
+                    return LintDirective::default();
+                }
+            }
+            Node::IfStatementBodyElseIfClause(if_statement_body_else_if_clause) => {
+                if let Expression::Parenthesized(condition) = if_statement_body_else_if_clause.condition.as_ref() {
+                    condition
+                } else {
+                    return LintDirective::default();
+                }
+            }
+            Node::IfColonDelimitedBodyElseIfClause(if_colon_delimited_body_else_if_clause) => {
+                if let Expression::Parenthesized(condition) = if_colon_delimited_body_else_if_clause.condition.as_ref()
+                {
+                    condition
+                } else {
+                    return LintDirective::default();
+                }
+            }
+            Node::FunctionLikeParameterDefaultValue(function_like_parameter_default_value) => {
+                if let Expression::Parenthesized(value) = &function_like_parameter_default_value.value {
+                    value
+                } else {
+                    return LintDirective::default();
+                }
+            }
+            Node::EnumCaseBackedItem(enum_case_backed_item) => {
+                if let Expression::Parenthesized(value) = &enum_case_backed_item.value {
+                    value
+                } else {
+                    return LintDirective::default();
+                }
+            }
+            Node::PropertyConcreteItem(property_concrete_item) => {
+                if let Expression::Parenthesized(value) = &property_concrete_item.value {
+                    value
+                } else {
+                    return LintDirective::default();
+                }
+            }
+            Node::ConstantItem(constant_item) => {
+                if let Expression::Parenthesized(value) = &constant_item.value {
+                    value
+                } else {
+                    return LintDirective::default();
+                }
+            }
+            Node::ClassLikeConstantItem(class_like_constant_item) => {
+                if let Expression::Parenthesized(value) = &class_like_constant_item.value {
+                    value
+                } else {
+                    return LintDirective::default();
+                }
+            }
+            _ => return LintDirective::default(),
+        };
+
         let issue = Issue::new(context.level(), "Redundant parentheses around expression.")
             .with_annotation(
                 Annotation::primary(parenthesized.expression.span())
@@ -44,123 +147,7 @@ impl RedundantParenthesesRule {
             plan.delete(parenthesized.left_parenthesis.to_range(), SafetyClassification::Safe);
             plan.delete(parenthesized.right_parenthesis.to_range(), SafetyClassification::Safe);
         });
-    }
-}
 
-impl<'a> Walker<LintContext<'a>> for RedundantParenthesesRule {
-    fn walk_in_parenthesized<'ast>(&self, parenthesized: &'ast Parenthesized, context: &mut LintContext<'a>) {
-        if let Expression::Parenthesized(inner) = parenthesized.expression.as_ref() {
-            self.report(inner, context);
-        }
-    }
-
-    fn walk_in_statement_expression(&self, statement_expression: &ExpressionStatement, context: &mut LintContext<'a>) {
-        if let Expression::Parenthesized(parenthesized) = statement_expression.expression.as_ref() {
-            self.report(parenthesized, context);
-
-            return;
-        }
-
-        if let Expression::AssignmentOperation(assignment) = statement_expression.expression.as_ref() {
-            if let Expression::Parenthesized(rhs) = assignment.rhs.as_ref() {
-                if rhs.expression.is_binary() {
-                    return; // Allow parentheses around binary expressions on the right-hand side of an assignment.
-                }
-
-                self.report(rhs, context);
-            }
-        }
-    }
-
-    fn walk_in_positional_argument<'ast>(
-        &self,
-        positional_argument: &'ast PositionalArgument,
-        context: &mut LintContext<'a>,
-    ) {
-        if positional_argument.ellipsis.is_some() {
-            return;
-        }
-
-        if let Expression::Parenthesized(value) = &positional_argument.value {
-            self.report(value, context);
-        }
-    }
-
-    fn walk_in_named_argument<'ast>(&self, named_argument: &'ast NamedArgument, context: &mut LintContext<'a>) {
-        if named_argument.ellipsis.is_some() {
-            return;
-        }
-
-        if let Expression::Parenthesized(value) = &named_argument.value {
-            self.report(value, context);
-        }
-    }
-
-    fn walk_in_if<'ast>(&self, r#if: &'ast If, context: &mut LintContext<'a>) {
-        if let Expression::Parenthesized(condition) = r#if.condition.as_ref() {
-            self.report(condition, context);
-        }
-    }
-
-    fn walk_in_if_statement_body_else_if_clause<'ast>(
-        &self,
-        if_statement_body_else_if_clause: &'ast IfStatementBodyElseIfClause,
-        context: &mut LintContext<'a>,
-    ) {
-        if let Expression::Parenthesized(condition) = if_statement_body_else_if_clause.condition.as_ref() {
-            self.report(condition, context);
-        }
-    }
-
-    fn walk_in_if_colon_delimited_body_else_if_clause<'ast>(
-        &self,
-        if_colon_delimited_body_else_if_clause: &'ast IfColonDelimitedBodyElseIfClause,
-        context: &mut LintContext<'a>,
-    ) {
-        if let Expression::Parenthesized(condition) = if_colon_delimited_body_else_if_clause.condition.as_ref() {
-            self.report(condition, context);
-        }
-    }
-
-    fn walk_in_function_like_parameter_default_value(
-        &self,
-        function_like_parameter_default_value: &FunctionLikeParameterDefaultValue,
-        context: &mut LintContext<'a>,
-    ) {
-        if let Expression::Parenthesized(value) = &function_like_parameter_default_value.value {
-            self.report(value, context);
-        }
-    }
-
-    fn walk_in_enum_case_backed_item(&self, enum_case_backed_item: &EnumCaseBackedItem, context: &mut LintContext<'a>) {
-        if let Expression::Parenthesized(value) = &enum_case_backed_item.value {
-            self.report(value, context);
-        }
-    }
-
-    fn walk_in_property_concrete_item(
-        &self,
-        property_concrete_item: &PropertyConcreteItem,
-        context: &mut LintContext<'a>,
-    ) {
-        if let Expression::Parenthesized(value) = &property_concrete_item.value {
-            self.report(value, context);
-        }
-    }
-
-    fn walk_in_constant_item(&self, constant_item: &ConstantItem, context: &mut LintContext<'a>) {
-        if let Expression::Parenthesized(value) = &constant_item.value {
-            self.report(value, context);
-        }
-    }
-
-    fn walk_in_class_like_constant_item(
-        &self,
-        class_like_constant_item: &ClassLikeConstantItem,
-        context: &mut LintContext<'a>,
-    ) {
-        if let Expression::Parenthesized(value) = &class_like_constant_item.value {
-            self.report(value, context);
-        }
+        LintDirective::default()
     }
 }

--- a/crates/linter/src/plugin/safety/rules/no_eval.rs
+++ b/crates/linter/src/plugin/safety/rules/no_eval.rs
@@ -3,11 +3,11 @@ use indoc::indoc;
 use mago_ast::*;
 use mago_reporting::*;
 use mago_span::HasSpan;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
 use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
 use crate::rule::Rule;
 
 #[derive(Clone, Debug)]
@@ -30,19 +30,20 @@ impl Rule for NoEvalRule {
                 "#},
             ))
     }
-}
 
-impl<'a> Walker<LintContext<'a>> for NoEvalRule {
-    fn walk_in_eval_construct<'ast>(&self, eval_construct: &'ast EvalConstruct, context: &mut LintContext<'a>) {
-        let issue = Issue::new(context.level(), "Unsafe use of `eval` construct.")
-            .with_annotation(Annotation::primary(eval_construct.eval.span).with_message("this `eval` construct is unsafe."))
-            .with_annotation(Annotation::secondary(eval_construct.value.span()).with_message("the evaluated code is here."))
-            .with_note("The `eval` construct executes arbitrary code, which can be a major security risk if not used carefully.")
-            .with_note("It can potentially lead to remote code execution vulnerabilities if the evaluated code is not properly sanitized.")
-            .with_note("Consider using safer alternatives whenever possible.")
-            .with_help("Avoid using `eval` unless absolutely necessary, and ensure that any dynamically generated code is properly validated and sanitized before execution.")
-        ;
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let Node::EvalConstruct(eval_construct) = node else { return LintDirective::default() };
 
-        context.report(issue);
+        context.report(
+            Issue::new(context.level(), "Unsafe use of `eval` construct.")
+                .with_annotation(Annotation::primary(eval_construct.eval.span).with_message("this `eval` construct is unsafe."))
+                .with_annotation(Annotation::secondary(eval_construct.value.span()).with_message("the evaluated code is here."))
+                .with_note("The `eval` construct executes arbitrary code, which can be a major security risk if not used carefully.")
+                .with_note("It can potentially lead to remote code execution vulnerabilities if the evaluated code is not properly sanitized.")
+                .with_note("Consider using safer alternatives whenever possible.")
+                .with_help("Avoid using `eval` unless absolutely necessary, and ensure that any dynamically generated code is properly validated and sanitized before execution.")
+        );
+
+        LintDirective::Prune
     }
 }

--- a/crates/linter/src/plugin/safety/rules/no_global.rs
+++ b/crates/linter/src/plugin/safety/rules/no_global.rs
@@ -3,14 +3,12 @@ use indoc::indoc;
 use mago_ast::*;
 use mago_reporting::*;
 use mago_span::HasSpan;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
 use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
 use crate::rule::Rule;
-
-const GLOBALS_VARIABLE: &str = "$GLOBALS";
 
 #[derive(Clone, Debug)]
 pub struct NoGlobalRule;
@@ -50,37 +48,47 @@ impl Rule for NoGlobalRule {
                 "#},
             ))
     }
+
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        match node {
+            Node::Global(global) => {
+                let mut issue = Issue::new(context.level(), "Unsafe use of `global` keyword.")
+                    .with_annotation(Annotation::primary(global.global.span).with_message("This `global` keyword is used here."))
+                    .with_note("The `global` keyword introduces global state into your function, making it harder to reason about and test.")
+                    .with_note("It can also lead to unexpected behavior and make your code more prone to errors.")
+                    .with_note("Consider using dependency injection or other techniques to manage state and avoid relying on global variables.")
+                    .with_help("Refactor your code to avoid using the `global` keyword.");
+
+                for variable in global.variables.iter() {
+                    issue = issue.with_annotation(
+                        Annotation::secondary(variable.span()).with_message("This variable is declared as global."),
+                    );
+                }
+
+                context.report(issue);
+
+                LintDirective::Prune
+            }
+            Node::DirectVariable(direct_variable) => {
+                let name = context.interner.lookup(&direct_variable.name);
+                if !GLOBALS_VARIABLE.eq(name) {
+                    return LintDirective::default();
+                }
+
+                let issue = Issue::new(context.level(), "Unsafe use of `$GLOBAL` variable.")
+                    .with_annotation(Annotation::primary(direct_variable.span).with_message("The `$GLOBALS` variable is used here."))
+                    .with_note("Accessing the `$GLOBALS` array directly can lead to similar issues as using the `global` keyword.")
+                    .with_note("It can make your code harder to understand, test, and maintain due to the implicit global state.")
+                    .with_note("Consider using dependency injection or other techniques to manage state and avoid relying on global variables.")
+                    .with_help("Refactor your code to avoid using the `$GLOBALS` variable directly.");
+
+                context.report(issue);
+
+                LintDirective::Prune
+            }
+            _ => LintDirective::default(),
+        }
+    }
 }
 
-impl<'a> Walker<LintContext<'a>> for NoGlobalRule {
-    fn walk_in_global<'ast>(&self, global: &'ast Global, context: &mut LintContext<'a>) {
-        let mut issue = Issue::new(context.level(), "Unsafe use of `global` keyword.")
-            .with_annotation(Annotation::primary(global.global.span).with_message("This `global` keyword is used here."))
-            .with_note("The `global` keyword introduces global state into your function, making it harder to reason about and test.")
-            .with_note("It can also lead to unexpected behavior and make your code more prone to errors.")
-            .with_note("Consider using dependency injection or other techniques to manage state and avoid relying on global variables.")
-            .with_help("Refactor your code to avoid using the `global` keyword.");
-
-        for variable in global.variables.iter() {
-            issue = issue.with_annotation(Annotation::secondary(variable.span()));
-        }
-
-        context.report(issue);
-    }
-
-    fn walk_in_direct_variable<'ast>(&self, direct_variable: &'ast DirectVariable, context: &mut LintContext<'a>) {
-        let name = context.interner.lookup(&direct_variable.name);
-        if !GLOBALS_VARIABLE.eq(name) {
-            return;
-        }
-
-        let issue = Issue::new(context.level(), "Unsafe use of `$GLOBAL` variable.")
-            .with_annotation(Annotation::primary(direct_variable.span).with_message("The `$GLOBALS` variable is used here."))
-            .with_note("Accessing the `$GLOBALS` array directly can lead to similar issues as using the `global` keyword.")
-            .with_note("It can make your code harder to understand, test, and maintain due to the implicit global state.")
-            .with_note("Consider using dependency injection or other techniques to manage state and avoid relying on global variables.")
-            .with_help("Refactor your code to avoid using the `$GLOBALS` variable directly.");
-
-        context.report(issue);
-    }
-}
+const GLOBALS_VARIABLE: &str = "$GLOBALS";

--- a/crates/linter/src/plugin/safety/rules/no_request_variable.rs
+++ b/crates/linter/src/plugin/safety/rules/no_request_variable.rs
@@ -2,14 +2,12 @@ use indoc::indoc;
 
 use mago_ast::*;
 use mago_reporting::*;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
 use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
 use crate::rule::Rule;
-
-const REQUEST_VARIABLE: &str = "$_REQUEST";
 
 #[derive(Clone, Debug)]
 pub struct NoRequestVariableRule;
@@ -31,21 +29,25 @@ impl Rule for NoRequestVariableRule {
                 "#},
             ))
     }
-}
 
-impl<'a> Walker<LintContext<'a>> for NoRequestVariableRule {
-    fn walk_in_direct_variable<'ast>(&self, direct_variable: &'ast DirectVariable, context: &mut LintContext<'a>) {
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let Node::DirectVariable(direct_variable) = node else { return LintDirective::default() };
+
         let name = context.interner.lookup(&direct_variable.name);
         if !REQUEST_VARIABLE.eq(name) {
-            return;
+            return LintDirective::Prune;
         }
 
-        let issue = Issue::new(context.level(), "Unsafe use of `$_REQUEST` variable.")
-            .with_annotation(
-                Annotation::primary(direct_variable.span).with_message("The `$_REQUEST` variable is used here."),
-            )
-            .with_help("use `$_GET`, `$_POST`, or `$_COOKIE` instead for better clarity.");
+        context.report(
+            Issue::new(context.level(), "Unsafe use of `$_REQUEST` variable.")
+                .with_annotation(
+                    Annotation::primary(direct_variable.span).with_message("The `$_REQUEST` variable is used here."),
+                )
+                .with_help("use `$_GET`, `$_POST`, or `$_COOKIE` instead for better clarity."),
+        );
 
-        context.report(issue);
+        LintDirective::Prune
     }
 }
+
+const REQUEST_VARIABLE: &str = "$_REQUEST";

--- a/crates/linter/src/plugin/safety/rules/no_unsafe_finally.rs
+++ b/crates/linter/src/plugin/safety/rules/no_unsafe_finally.rs
@@ -5,11 +5,11 @@ use mago_ast_utils::control_flow::find_control_flows_in_block;
 use mago_ast_utils::control_flow::ControlFlow;
 use mago_reporting::*;
 use mago_span::HasSpan;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
 use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
 use crate::rule::Rule;
 
 #[derive(Clone, Debug)]
@@ -40,12 +40,12 @@ impl Rule for NoUnsafeFinallyRule {
                 "#},
             ))
     }
-}
 
-impl<'a> Walker<LintContext<'a>> for NoUnsafeFinallyRule {
-    fn walk_in_try(&self, r#try: &Try, context: &mut LintContext<'a>) {
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let Node::Try(r#try) = node else { return LintDirective::default() };
+
         let Some(finally) = r#try.finally_clause.as_ref() else {
-            return;
+            return LintDirective::default();
         };
 
         for control_flow in find_control_flows_in_block(&finally.block) {
@@ -72,5 +72,7 @@ impl<'a> Walker<LintContext<'a>> for NoUnsafeFinallyRule {
 
             context.report(issue);
         }
+
+        LintDirective::default()
     }
 }

--- a/crates/linter/src/plugin/security/rules/no_literal_password.rs
+++ b/crates/linter/src/plugin/security/rules/no_literal_password.rs
@@ -5,11 +5,11 @@ use mago_reporting::Annotation;
 use mago_reporting::Issue;
 use mago_reporting::Level;
 use mago_span::HasSpan;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
 use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
 use crate::plugin::security::rules::utils::get_password;
 use crate::plugin::security::rules::utils::is_password;
 use crate::plugin::security::rules::utils::is_password_literal;
@@ -87,99 +87,84 @@ impl Rule for NoLiteralPasswordRule {
                 "#},
             ))
     }
-}
 
-impl Walker<LintContext<'_>> for NoLiteralPasswordRule {
-    fn walk_in_assignment(&self, assignment: &Assignment, context: &mut LintContext<'_>) {
-        let Some(password) = get_password(context, &assignment.lhs) else {
-            return;
-        };
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        match node {
+            Node::Assignment(assignment) => {
+                let Some(password) = get_password(context, &assignment.lhs) else {
+                    return LintDirective::default();
+                };
 
-        check(password, &assignment.rhs, context);
-    }
+                check(password, &assignment.rhs, context)
+            }
+            Node::ArrayElement(array_element) => {
+                let ArrayElement::KeyValue(kv) = array_element else {
+                    return LintDirective::default();
+                };
 
-    fn walk_in_array_element(&self, array_element: &ArrayElement, context: &mut LintContext<'_>) {
-        let ArrayElement::KeyValue(kv) = array_element else {
-            return;
-        };
+                let is_key_a_password = matches!(
+                    kv.key.as_ref(),
+                    Expression::Literal(Literal::String(literal_string)) if is_password_literal(context, literal_string),
+                );
 
-        let is_key_a_password = matches!(
-            kv.key.as_ref(),
-            Expression::Literal(Literal::String(literal_string)) if is_password_literal(context, literal_string),
-        );
+                if !is_key_a_password {
+                    return LintDirective::default();
+                }
 
-        if !is_key_a_password {
-            return;
+                check(kv.key.as_ref(), kv.value.as_ref(), context)
+            }
+            Node::ConstantItem(constant_item) => {
+                let constant_name = context.interner.lookup(&constant_item.name.value);
+                if !is_password(constant_name) {
+                    return LintDirective::default();
+                }
+
+                check(&constant_item.name, &constant_item.value, context)
+            }
+            Node::ClassLikeConstantItem(class_like_constant_item) => {
+                let constant_name = context.interner.lookup(&class_like_constant_item.name.value);
+                if !is_password(constant_name) {
+                    return LintDirective::default();
+                }
+
+                check(&class_like_constant_item.name, &class_like_constant_item.value, context)
+            }
+            Node::PropertyConcreteItem(property_concrete_item) => {
+                let variable_name = context.interner.lookup(&property_concrete_item.variable.name);
+                if !is_password(&variable_name[1..]) {
+                    return LintDirective::default();
+                }
+
+                check(&property_concrete_item.variable, &property_concrete_item.value, context)
+            }
+            Node::FunctionLikeParameter(function_like_parameter) => {
+                let Some(default_value) = function_like_parameter.default_value.as_ref() else {
+                    return LintDirective::default();
+                };
+
+                let parameter_name = context.interner.lookup(&function_like_parameter.variable.name);
+                if !is_password(&parameter_name[1..]) {
+                    return LintDirective::default();
+                }
+
+                check(&function_like_parameter.variable, &default_value.value, context)
+            }
+            Node::NamedArgument(named_argument) => {
+                let argument_name = context.interner.lookup(&named_argument.name.value);
+                if !is_password(argument_name) {
+                    return LintDirective::default();
+                }
+
+                check(&named_argument.name, &named_argument.value, context)
+            }
+            _ => LintDirective::default(),
         }
-
-        check(kv.key.as_ref(), kv.value.as_ref(), context);
-    }
-
-    fn walk_in_constant_item(&self, constant_item: &ConstantItem, context: &mut LintContext<'_>) {
-        let constant_name = context.interner.lookup(&constant_item.name.value);
-        if !is_password(constant_name) {
-            return;
-        }
-
-        check(&constant_item.name, &constant_item.value, context);
-    }
-
-    fn walk_in_class_like_constant_item(
-        &self,
-        class_like_constant_item: &ClassLikeConstantItem,
-        context: &mut LintContext<'_>,
-    ) {
-        let constant_name = context.interner.lookup(&class_like_constant_item.name.value);
-        if !is_password(constant_name) {
-            return;
-        }
-
-        check(&class_like_constant_item.name, &class_like_constant_item.value, context);
-    }
-
-    fn walk_in_property_concrete_item(
-        &self,
-        property_concrete_item: &PropertyConcreteItem,
-        context: &mut LintContext<'_>,
-    ) {
-        let variable_name = context.interner.lookup(&property_concrete_item.variable.name);
-        if !is_password(&variable_name[1..]) {
-            return;
-        }
-
-        check(&property_concrete_item.variable, &property_concrete_item.value, context);
-    }
-
-    // check for `function foo($password = 'literal') {}`
-    fn walk_in_function_like_parameter(
-        &self,
-        function_like_parameter: &FunctionLikeParameter,
-        context: &mut LintContext<'_>,
-    ) {
-        let Some(default_value) = function_like_parameter.default_value.as_ref() else {
-            return;
-        };
-
-        let parameter_name = context.interner.lookup(&function_like_parameter.variable.name);
-        if !is_password(&parameter_name[1..]) {
-            return;
-        }
-
-        check(&function_like_parameter.variable, &default_value.value, context);
-    }
-
-    // check for `foo(password: 'literal')`
-    fn walk_in_named_argument(&self, named_argument: &NamedArgument, context: &mut LintContext<'_>) {
-        let argument_name = context.interner.lookup(&named_argument.name.value);
-        if !is_password(argument_name) {
-            return;
-        }
-
-        check(&named_argument.name, &named_argument.value, context);
     }
 }
 
-fn check(name: impl HasSpan, value: &Expression, context: &mut LintContext) {
+#[inline]
+#[must_use]
+fn check(name: impl HasSpan, value: &Expression, context: &mut LintContext) -> LintDirective {
     let is_literal_password = match value {
         Expression::Literal(Literal::String(literal_string)) => {
             let value = context.interner.lookup(&literal_string.value);
@@ -191,7 +176,7 @@ fn check(name: impl HasSpan, value: &Expression, context: &mut LintContext) {
     };
 
     if !is_literal_password {
-        return;
+        return LintDirective::default();
     }
 
     let issue = Issue::new(context.level(), "Literal passwords or sensitive data should not be stored in code.")
@@ -200,4 +185,6 @@ fn check(name: impl HasSpan, value: &Expression, context: &mut LintContext) {
         .with_help("Use environment variables or secure configuration management instead.");
 
     context.report(issue);
+
+    LintDirective::Prune
 }

--- a/crates/linter/src/plugin/security/rules/tainted_data_to_skin.rs
+++ b/crates/linter/src/plugin/security/rules/tainted_data_to_skin.rs
@@ -6,12 +6,12 @@ use mago_reporting::Annotation;
 use mago_reporting::Issue;
 use mago_reporting::Level;
 use mago_span::HasSpan;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
 use crate::definition::RuleOptionDefinition;
 use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
 use crate::plugin::security::rules::utils::is_user_input;
 use crate::rule::Rule;
 
@@ -56,57 +56,61 @@ impl Rule for TaintedDataToSinkRule {
                 "#},
             ))
     }
+
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        match node {
+            Node::Echo(echo) => {
+                for value in echo.values.iter() {
+                    check_tainted_data_to_sink(context, &echo.echo, value);
+                }
+            }
+            Node::PrintConstruct(print_construct) => {
+                check_tainted_data_to_sink(context, &print_construct.print, &print_construct.value);
+            }
+            Node::FunctionCall(function_call) => {
+                let Expression::Identifier(identifier) = function_call.function.as_ref() else {
+                    return LintDirective::default();
+                };
+
+                let function_name = context.resolve_function_name(identifier);
+
+                // Check if this function name is listed among known sinks
+                let is_sink_function =
+                    if let Some(known_sinks) = context.option(KNOWN_SINK_FUNCTIONS).and_then(|o| o.as_array()) {
+                        known_sinks.iter().any(|f| f.as_str().is_some_and(|f| f.eq_ignore_ascii_case(function_name)))
+                    } else {
+                        KNOWN_SINK_FUNCTIONS_DEFAULT.iter().any(|f| f.eq_ignore_ascii_case(function_name))
+                    };
+
+                if !is_sink_function {
+                    return LintDirective::default();
+                }
+
+                // If it is indeed a known sink, check each argument
+                for argument in function_call.argument_list.arguments.iter() {
+                    check_tainted_data_to_sink(context, &function_call.function, argument.value());
+                }
+            }
+            _ => (),
+        }
+
+        LintDirective::default()
+    }
 }
 
-impl Walker<LintContext<'_>> for TaintedDataToSinkRule {
-    fn walk_in_echo(&self, echo: &Echo, context: &mut LintContext<'_>) {
-        for value in echo.values.iter() {
-            check_tainted_data_to_sink(context, &echo.echo, value);
-        }
-    }
-
-    fn walk_in_print_construct(&self, print_construct: &PrintConstruct, context: &mut LintContext<'_>) {
-        check_tainted_data_to_sink(context, &print_construct.print, &print_construct.value);
-    }
-
-    fn walk_in_function_call(&self, function_call: &FunctionCall, context: &mut LintContext<'_>) {
-        let Expression::Identifier(identifier) = function_call.function.as_ref() else {
-            return;
-        };
-
-        let function_name = context.resolve_function_name(identifier);
-
-        // Check if this function name is listed among known sinks
-        let is_sink_function =
-            if let Some(known_sinks) = context.option(KNOWN_SINK_FUNCTIONS).and_then(|o| o.as_array()) {
-                known_sinks.iter().any(|f| f.as_str().is_some_and(|f| f.eq_ignore_ascii_case(function_name)))
-            } else {
-                KNOWN_SINK_FUNCTIONS_DEFAULT.iter().any(|f| f.eq_ignore_ascii_case(function_name))
-            };
-
-        if !is_sink_function {
-            return;
-        }
-
-        // If it is indeed a known sink, check each argument
-        for argument in function_call.argument_list.arguments.iter() {
-            check_tainted_data_to_sink(context, &function_call.function, argument.value());
-        }
-    }
-}
-
+#[inline]
 fn check_tainted_data_to_sink(context: &mut LintContext<'_>, used_in: &impl HasSpan, value: &Expression) {
     if !is_user_input(context, value) {
         return;
     }
 
-    let issue = Issue::new(context.level(), "Tainted data passed to a sink function/construct.")
-        .with_annotation(Annotation::primary(value.span()).with_message("This value originates from user input."))
-        .with_annotation(
-            Annotation::secondary(used_in.span()).with_message("Data is passed here without sanitization."),
-        )
-        .with_note("Tainted (user-supplied) data must be sanitized or escaped before being passed to sinks, or risk injection vulnerabilities.")
-        .with_help("Ensure the data is validated or escaped prior to using this sink.");
-
-    context.report(issue);
+    context.report(
+        Issue::new(context.level(), "Tainted data passed to a sink function/construct.")
+            .with_annotation(Annotation::primary(value.span()).with_message("This value originates from user input."))
+            .with_annotation(
+                Annotation::secondary(used_in.span()).with_message("Data is passed here without sanitization."),
+            )
+            .with_note("Tainted (user-supplied) data must be sanitized or escaped before being passed to sinks, or risk injection vulnerabilities.")
+            .with_help("Ensure the data is validated or escaped prior to using this sink.")
+    );
 }

--- a/crates/linter/src/plugin/security/rules/utils.rs
+++ b/crates/linter/src/plugin/security/rules/utils.rs
@@ -10,7 +10,7 @@ use crate::context::LintContext;
 pub fn is_user_input(context: &LintContext, expression: &Expression) -> bool {
     match expression {
         Expression::Parenthesized(parenthesized) => is_user_input(context, &parenthesized.expression),
-        Expression::AssignmentOperation(assignment) => is_user_input(context, &assignment.rhs),
+        Expression::Assignment(assignment) => is_user_input(context, &assignment.rhs),
         Expression::Conditional(conditional) => match conditional.then.as_ref() {
             Some(then) => is_user_input(context, then) || is_user_input(context, &conditional.r#else),
             None => is_user_input(context, &conditional.condition) || is_user_input(context, &conditional.r#else),
@@ -61,7 +61,7 @@ pub fn get_password(context: &LintContext, expr: &Expression) -> Option<Span> {
         Expression::Literal(Literal::String(literal_string)) if is_password_literal(context, literal_string) => {
             Some(literal_string.span())
         }
-        Expression::AssignmentOperation(assignment) => {
+        Expression::Assignment(assignment) => {
             get_password(context, &assignment.lhs).or_else(|| get_password(context, &assignment.rhs))
         }
         Expression::ArrayAccess(array_access) => get_password(context, &array_access.index),

--- a/crates/linter/src/plugin/strictness/rules/require_identity_comparison.rs
+++ b/crates/linter/src/plugin/strictness/rules/require_identity_comparison.rs
@@ -1,13 +1,13 @@
 use indoc::indoc;
 
-use mago_ast::ast::*;
+use mago_ast::*;
 use mago_fixer::SafetyClassification;
 use mago_reporting::*;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
 use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
 use crate::rule::Rule;
 
 #[derive(Clone, Debug)]
@@ -44,10 +44,10 @@ impl Rule for RequireIdentityComparisonRule {
                 "#},
             ))
     }
-}
 
-impl<'a> Walker<LintContext<'a>> for RequireIdentityComparisonRule {
-    fn walk_in_binary<'ast>(&self, binary: &'ast Binary, context: &mut LintContext<'a>) {
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let Node::Binary(binary) = node else { return LintDirective::default() };
+
         match &binary.operator {
             // `==` -> `===`
             BinaryOperator::Equal(span) => {
@@ -95,5 +95,7 @@ impl<'a> Walker<LintContext<'a>> for RequireIdentityComparisonRule {
             }
             _ => {}
         }
+
+        LintDirective::default()
     }
 }

--- a/crates/linter/src/plugin/strictness/rules/require_parameter_type.rs
+++ b/crates/linter/src/plugin/strictness/rules/require_parameter_type.rs
@@ -1,17 +1,17 @@
 use indoc::indoc;
 use toml::Value;
 
-use mago_ast::ast::*;
+use mago_ast::*;
 use mago_php_version::PHPVersion;
 use mago_reflection::class_like::ClassLikeReflection;
 use mago_reporting::*;
 use mago_span::HasSpan;
-use mago_walker::Walker;
 
 use crate::context::LintContext;
 use crate::definition::RuleDefinition;
 use crate::definition::RuleOptionDefinition;
 use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
 use crate::rule::Rule;
 
 pub const IGNORE_PARAMETER_TYPE_FOR_CLOSURE: &str = "ignore_closure";
@@ -123,123 +123,122 @@ impl Rule for RequireParameterTypeRule {
                 .with_option(IGNORE_PARAMETER_TYPE_FOR_ARROW_FUNCTION, Value::Boolean(true)),
             )
     }
+
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        match node {
+            Node::Function(function) => {
+                for parameter in function.parameter_list.parameters.iter() {
+                    check_function_like_parameter(parameter, context);
+                }
+            }
+            Node::Closure(closure) => {
+                let ignore_parameter_type_for_closure = context
+                    .option(IGNORE_PARAMETER_TYPE_FOR_CLOSURE)
+                    .and_then(|o| o.as_bool())
+                    .unwrap_or(IGNORE_PARAMETER_TYPE_FOR_CLOSURE_DEFAULT);
+
+                if ignore_parameter_type_for_closure {
+                    return LintDirective::Abort;
+                }
+
+                for parameter in closure.parameter_list.parameters.iter() {
+                    check_function_like_parameter(parameter, context);
+                }
+            }
+            Node::ArrowFunction(arrow_function) => {
+                let ignore_parameter_type_for_arrow_function = context
+                    .option(IGNORE_PARAMETER_TYPE_FOR_ARROW_FUNCTION)
+                    .and_then(|o| o.as_bool())
+                    .unwrap_or(IGNORE_PARAMETER_TYPE_FOR_ARROW_FUNCTION_DEFAULT);
+
+                if ignore_parameter_type_for_arrow_function {
+                    return LintDirective::Abort;
+                }
+
+                for parameter in arrow_function.parameter_list.parameters.iter() {
+                    check_function_like_parameter(parameter, context);
+                }
+            }
+            Node::Interface(interface) => {
+                let name = context.semantics.names.get(&interface.name);
+                let Some(reflection) = context.codebase.get_interface(context.interner, name) else {
+                    return LintDirective::default();
+                };
+
+                check_class_like_members(reflection, interface.members.as_slice(), context);
+            }
+            Node::Class(class) => {
+                let name = context.semantics.names.get(&class.name);
+                let Some(reflection) = context.codebase.get_class(context.interner, name) else {
+                    return LintDirective::default();
+                };
+
+                check_class_like_members(reflection, class.members.as_slice(), context);
+            }
+            Node::Enum(r#enum) => {
+                let name = context.semantics.names.get(&r#enum.name);
+                let Some(reflection) = context.codebase.get_enum(context.interner, name) else {
+                    return LintDirective::default();
+                };
+
+                check_class_like_members(reflection, r#enum.members.as_slice(), context);
+            }
+            Node::Trait(r#trait) => {
+                let name = context.semantics.names.get(&r#trait.name);
+                let Some(reflection) = context.codebase.get_trait(context.interner, name) else {
+                    return LintDirective::default();
+                };
+
+                check_class_like_members(reflection, r#trait.members.as_slice(), context);
+            }
+            _ => (),
+        }
+
+        LintDirective::default()
+    }
 }
 
-impl RequireParameterTypeRule {
-    fn report(function_like_parameter: &FunctionLikeParameter, context: &mut LintContext<'_>) {
-        if function_like_parameter.hint.is_some() {
-            return;
-        }
-
-        let parameter_name = context.lookup(&function_like_parameter.variable.name);
-
-        context.report(
-            Issue::new(context.level(), format!("Parameter `{}` is missing a type hint.", parameter_name))
-                .with_annotation(
-                    Annotation::primary(function_like_parameter.span())
-                        .with_message(format!("Parameter `{}` is declared here", parameter_name)),
-                )
-                .with_note("Type hints improve code readability and help prevent type-related errors.")
-                .with_help(format!("Consider adding a type hint to parameter `{}`.", parameter_name)),
-        );
+#[inline]
+fn check_function_like_parameter(function_like_parameter: &FunctionLikeParameter, context: &mut LintContext<'_>) {
+    if function_like_parameter.hint.is_some() {
+        return;
     }
 
-    fn report_class_like_members(
-        reflection: &ClassLikeReflection,
-        members: &[ClassLikeMember],
-        context: &mut LintContext<'_>,
-    ) {
-        for member in members {
-            let ClassLikeMember::Method(method) = member else {
-                continue;
-            };
+    let parameter_name = context.lookup(&function_like_parameter.variable.name);
 
-            let Some(method_reflection) = reflection.get_method(&method.name.value) else {
-                continue;
-            };
-
-            if method_reflection.is_overriding {
-                // This method is overriding a method from a parent class.
-                continue;
-            }
-
-            for parameter in method.parameter_list.parameters.iter() {
-                Self::report(parameter, context);
-            }
-        }
-    }
+    context.report(
+        Issue::new(context.level(), format!("Parameter `{}` is missing a type hint.", parameter_name))
+            .with_annotation(
+                Annotation::primary(function_like_parameter.span())
+                    .with_message(format!("Parameter `{}` is declared here", parameter_name)),
+            )
+            .with_note("Type hints improve code readability and help prevent type-related errors.")
+            .with_help(format!("Consider adding a type hint to parameter `{}`.", parameter_name)),
+    );
 }
 
-impl<'a> Walker<LintContext<'a>> for RequireParameterTypeRule {
-    fn walk_in_function(&self, function: &Function, context: &mut LintContext<'a>) {
-        for parameter in function.parameter_list.parameters.iter() {
-            Self::report(parameter, context);
-        }
-    }
-
-    fn walk_in_closure(&self, closure: &Closure, context: &mut LintContext<'a>) {
-        let ignore_parameter_type_for_closure = context
-            .option(IGNORE_PARAMETER_TYPE_FOR_CLOSURE)
-            .and_then(|o| o.as_bool())
-            .unwrap_or(IGNORE_PARAMETER_TYPE_FOR_CLOSURE_DEFAULT);
-
-        if ignore_parameter_type_for_closure {
-            return;
-        }
-
-        for parameter in closure.parameter_list.parameters.iter() {
-            Self::report(parameter, context);
-        }
-    }
-
-    fn walk_in_arrow_function(&self, arrow_function: &ArrowFunction, context: &mut LintContext<'a>) {
-        let ignore_parameter_type_for_arrow_function = context
-            .option(IGNORE_PARAMETER_TYPE_FOR_ARROW_FUNCTION)
-            .and_then(|o| o.as_bool())
-            .unwrap_or(IGNORE_PARAMETER_TYPE_FOR_ARROW_FUNCTION_DEFAULT);
-
-        if ignore_parameter_type_for_arrow_function {
-            return;
-        }
-
-        for parameter in arrow_function.parameter_list.parameters.iter() {
-            Self::report(parameter, context);
-        }
-    }
-
-    fn walk_in_interface(&self, interface: &Interface, context: &mut LintContext<'a>) {
-        let name = context.semantics.names.get(&interface.name);
-        let Some(reflection) = context.codebase.get_interface(context.interner, name) else {
-            return;
+#[inline]
+fn check_class_like_members(
+    reflection: &ClassLikeReflection,
+    members: &[ClassLikeMember],
+    context: &mut LintContext<'_>,
+) {
+    for member in members {
+        let ClassLikeMember::Method(method) = member else {
+            continue;
         };
 
-        Self::report_class_like_members(reflection, interface.members.as_slice(), context);
-    }
-
-    fn walk_in_class(&self, class: &Class, context: &mut LintContext<'a>) {
-        let name = context.semantics.names.get(&class.name);
-        let Some(reflection) = context.codebase.get_class(context.interner, name) else {
-            return;
+        let Some(method_reflection) = reflection.get_method(&method.name.value) else {
+            continue;
         };
 
-        Self::report_class_like_members(reflection, class.members.as_slice(), context);
-    }
+        if method_reflection.is_overriding {
+            // This method is overriding a method from a parent class.
+            continue;
+        }
 
-    fn walk_in_enum(&self, r#enum: &Enum, context: &mut LintContext<'a>) {
-        let name = context.semantics.names.get(&r#enum.name);
-        let Some(reflection) = context.codebase.get_enum(context.interner, name) else {
-            return;
-        };
-
-        Self::report_class_like_members(reflection, r#enum.members.as_slice(), context);
-    }
-
-    fn walk_in_trait(&self, r#trait: &Trait, context: &mut LintContext<'a>) {
-        let name = context.semantics.names.get(&r#trait.name);
-        let Some(reflection) = context.codebase.get_trait(context.interner, name) else {
-            return;
-        };
-
-        Self::report_class_like_members(reflection, r#trait.members.as_slice(), context);
+        for parameter in method.parameter_list.parameters.iter() {
+            check_function_like_parameter(parameter, context);
+        }
     }
 }

--- a/crates/linter/src/runner.rs
+++ b/crates/linter/src/runner.rs
@@ -1,0 +1,163 @@
+use mago_ast::Node;
+use mago_interner::ThreadedInterner;
+use mago_php_version::PHPVersion;
+use mago_reflection::CodebaseReflection;
+use mago_reporting::IssueCollection;
+use mago_semantics::Semantics;
+
+use crate::context::LintContext;
+use crate::directive::LintDirective;
+use crate::rule::ConfiguredRule;
+use crate::rule::Rule;
+
+/// The `Runner` is responsible for executing a lint rule on the AST of a PHP program.
+///
+/// It holds contextual data such as the PHP version, interner, codebase, semantics, and a collection
+/// of issues discovered during linting. To optimize repeated calls to [`Node::children()`], the runner
+/// precomputes a tree representation of the AST using the [`AstNode`] structure.
+///
+/// # Usage
+///
+/// 1. Create a new runner via [`Runner::new`].
+/// 2. For each configured lint rule, call [`Runner::run`].
+/// 3. After processing all rules, call [`Runner::finish`] to retrieve the reported issues.
+pub struct Runner<'a> {
+    php_version: PHPVersion,
+    interner: &'a ThreadedInterner,
+    codebase: &'a CodebaseReflection,
+    semantics: &'a Semantics,
+    ast: AstNode<'a>,
+    issues: IssueCollection,
+}
+
+impl<'a> Runner<'a> {
+    /// Creates a new `Runner` instance.
+    ///
+    /// This method converts the program AST (found in `semantics`) into a precomputed tree
+    /// representation to avoid repeated calls to [`Node::children()`] during linting.
+    ///
+    /// # Parameters
+    ///
+    /// - `php_version`: The PHP version used during linting.
+    /// - `interner`: A reference to the threaded interner for resolving interned strings.
+    /// - `codebase`: A reference to the codebase reflection, providing additional context.
+    /// - `semantics`: The semantics of the program to be linted.
+    ///
+    /// # Returns
+    ///
+    /// A new `Runner` instance.
+    pub fn new(
+        php_version: PHPVersion,
+        interner: &'a ThreadedInterner,
+        codebase: &'a CodebaseReflection,
+        semantics: &'a Semantics,
+    ) -> Self {
+        // Precompute the AST tree from the semantics program.
+        let ast = AstNode::from(Node::Program(&semantics.program));
+
+        Self { php_version, interner, codebase, semantics, issues: IssueCollection::default(), ast }
+    }
+
+    /// Executes the specified lint rule on the precomputed AST.
+    ///
+    /// This method creates a [`LintContext`] for the given rule and recursively lints the AST starting
+    /// from the root node. The rule's `lint_node` method is applied at each node, and any issues reported
+    /// are added to the runner's issue collection.
+    ///
+    /// # Parameters
+    ///
+    /// - `configured_rule`: The lint rule configuration to be executed.
+    pub fn run(&mut self, configured_rule: &ConfiguredRule) {
+        let mut context = LintContext {
+            php_version: self.php_version,
+            rule: configured_rule,
+            interner: self.interner,
+            codebase: self.codebase,
+            semantics: self.semantics,
+            issues: &mut self.issues,
+        };
+
+        lint_ast_node(&configured_rule.rule, &self.ast, &mut context);
+    }
+
+    /// Finalizes the linting process and returns the collection of reported issues.
+    ///
+    /// # Returns
+    ///
+    /// An [`IssueCollection`] containing all issues reported during linting.
+    pub fn finish(self) -> IssueCollection {
+        self.issues
+    }
+}
+
+/// Recursively applies a lint rule to the precomputed AST.
+///
+/// For each node, this function calls the rule's [`Rule::lint_node`] method and then recurses
+/// into the node's children based on the returned [`LintDirective`]:
+///
+/// - **`LintDirective::Continue`**: Lint the children of the node.
+/// - **`LintDirective::Prune`**: Skip linting the node's children.
+/// - **`LintDirective::Abort`**: Immediately stop linting the current branch.
+///
+/// # Parameters
+///
+/// - `rule`: The lint rule to apply.
+/// - `ast_node`: The current node in the precomputed AST.
+/// - `context`: The linting context for reporting issues and providing additional data.
+///
+/// # Returns
+///
+/// Returns `true` if the linting process should be aborted for the current branch;
+/// otherwise, returns `false`.
+#[inline]
+fn lint_ast_node<'a, R: Rule>(rule: &R, ast_node: &AstNode<'a>, context: &mut LintContext<'a>) -> bool {
+    let directive = rule.lint_node(ast_node.node, context);
+
+    match directive {
+        LintDirective::Continue => {
+            // Recurse into each child node.
+            for child in &ast_node.children {
+                if lint_ast_node(rule, child, context) {
+                    return true;
+                }
+            }
+            false
+        }
+        LintDirective::Prune => false, // Skip children.
+        LintDirective::Abort => true,  // Abort the current branch.
+    }
+}
+
+/// A precomputed tree node for the AST.
+///
+/// `AstNode` wraps a [`Node`] from the AST and precomputes its children into a vector of [`AstNode`]
+/// structures. This avoids multiple calls to [`Node::children()`] during linting, thereby optimizing
+/// traversal performance.
+#[derive(Debug)]
+struct AstNode<'a> {
+    /// The wrapped AST node.
+    node: Node<'a>,
+    /// The precomputed child nodes.
+    children: Vec<AstNode<'a>>,
+}
+
+impl<'a> From<Node<'a>> for AstNode<'a> {
+    /// Recursively converts a [`Node`] into an [`AstNode`], precomputing its children.
+    ///
+    /// # Parameters
+    ///
+    /// - `node`: The AST node to be converted.
+    ///
+    /// # Returns
+    ///
+    /// An [`AstNode`] representing the given node and its descendants.
+    fn from(node: Node<'a>) -> Self {
+        let node_children = node.children();
+        let mut children = Vec::with_capacity(node_children.len());
+        for child in node_children {
+            children.push(AstNode::from(child));
+        }
+
+        Self { node, children }
+    }
+}

--- a/crates/names/src/internal/context.rs
+++ b/crates/names/src/internal/context.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use std::collections::HashMap;
 
 use ahash::RandomState;
@@ -185,18 +183,20 @@ impl<'a> NameContext<'a> {
 
                 return Some(self.interner.intern(resolved));
             }
-        } else {
-            let alias = match kind {
-                NameKind::Default => context.default_aliases.get(first_part_lower.as_str()),
-                NameKind::Function => context.function_aliases.get(first_part_lower.as_str()),
-                NameKind::Constant => context.constant_aliases.get(first_part_lower.as_str()),
-            };
 
-            if let Some(resolved) = alias {
-                return Some(self.interner.intern(resolved));
-            }
+            return None;
         }
 
-        None
+        match kind {
+            NameKind::Default => {
+                context.default_aliases.get(first_part_lower.as_str()).map(|resolved| self.interner.intern(resolved))
+            }
+            NameKind::Function => {
+                context.function_aliases.get(first_part_lower.as_str()).map(|resolved| self.interner.intern(resolved))
+            }
+            NameKind::Constant => {
+                context.constant_aliases.get(first_part_lower.as_str()).map(|resolved| self.interner.intern(resolved))
+            }
+        }
     }
 }

--- a/crates/parser/src/internal/expression.rs
+++ b/crates/parser/src/internal/expression.rs
@@ -720,20 +720,16 @@ fn create_assignment_expression(lhs: Expression, operator: AssignmentOperator, r
                 Expression::Binary(Binary {
                     lhs: binary_lhs,
                     operator: binary_operator,
-                    rhs: Box::new(Expression::AssignmentOperation(Assignment {
-                        lhs: binary_rhs,
-                        operator,
-                        rhs: Box::new(rhs),
-                    })),
+                    rhs: Box::new(Expression::Assignment(Assignment { lhs: binary_rhs, operator, rhs: Box::new(rhs) })),
                 })
             } else {
-                Expression::AssignmentOperation(Assignment {
+                Expression::Assignment(Assignment {
                     lhs: Box::new(Expression::Binary(operation)),
                     operator,
                     rhs: Box::new(rhs),
                 })
             }
         }
-        _ => Expression::AssignmentOperation(Assignment { lhs: Box::new(lhs), operator, rhs: Box::new(rhs) }),
+        _ => Expression::Assignment(Assignment { lhs: Box::new(lhs), operator, rhs: Box::new(rhs) }),
     }
 }

--- a/crates/parser/src/internal/utils.rs
+++ b/crates/parser/src/internal/utils.rs
@@ -6,6 +6,7 @@ use mago_token::TokenKind;
 use crate::error::ParseError;
 use crate::internal::token_stream::TokenStream;
 
+#[inline]
 pub fn peek(stream: &mut TokenStream<'_, '_>) -> Result<Token, ParseError> {
     match stream.peek() {
         Some(Ok(token)) => Ok(token),
@@ -14,6 +15,7 @@ pub fn peek(stream: &mut TokenStream<'_, '_>) -> Result<Token, ParseError> {
     }
 }
 
+#[inline]
 pub fn maybe_peek(stream: &mut TokenStream<'_, '_>) -> Result<Option<Token>, ParseError> {
     match stream.peek() {
         Some(Ok(token)) => Ok(Some(token)),
@@ -22,6 +24,7 @@ pub fn maybe_peek(stream: &mut TokenStream<'_, '_>) -> Result<Option<Token>, Par
     }
 }
 
+#[inline]
 pub fn peek_nth(stream: &mut TokenStream<'_, '_>, n: usize) -> Result<Token, ParseError> {
     match stream.peek_nth(n) {
         Some(Ok(token)) => Ok(token),
@@ -30,6 +33,7 @@ pub fn peek_nth(stream: &mut TokenStream<'_, '_>, n: usize) -> Result<Token, Par
     }
 }
 
+#[inline]
 pub fn maybe_peek_nth(stream: &mut TokenStream<'_, '_>, n: usize) -> Result<Option<Token>, ParseError> {
     match stream.peek_nth(n) {
         Some(Ok(token)) => Ok(Some(token)),
@@ -38,6 +42,7 @@ pub fn maybe_peek_nth(stream: &mut TokenStream<'_, '_>, n: usize) -> Result<Opti
     }
 }
 
+#[inline]
 pub fn expect_any(stream: &mut TokenStream<'_, '_>) -> Result<Token, ParseError> {
     match stream.advance() {
         Some(Ok(token)) => Ok(token),
@@ -46,6 +51,7 @@ pub fn expect_any(stream: &mut TokenStream<'_, '_>) -> Result<Token, ParseError>
     }
 }
 
+#[inline]
 pub fn expect(stream: &mut TokenStream<'_, '_>, kind: TokenKind) -> Result<Token, ParseError> {
     let token = expect_any(stream)?;
 
@@ -56,6 +62,7 @@ pub fn expect(stream: &mut TokenStream<'_, '_>, kind: TokenKind) -> Result<Token
     }
 }
 
+#[inline]
 pub fn expect_one_of(stream: &mut TokenStream<'_, '_>, one_of: &[TokenKind]) -> Result<Token, ParseError> {
     let token = expect_any(stream)?;
 
@@ -66,6 +73,7 @@ pub fn expect_one_of(stream: &mut TokenStream<'_, '_>, one_of: &[TokenKind]) -> 
     }
 }
 
+#[inline]
 pub fn maybe_expect(stream: &mut TokenStream<'_, '_>, kind: TokenKind) -> Result<Option<Token>, ParseError> {
     let next = match stream.peek() {
         Some(Ok(token)) => token,
@@ -85,30 +93,37 @@ pub fn maybe_expect(stream: &mut TokenStream<'_, '_>, kind: TokenKind) -> Result
     }
 }
 
+#[inline]
 pub fn expect_span(stream: &mut TokenStream<'_, '_>, kind: TokenKind) -> Result<Span, ParseError> {
     expect(stream, kind).map(|token| token.span)
 }
 
+#[inline]
 pub fn expect_one_of_keyword(stream: &mut TokenStream<'_, '_>, one_of: &[TokenKind]) -> Result<Keyword, ParseError> {
     expect_one_of(stream, one_of).map(to_keyword)
 }
 
+#[inline]
 pub fn maybe_expect_keyword(stream: &mut TokenStream<'_, '_>, kind: TokenKind) -> Result<Option<Keyword>, ParseError> {
     maybe_expect(stream, kind).map(|maybe_token| maybe_token.map(to_keyword))
 }
 
+#[inline]
 pub fn expect_keyword(stream: &mut TokenStream<'_, '_>, kind: TokenKind) -> Result<Keyword, ParseError> {
     expect(stream, kind).map(to_keyword)
 }
 
+#[inline]
 pub fn expect_any_keyword(stream: &mut TokenStream<'_, '_>) -> Result<Keyword, ParseError> {
     expect_any(stream).map(to_keyword)
 }
 
+#[inline]
 pub fn to_keyword(token: Token) -> Keyword {
     Keyword { span: token.span, value: token.value }
 }
 
+#[inline]
 pub fn unexpected(stream: &mut TokenStream<'_, '_>, token: Option<Token>, one_of: &[TokenKind]) -> ParseError {
     if let Some(token) = token {
         ParseError::UnexpectedToken(one_of.to_vec(), token.kind, token.span)

--- a/crates/source/src/lib.rs
+++ b/crates/source/src/lib.rs
@@ -37,11 +37,11 @@ pub enum SourceCategory {
     UserDefined,
 }
 
-/// A unique identifier for a source, consisting of a string identifier and a user-defined flag.
+/// A unique identifier for a source.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
 pub struct SourceIdentifier(pub StringIdentifier, pub SourceCategory);
 
-/// Represents a source file with an identifier, optional path, content, and line information.
+/// Represents a source file.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
 pub struct Source {
     pub identifier: SourceIdentifier,
@@ -51,6 +51,7 @@ pub struct Source {
     pub lines: Vec<usize>,
 }
 
+/// Trait for items that have a source.
 pub trait HasSource {
     fn source(&self) -> SourceIdentifier;
 }
@@ -58,38 +59,25 @@ pub trait HasSource {
 /// Internal structure to store source information before full loading.
 #[derive(Debug)]
 struct SourceEntry {
-    /// The name of the source.
-    name: String,
-    /// The path to the source.
+    /// The file path (if any).
     path: Option<PathBuf>,
-    /// The content of the source.
+    /// The content, if already loaded, along with its size and line-starts.
     content: Option<(StringIdentifier, usize, Vec<usize>)>,
 }
 
-/// A manager for sources, which stores sources and provides methods to insert and retrieve them.
+/// A manager for sources.
 #[derive(Clone, Debug)]
 pub struct SourceManager {
-    /// The interner used to store source names.
+    /// The interner used for source names and content.
     interner: ThreadedInterner,
-    /// The map of source identifiers to source entries.
+    /// Map of SourceIdentifier -> SourceEntry.
     sources: Arc<DashMap<SourceIdentifier, SourceEntry>>,
-}
-
-impl SourceCategory {
-    pub fn is_built_in(&self) -> bool {
-        matches!(self, Self::BuiltIn)
-    }
-
-    pub fn is_external(&self) -> bool {
-        matches!(self, Self::External)
-    }
-
-    pub fn is_user_defined(&self) -> bool {
-        matches!(self, Self::UserDefined)
-    }
+    /// Auxiliary index from interned name to SourceIdentifier.
+    sources_by_name: Arc<DashMap<StringIdentifier, SourceIdentifier>>,
 }
 
 impl SourceIdentifier {
+    #[inline(always)]
     pub fn dummy() -> Self {
         Self(StringIdentifier::empty(), SourceCategory::UserDefined)
     }
@@ -120,6 +108,7 @@ impl Source {
     /// * `name` - A logical identifier for this source, such as `"inline"`
     ///   or `"my_script.php"`.
     /// * `content` - The actual PHP (or other) code string.
+    #[inline(always)]
     pub fn standalone(interner: &ThreadedInterner, name: &str, content: &str) -> Self {
         let lines: Vec<_> = line_starts(content).collect();
         let size = content.len();
@@ -143,6 +132,7 @@ impl Source {
     /// # Returns
     ///
     /// The line number for the given byte offset (0-based index).
+    #[inline(always)]
     pub fn line_number(&self, offset: usize) -> usize {
         self.lines.binary_search(&offset).unwrap_or_else(|next_line| next_line - 1)
     }
@@ -156,6 +146,7 @@ impl Source {
     /// # Returns
     ///
     /// The column number for the given byte offset (0-based index).
+    #[inline(always)]
     pub fn column_number(&self, offset: usize) -> usize {
         let line_start = self.lines.binary_search(&offset).unwrap_or_else(|next_line| self.lines[next_line - 1]);
 
@@ -164,178 +155,146 @@ impl Source {
 }
 
 impl SourceManager {
-    /// Creates a new source manager with the given interner.
-    ///
-    /// # Parameters
-    ///
-    /// - `interner`: The interner to use for source names.
-    ///
-    /// # Returns
-    ///
-    /// The new source manager.
+    /// Creates a new source manager.
+    #[inline(always)]
     pub fn new(interner: ThreadedInterner) -> Self {
-        Self { interner, sources: Arc::new(DashMap::new()) }
+        Self { interner, sources: Arc::new(DashMap::new()), sources_by_name: Arc::new(DashMap::new()) }
     }
 
-    /// Inserts a source with the given name and path into the manager.
-    ///
-    /// # Parameters
-    ///
-    /// - `name`: The name of the source.
-    /// - `path`: The path to the source.
-    /// - `category`: The category of the source.
-    ///
-    /// # Returns
-    ///
-    /// The identifier of the inserted source.
-    pub fn insert_path(&self, name: String, path: PathBuf, category: SourceCategory) -> SourceIdentifier {
-        let string_id = self.interner.intern(&name);
-        let source_id = SourceIdentifier(string_id, category);
-
+    /// Inserts a source with the given name and path.
+    #[inline(always)]
+    pub fn insert_path(&self, name: impl AsRef<str>, path: PathBuf, category: SourceCategory) -> SourceIdentifier {
+        let name_id = self.interner.intern(&name);
+        let source_id = SourceIdentifier(name_id, category);
+        // Fast-path: if already present, return.
         if self.sources.contains_key(&source_id) {
             return source_id;
         }
 
-        self.sources.insert(source_id, SourceEntry { name, path: Some(path), content: None });
-
+        self.sources.insert(source_id, SourceEntry { path: Some(path), content: None });
+        self.sources_by_name.insert(name_id, source_id);
         source_id
     }
 
-    /// Inserts a source with the given name and content into the manager.
-    ///
-    /// # Parameters
-    ///
-    /// - `name`: The name of the source.
-    /// - `content`: The content of the source.
-    /// - `category`: The category of the source.
-    ///
-    /// # Returns
-    ///
-    /// The identifier of the inserted source.
-    pub fn insert_content(&self, name: String, content: String, category: SourceCategory) -> SourceIdentifier {
-        if let Some(entry) = self.sources.iter().find(|entry| entry.name == name) {
-            return *entry.key();
+    /// Inserts a source with the given name and content.
+    #[inline(always)]
+    pub fn insert_content(
+        &self,
+        name: impl AsRef<str>,
+        content: impl AsRef<str>,
+        category: SourceCategory,
+    ) -> SourceIdentifier {
+        let name_id = self.interner.intern(&name);
+        // Try our auxiliary index first.
+        if let Some(source_id) = self.sources_by_name.get(&name_id).map(|v| *v) {
+            return source_id;
         }
-
-        let source_id = SourceIdentifier(self.interner.intern(&name), category);
-        let lines = line_starts(&content).collect();
-        let size = content.len();
-        let content = self.interner.intern(content);
-
-        self.sources.insert(source_id, SourceEntry { name, path: None, content: Some((content, size, lines)) });
-
+        let source_id = SourceIdentifier(name_id, category);
+        let lines: Vec<_> = line_starts(content.as_ref()).collect();
+        let size = content.as_ref().len();
+        let content_id = self.interner.intern(content);
+        self.sources.insert(source_id, SourceEntry { path: None, content: Some((content_id, size, lines)) });
+        self.sources_by_name.insert(name_id, source_id);
         source_id
     }
 
-    /// Checks whether the manager contains a source with the given identifier.
-    ///
-    /// # Parameters
-    ///
-    /// - `source_id`: The identifier of the source to check for.
-    ///
-    /// # Returns
-    ///
-    /// Whether the manager contains a source with the given identifier.
+    /// Returns whether the manager contains a source with the given identifier.
+    #[inline(always)]
     pub fn contains(&self, source_id: &SourceIdentifier) -> bool {
         self.sources.contains_key(source_id)
     }
 
-    /// Retrieve an iterator over all source identifiers in the manager.
+    /// Returns an iterator over all source identifiers.
+    #[inline(always)]
     pub fn source_ids(&self) -> impl Iterator<Item = SourceIdentifier> + '_ {
         self.sources.iter().map(|entry| *entry.key())
     }
 
-    /// Retrieve an iterator over all source identifiers in the manager for the given category.
+    /// Returns an iterator over source identifiers for the given category.
+    #[inline(always)]
     pub fn source_ids_for_category(&self, category: SourceCategory) -> impl Iterator<Item = SourceIdentifier> + '_ {
         self.sources.iter().filter(move |entry| entry.key().category() == category).map(|entry| *entry.key())
     }
 
-    /// Retrieve an iterator over all source identifiers in the manager for categories other than the given category.
+    /// Returns an iterator over source identifiers for categories other than the given category.
+    #[inline(always)]
     pub fn source_ids_except_category(&self, category: SourceCategory) -> impl Iterator<Item = SourceIdentifier> + '_ {
         self.sources.iter().filter(move |entry| entry.key().category() != category).map(|entry| *entry.key())
     }
 
-    /// Retrieve the source with the given identifier from the manager.
+    /// Loads the source with the given identifier.
     ///
-    /// # Parameters
-    ///
-    /// - `source_id`: The identifier of the source to retrieve.
-    ///
-    /// # Returns
-    ///
-    /// The source with the given identifier, or an error if the source does not exist, or could not be loaded.
+    /// If the source content is already loaded, it is returned directly.
+    /// Otherwise, the file is read from disk, processed, and cached.
+    #[inline(always)]
     pub fn load(&self, source_id: &SourceIdentifier) -> Result<Source, SourceError> {
-        let Some(mut entry) = self.sources.get_mut(source_id) else {
-            return Err(SourceError::UnavailableSource(*source_id));
-        };
-
-        match &entry.content {
-            Some((content, size, lines)) => Ok(Source {
+        // Try to get a mutable reference from the dashmap.
+        let mut entry = self.sources.get_mut(source_id).ok_or(SourceError::UnavailableSource(*source_id))?;
+        if let Some((content, size, ref lines)) = entry.content {
+            // Fast path: content is already loaded.
+            return Ok(Source {
                 identifier: *source_id,
                 path: entry.path.clone(),
-                content: *content,
-                size: *size,
+                content,
+                size,
                 lines: lines.clone(),
-            }),
-            None => {
-                let path = entry.path.clone().expect("source entry must contain either content or path");
-                let content = std::fs::read(&path)
-                    .map(|bytes| match String::from_utf8_lossy(&bytes) {
-                        Cow::Borrowed(str) => str.to_string(),
-                        Cow::Owned(string) => {
-                            tracing::warn!(
-                                "encountered invalid utf-8 sequence in file {:?}. behavior with non-utf-8 files is undefined and may lead to unexpected results.",
-                                path,
-                            );
-
-                            string
-                        }
-                    })?;
-
-                let (_, v) = entry.pair_mut();
-
-                let lines: Vec<_> = line_starts(&content).collect();
-                let size = content.len();
-                let content = self.interner.intern(content);
-
-                let source = Source { identifier: *source_id, path: Some(path), content, size, lines: lines.clone() };
-
-                v.content = Some((content, size, lines));
-
-                Ok(source)
-            }
+            });
         }
+
+        // Slow path: load from file.
+        let path = entry.path.clone().expect("Entry must have either content or path");
+        let bytes = std::fs::read(&path).map_err(SourceError::IOError)?;
+        let content = match String::from_utf8_lossy(&bytes) {
+            Cow::Borrowed(s) => s.to_owned(),
+            Cow::Owned(s) => {
+                tracing::warn!("Source '{}' contains invalid UTF-8 sequence, behavior is undefined.", path.display());
+
+                s
+            }
+        };
+
+        let lines: Vec<_> = line_starts(&content).collect();
+        let size = content.len();
+        let content_id = self.interner.intern(content);
+
+        // Update the entry.
+        entry.content = Some((content_id, size, lines.clone()));
+
+        Ok(Source { identifier: *source_id, path: Some(path), content: content_id, size, lines })
     }
 
-    pub fn write(&self, source_id: SourceIdentifier, content: String) -> Result<(), SourceError> {
+    /// Writes updated content for the source with the given identifier.
+    #[inline(always)]
+    pub fn write(&self, source_id: SourceIdentifier, new_content: impl AsRef<str>) -> Result<(), SourceError> {
         let mut entry = self.sources.get_mut(&source_id).ok_or(SourceError::UnavailableSource(source_id))?;
-
-        // Update the content of the source entry.
-        let lines = line_starts(&content).collect();
-        let size = content.len();
-        let content = self.interner.intern(content);
-
-        let (_, v) = entry.pair_mut();
-        if let Some((old_content, _, _)) = v.content.as_mut() {
-            if *old_content == content {
+        let new_content = new_content.as_ref();
+        let new_content_id = self.interner.intern(new_content);
+        // Check if content is unchanged.
+        if let Some((old_content, _, _)) = entry.content.as_ref() {
+            if *old_content == new_content_id {
                 return Ok(());
             }
         }
 
-        v.content = Some((content, size, lines));
-        if let Some(path) = entry.value().path.as_ref() {
-            std::fs::write(path, self.interner.lookup(&content)).map_err(SourceError::IOError)?;
+        let new_lines: Vec<_> = line_starts(new_content).collect();
+        let new_size = new_content.len();
+
+        entry.content = Some((new_content_id, new_size, new_lines.clone()));
+        if let Some(ref path) = entry.path {
+            std::fs::write(path, self.interner.lookup(&new_content_id)).map_err(SourceError::IOError)?;
         }
 
         Ok(())
     }
 
-    /// Retrieve the number of sources in the manager.
+    /// Returns the number of sources.
+    #[inline(always)]
     pub fn len(&self) -> usize {
         self.sources.len()
     }
 
-    /// Check whether the manager is empty.
+    /// Returns true if there are no sources.
+    #[inline(always)]
     pub fn is_empty(&self) -> bool {
         self.sources.is_empty()
     }
@@ -345,11 +304,14 @@ unsafe impl Send for SourceManager {}
 unsafe impl Sync for SourceManager {}
 
 impl<T: HasSource> HasSource for Box<T> {
+    #[inline(always)]
     fn source(&self) -> SourceIdentifier {
         self.as_ref().source()
     }
 }
 
-fn line_starts(source: &str) -> impl '_ + Iterator<Item = usize> {
+/// Returns an iterator over the starting byte offsets of each line in `source`.
+#[inline(always)]
+fn line_starts(source: &str) -> impl Iterator<Item = usize> + '_ {
     std::iter::once(0).chain(source.match_indices('\n').map(|(i, _)| i + 1))
 }

--- a/crates/typing/src/resolver.rs
+++ b/crates/typing/src/resolver.rs
@@ -68,7 +68,7 @@ impl<'i, 'c> TypeResolver<'i, 'c> {
             Expression::CompositeString(composite_string) => {
                 get_composite_string_kind(composite_string, |e| self.resolve(e))
             }
-            Expression::AssignmentOperation(assignment_operation) => self.resolve(&assignment_operation.rhs),
+            Expression::Assignment(assignment_operation) => self.resolve(&assignment_operation.rhs),
             Expression::Conditional(conditional) => get_conditional_kind(conditional, |e| self.resolve(e)),
             Expression::Array(array) => get_array_kind(&array.elements, |e| self.resolve(e)),
             Expression::LegacyArray(legacy_array) => get_array_kind(&legacy_array.elements, |e| self.resolve(e)),

--- a/crates/walker/src/lib.rs
+++ b/crates/walker/src/lib.rs
@@ -1295,7 +1295,7 @@ generate_ast_walker! {
             Expression::UnaryPostfix(operation) => walker.walk_unary_postfix(operation, context),
             Expression::Literal(literal) => walker.walk_literal_expression(literal, context),
             Expression::CompositeString(string) => walker.walk_composite_string(string, context),
-            Expression::AssignmentOperation(assignment) => {
+            Expression::Assignment(assignment) => {
                 walker.walk_assignment(assignment, context)
             }
             Expression::Conditional(conditional) => {

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -171,7 +171,7 @@ pub fn mago_format(code: String, format_settings: JsValue) -> Result<JsValue, Js
     // Prepare interner and source manager
     let interner = ThreadedInterner::new();
     let manager = SourceManager::new(interner.clone());
-    let source_id = manager.insert_content("code.php".to_string(), code, SourceCategory::UserDefined);
+    let source_id = manager.insert_content("code.php", code, SourceCategory::UserDefined);
 
     let source = manager.load(&source_id).map_err(|e| JsValue::from_str(&e.to_string()))?;
 

--- a/m.php
+++ b/m.php
@@ -1,0 +1,4 @@
+#!/usr/bin/env php
+<?php
+
+echo "Hello, World!\n";

--- a/new.json
+++ b/new.json
@@ -1,0 +1,249 @@
+{
+  "error": null,
+  "interner": [
+    [
+      8,
+      "\"Hello, World!\\n\""
+    ],
+    [
+      6,
+      "echo"
+    ],
+    [
+      10,
+      "\n"
+    ],
+    [
+      9,
+      ";"
+    ],
+    [
+      3,
+      "#!/usr/bin/env php"
+    ],
+    [
+      1,
+      "m.php"
+    ],
+    [
+      2,
+      "#!/usr/bin/env php\n<?php\n\necho \"Hello, World!\\n\";\n"
+    ],
+    [
+      5,
+      "\n\n"
+    ],
+    [
+      7,
+      " "
+    ],
+    [
+      4,
+      "<?php"
+    ]
+  ],
+  "program": {
+    "source": [
+      1,
+      "UserDefined"
+    ],
+    "statements": {
+      "inner": [
+        {
+          "type": "Inline",
+          "value": {
+            "kind": "Shebang",
+            "span": {
+              "end": {
+                "offset": 19,
+                "source": [
+                  1,
+                  "UserDefined"
+                ]
+              },
+              "start": {
+                "offset": 0,
+                "source": [
+                  1,
+                  "UserDefined"
+                ]
+              }
+            },
+            "value": 3
+          }
+        },
+        {
+          "type": "OpeningTag",
+          "value": {
+            "type": "Full",
+            "value": {
+              "span": {
+                "end": {
+                  "offset": 24,
+                  "source": [
+                    1,
+                    "UserDefined"
+                  ]
+                },
+                "start": {
+                  "offset": 19,
+                  "source": [
+                    1,
+                    "UserDefined"
+                  ]
+                }
+              },
+              "value": 4
+            }
+          }
+        },
+        {
+          "type": "Echo",
+          "value": {
+            "echo": {
+              "span": {
+                "end": {
+                  "offset": 30,
+                  "source": [
+                    1,
+                    "UserDefined"
+                  ]
+                },
+                "start": {
+                  "offset": 26,
+                  "source": [
+                    1,
+                    "UserDefined"
+                  ]
+                }
+              },
+              "value": 6
+            },
+            "terminator": {
+              "type": "Semicolon",
+              "value": {
+                "end": {
+                  "offset": 49,
+                  "source": [
+                    1,
+                    "UserDefined"
+                  ]
+                },
+                "start": {
+                  "offset": 48,
+                  "source": [
+                    1,
+                    "UserDefined"
+                  ]
+                }
+              }
+            },
+            "values": {
+              "inner": [
+                {
+                  "type": "Literal",
+                  "value": {
+                    "type": "String",
+                    "value": {
+                      "kind": {
+                        "type": "DoubleQuoted"
+                      },
+                      "span": {
+                        "end": {
+                          "offset": 48,
+                          "source": [
+                            1,
+                            "UserDefined"
+                          ]
+                        },
+                        "start": {
+                          "offset": 31,
+                          "source": [
+                            1,
+                            "UserDefined"
+                          ]
+                        }
+                      },
+                      "value": 8
+                    }
+                  }
+                }
+              ],
+              "tokens": []
+            }
+          }
+        }
+      ]
+    },
+    "trivia": {
+      "inner": [
+        {
+          "kind": {
+            "type": "WhiteSpace"
+          },
+          "span": {
+            "end": {
+              "offset": 26,
+              "source": [
+                1,
+                "UserDefined"
+              ]
+            },
+            "start": {
+              "offset": 26,
+              "source": [
+                1,
+                "UserDefined"
+              ]
+            }
+          },
+          "value": 5
+        },
+        {
+          "kind": {
+            "type": "WhiteSpace"
+          },
+          "span": {
+            "end": {
+              "offset": 31,
+              "source": [
+                1,
+                "UserDefined"
+              ]
+            },
+            "start": {
+              "offset": 31,
+              "source": [
+                1,
+                "UserDefined"
+              ]
+            }
+          },
+          "value": 7
+        },
+        {
+          "kind": {
+            "type": "WhiteSpace"
+          },
+          "span": {
+            "end": {
+              "offset": 50,
+              "source": [
+                1,
+                "UserDefined"
+              ]
+            },
+            "start": {
+              "offset": 50,
+              "source": [
+                1,
+                "UserDefined"
+              ]
+            }
+          },
+          "value": 10
+        }
+      ]
+    }
+  }
+}

--- a/new.php
+++ b/new.php
@@ -1,0 +1,249 @@
+{
+  "error": null,
+  "interner": [
+    [
+      4,
+      "<?php"
+    ],
+    [
+      5,
+      "\n\n"
+    ],
+    [
+      10,
+      "\n"
+    ],
+    [
+      2,
+      "#!/usr/bin/env php\n<?php\n\necho \"Hello, World!\\n\";\n"
+    ],
+    [
+      9,
+      ";"
+    ],
+    [
+      7,
+      " "
+    ],
+    [
+      6,
+      "echo"
+    ],
+    [
+      8,
+      "\"Hello, World!\\n\""
+    ],
+    [
+      3,
+      "#!/usr/bin/env php"
+    ],
+    [
+      1,
+      "m.php"
+    ]
+  ],
+  "program": {
+    "source": [
+      1,
+      "UserDefined"
+    ],
+    "statements": {
+      "inner": [
+        {
+          "type": "Inline",
+          "value": {
+            "kind": "Shebang",
+            "span": {
+              "end": {
+                "offset": 19,
+                "source": [
+                  1,
+                  "UserDefined"
+                ]
+              },
+              "start": {
+                "offset": 0,
+                "source": [
+                  1,
+                  "UserDefined"
+                ]
+              }
+            },
+            "value": 3
+          }
+        },
+        {
+          "type": "OpeningTag",
+          "value": {
+            "type": "Full",
+            "value": {
+              "span": {
+                "end": {
+                  "offset": 24,
+                  "source": [
+                    1,
+                    "UserDefined"
+                  ]
+                },
+                "start": {
+                  "offset": 19,
+                  "source": [
+                    1,
+                    "UserDefined"
+                  ]
+                }
+              },
+              "value": 4
+            }
+          }
+        },
+        {
+          "type": "Echo",
+          "value": {
+            "echo": {
+              "span": {
+                "end": {
+                  "offset": 30,
+                  "source": [
+                    1,
+                    "UserDefined"
+                  ]
+                },
+                "start": {
+                  "offset": 26,
+                  "source": [
+                    1,
+                    "UserDefined"
+                  ]
+                }
+              },
+              "value": 6
+            },
+            "terminator": {
+              "type": "Semicolon",
+              "value": {
+                "end": {
+                  "offset": 49,
+                  "source": [
+                    1,
+                    "UserDefined"
+                  ]
+                },
+                "start": {
+                  "offset": 48,
+                  "source": [
+                    1,
+                    "UserDefined"
+                  ]
+                }
+              }
+            },
+            "values": {
+              "inner": [
+                {
+                  "type": "Literal",
+                  "value": {
+                    "type": "String",
+                    "value": {
+                      "kind": {
+                        "type": "DoubleQuoted"
+                      },
+                      "span": {
+                        "end": {
+                          "offset": 48,
+                          "source": [
+                            1,
+                            "UserDefined"
+                          ]
+                        },
+                        "start": {
+                          "offset": 31,
+                          "source": [
+                            1,
+                            "UserDefined"
+                          ]
+                        }
+                      },
+                      "value": 8
+                    }
+                  }
+                }
+              ],
+              "tokens": []
+            }
+          }
+        }
+      ]
+    },
+    "trivia": {
+      "inner": [
+        {
+          "kind": {
+            "type": "WhiteSpace"
+          },
+          "span": {
+            "end": {
+              "offset": 26,
+              "source": [
+                1,
+                "UserDefined"
+              ]
+            },
+            "start": {
+              "offset": 26,
+              "source": [
+                1,
+                "UserDefined"
+              ]
+            }
+          },
+          "value": 5
+        },
+        {
+          "kind": {
+            "type": "WhiteSpace"
+          },
+          "span": {
+            "end": {
+              "offset": 31,
+              "source": [
+                1,
+                "UserDefined"
+              ]
+            },
+            "start": {
+              "offset": 31,
+              "source": [
+                1,
+                "UserDefined"
+              ]
+            }
+          },
+          "value": 7
+        },
+        {
+          "kind": {
+            "type": "WhiteSpace"
+          },
+          "span": {
+            "end": {
+              "offset": 50,
+              "source": [
+                1,
+                "UserDefined"
+              ]
+            },
+            "start": {
+              "offset": 50,
+              "source": [
+                1,
+                "UserDefined"
+              ]
+            }
+          },
+          "value": 10
+        }
+      ]
+    }
+  }
+}

--- a/old.json
+++ b/old.json
@@ -1,0 +1,249 @@
+{
+  "error": null,
+  "interner": [
+    [
+      9,
+      ";"
+    ],
+    [
+      7,
+      " "
+    ],
+    [
+      5,
+      "\n\n"
+    ],
+    [
+      2,
+      "#!/usr/bin/env php\n<?php\n\necho \"Hello, World!\\n\";\n"
+    ],
+    [
+      10,
+      "\n"
+    ],
+    [
+      3,
+      "#!/usr/bin/env php\n"
+    ],
+    [
+      4,
+      "<?php"
+    ],
+    [
+      6,
+      "echo"
+    ],
+    [
+      1,
+      "m.php"
+    ],
+    [
+      8,
+      "\"Hello, World!\\n\""
+    ]
+  ],
+  "program": {
+    "source": [
+      1,
+      "UserDefined"
+    ],
+    "statements": {
+      "inner": [
+        {
+          "type": "Inline",
+          "value": {
+            "kind": "Shebang",
+            "span": {
+              "end": {
+                "offset": 19,
+                "source": [
+                  1,
+                  "UserDefined"
+                ]
+              },
+              "start": {
+                "offset": 0,
+                "source": [
+                  1,
+                  "UserDefined"
+                ]
+              }
+            },
+            "value": 3
+          }
+        },
+        {
+          "type": "OpeningTag",
+          "value": {
+            "type": "Full",
+            "value": {
+              "span": {
+                "end": {
+                  "offset": 24,
+                  "source": [
+                    1,
+                    "UserDefined"
+                  ]
+                },
+                "start": {
+                  "offset": 19,
+                  "source": [
+                    1,
+                    "UserDefined"
+                  ]
+                }
+              },
+              "value": 4
+            }
+          }
+        },
+        {
+          "type": "Echo",
+          "value": {
+            "echo": {
+              "span": {
+                "end": {
+                  "offset": 30,
+                  "source": [
+                    1,
+                    "UserDefined"
+                  ]
+                },
+                "start": {
+                  "offset": 26,
+                  "source": [
+                    1,
+                    "UserDefined"
+                  ]
+                }
+              },
+              "value": 6
+            },
+            "terminator": {
+              "type": "Semicolon",
+              "value": {
+                "end": {
+                  "offset": 49,
+                  "source": [
+                    1,
+                    "UserDefined"
+                  ]
+                },
+                "start": {
+                  "offset": 48,
+                  "source": [
+                    1,
+                    "UserDefined"
+                  ]
+                }
+              }
+            },
+            "values": {
+              "inner": [
+                {
+                  "type": "Literal",
+                  "value": {
+                    "type": "String",
+                    "value": {
+                      "kind": {
+                        "type": "DoubleQuoted"
+                      },
+                      "span": {
+                        "end": {
+                          "offset": 48,
+                          "source": [
+                            1,
+                            "UserDefined"
+                          ]
+                        },
+                        "start": {
+                          "offset": 31,
+                          "source": [
+                            1,
+                            "UserDefined"
+                          ]
+                        }
+                      },
+                      "value": 8
+                    }
+                  }
+                }
+              ],
+              "tokens": []
+            }
+          }
+        }
+      ]
+    },
+    "trivia": {
+      "inner": [
+        {
+          "kind": {
+            "type": "WhiteSpace"
+          },
+          "span": {
+            "end": {
+              "offset": 26,
+              "source": [
+                1,
+                "UserDefined"
+              ]
+            },
+            "start": {
+              "offset": 26,
+              "source": [
+                1,
+                "UserDefined"
+              ]
+            }
+          },
+          "value": 5
+        },
+        {
+          "kind": {
+            "type": "WhiteSpace"
+          },
+          "span": {
+            "end": {
+              "offset": 31,
+              "source": [
+                1,
+                "UserDefined"
+              ]
+            },
+            "start": {
+              "offset": 31,
+              "source": [
+                1,
+                "UserDefined"
+              ]
+            }
+          },
+          "value": 7
+        },
+        {
+          "kind": {
+            "type": "WhiteSpace"
+          },
+          "span": {
+            "end": {
+              "offset": 50,
+              "source": [
+                1,
+                "UserDefined"
+              ]
+            },
+            "start": {
+              "offset": 50,
+              "source": [
+                1,
+                "UserDefined"
+              ]
+            }
+          },
+          "value": 10
+        }
+      ]
+    }
+  }
+}

--- a/src/source.rs
+++ b/src/source.rs
@@ -47,7 +47,7 @@ pub async fn from_paths(
 
     if include_stubs {
         for (stub, content) in PHP_STUBS {
-            manager.insert_content(stub.to_owned(), content.to_owned(), SourceCategory::BuiltIn);
+            manager.insert_content(stub, content, SourceCategory::BuiltIn);
         }
     }
 
@@ -102,7 +102,7 @@ pub async fn load(
 
     if include_stubs {
         for (stub, content) in PHP_STUBS {
-            manager.insert_content(stub.to_owned(), content.to_owned(), SourceCategory::BuiltIn);
+            manager.insert_content(stub, content, SourceCategory::BuiltIn);
         }
     }
 


### PR DESCRIPTION
## 📌 What Does This PR Do?

- reworked the linter’s rule evaluation to support upcoming features, including the ability to ignore specific rules via `@mago-ignore` comments.
- modified internal rule handling to enable granular control over specific AST nodes.
- applied micro-optimizations across several crates to improve efficiency, although overall performance gains remain modest.
- updated tests and documentation to reflect these structural changes.

This refactor paves the way for future linter enhancements and improved maintainability.

## 🔍 Context & Motivation

This PR addresses the need for a more flexible linter that can adapt to upcoming features and future requirements. In particular, the changes enable the use of `@mago-ignore` comments to bypass specific rules on designated nodes, which is crucial for our evolving codebase. Additionally, the micro-optimizations across several crates, though minor in performance impact, contribute to overall code quality and maintainability.

## 🛠️ Summary of Changes

- **Refactor:** Overhaul linter rule system and micro-optimize crates

## 📂 Affected Areas

- [x] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

related to #46 

## 📝 Notes for Reviewers

N/A
