### PR TITLE
feat(lexer/linter): add support for #️⃣ hash emoji & corresponding linter rule

### DIFF
--- a/crates/lexer/src/internal/consts.rs
+++ b/crates/lexer/src/internal/consts.rs
@@ -1,5 +1,8 @@
 use mago_token::TokenKind;
 
+pub const HASH_EMOJI_LEN: usize = 7;
+pub const HASH_EMOJI_BYTES: [u8; 7] = [35, 239, 184, 143, 226, 131, 163];
+
 pub const CAST_TYPES: [(&[u8], TokenKind); 12] = [
     (b"(int)", TokenKind::IntCast),
     (b"(integer)", TokenKind::IntegerCast),

--- a/crates/lexer/src/lib.rs
+++ b/crates/lexer/src/lib.rs
@@ -10,6 +10,8 @@ use mago_token::TokenKind;
 
 use crate::error::SyntaxError;
 use crate::input::Input;
+use crate::internal::consts::HASH_EMOJI_BYTES;
+use crate::internal::consts::HASH_EMOJI_LEN;
 use crate::internal::macros::float_exponent;
 use crate::internal::macros::float_separator;
 use crate::internal::macros::number_separator;
@@ -393,25 +395,31 @@ impl<'a, 'i> Lexer<'a, 'i> {
                         (TokenKind::LeftParenthesis, 1)
                     }
                     [b'#', ..] => {
-                        let mut length = 1;
-                        loop {
-                            match self.input.peek(length, 3) {
-                                [b'\n' | b'\r', ..] => {
-                                    break;
-                                }
-                                [w, b'?', b'>'] if w.is_ascii_whitespace() => {
-                                    break;
-                                }
-                                [b'?', b'>', ..] | [] => {
-                                    break;
-                                }
-                                [_, ..] => {
-                                    length += 1;
+                        if self.input.is_at(&HASH_EMOJI_BYTES, false)
+                            && matches!(self.input.peek(HASH_EMOJI_LEN, 1), [b'['])
+                        {
+                            (TokenKind::HashLeftBracket, HASH_EMOJI_LEN + 1)
+                        } else {
+                            let mut length = 1;
+                            loop {
+                                match self.input.peek(length, 3) {
+                                    [b'\n' | b'\r', ..] => {
+                                        break;
+                                    }
+                                    [w, b'?', b'>'] if w.is_ascii_whitespace() => {
+                                        break;
+                                    }
+                                    [b'?', b'>', ..] | [] => {
+                                        break;
+                                    }
+                                    [_, ..] => {
+                                        length += 1;
+                                    }
                                 }
                             }
-                        }
 
-                        (TokenKind::HashComment, length)
+                            (TokenKind::HashComment, length)
+                        }
                     }
                     [b'\\', ..] => (TokenKind::NamespaceSeparator, 1),
                     [start_of_identifier!(), ..] => 'identifier: {

--- a/crates/lexer/tests/tokenizer.rs
+++ b/crates/lexer/tests/tokenizer.rs
@@ -20,6 +20,29 @@ fn test_shebang() -> Result<(), SyntaxError> {
 }
 
 #[test]
+fn test_emoji_attribute() -> Result<(), SyntaxError> {
+    let code = "<?php #️⃣[Foo] class Bar {}".as_bytes();
+    let expected = vec![
+        TokenKind::OpenTag,
+        TokenKind::Whitespace,
+        TokenKind::HashLeftBracket,
+        TokenKind::Identifier,
+        TokenKind::RightBracket,
+        TokenKind::Whitespace,
+        TokenKind::Class,
+        TokenKind::Whitespace,
+        TokenKind::Identifier,
+        TokenKind::Whitespace,
+        TokenKind::LeftBrace,
+        TokenKind::RightBrace,
+    ];
+
+    test_lexer(code, expected).map_err(|err| {
+        panic!("unexpected error: {}", err);
+    })
+}
+
+#[test]
 fn test_casts() -> Result<(), SyntaxError> {
     let code = b"hello <?= ( string ) + - / ??= ?-> ... ( int   ) (integer    ) (    double) &&  ?> world";
     let expected = vec![

--- a/crates/linter/src/plugin/best_practices/mod.rs
+++ b/crates/linter/src/plugin/best_practices/mod.rs
@@ -6,6 +6,7 @@ use crate::plugin::best_practices::rules::loop_does_not_iterate::LoopDoesNotIter
 use crate::plugin::best_practices::rules::no_debug_symbols::NoDebugSymbolsRule;
 use crate::plugin::best_practices::rules::no_empty_loop::NoEmptyLoopRule;
 use crate::plugin::best_practices::rules::no_goto::NoGotoRule;
+use crate::plugin::best_practices::rules::no_hash_emoji::NoHashEmojiRule;
 use crate::plugin::best_practices::rules::no_multi_assignments::NoMultiAssignmentsRule;
 use crate::plugin::best_practices::rules::no_unused_parameter::NoUnusedParameterRule;
 use crate::plugin::best_practices::rules::use_while_instead_of_for::UseWhileInsteadOfForRule;
@@ -35,6 +36,7 @@ impl Plugin for BestPracticesPlugin {
             Box::new(ExcessiveNesting),
             Box::new(LoopDoesNotIterateRule),
             Box::new(NoGotoRule),
+            Box::new(NoHashEmojiRule),
             Box::new(NoDebugSymbolsRule),
             Box::new(NoMultiAssignmentsRule),
             Box::new(NoEmptyLoopRule),

--- a/crates/linter/src/plugin/best_practices/rules/mod.rs
+++ b/crates/linter/src/plugin/best_practices/rules/mod.rs
@@ -5,6 +5,7 @@ pub mod loop_does_not_iterate;
 pub mod no_debug_symbols;
 pub mod no_empty_loop;
 pub mod no_goto;
+pub mod no_hash_emoji;
 pub mod no_multi_assignments;
 pub mod no_unused_parameter;
 pub mod use_while_instead_of_for;

--- a/crates/linter/src/plugin/best_practices/rules/no_hash_emoji.rs
+++ b/crates/linter/src/plugin/best_practices/rules/no_hash_emoji.rs
@@ -1,0 +1,131 @@
+use indoc::indoc;
+use mago_ast::*;
+use mago_fixer::SafetyClassification;
+use mago_php_version::feature::Feature;
+use mago_reporting::*;
+use mago_span::HasSpan;
+
+use crate::context::LintContext;
+use crate::definition::RuleDefinition;
+use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
+use crate::rule::Rule;
+
+/// A rule that discourages using the `#️⃣` emoji in place of the ASCII `#`
+/// for comments or attribute declarations.
+///
+/// Although `#️⃣` may work in PHP or Mago, it can confuse readers and may
+/// break third-party tools that expect a simple ASCII hash symbol.
+#[derive(Clone, Debug)]
+pub struct NoHashEmojiRule;
+
+impl Rule for NoHashEmojiRule {
+    fn get_definition(&self) -> RuleDefinition {
+        RuleDefinition::enabled("No Hash Emoji", Level::Warning)
+            .with_description(indoc! {"
+                Discourages usage of the `#️⃣` emoji in place of the ASCII `#`.
+
+                While this emoji might look visually appealing, it can cause confusion for
+                other developers and potentially break external tools that do not handle
+                emoji characters in code.
+            "})
+            .with_example(RuleUsageExample::valid(
+                "Using a normal `#` symbol for comments",
+                indoc! {r#"
+                    <?php
+
+                    # This is a comment
+                "#},
+            ))
+            .with_example(RuleUsageExample::invalid(
+                "Using the `#️⃣` emoji for comments",
+                indoc! {r#"
+                    <?php
+
+                    #️⃣ This is a comment
+                "#},
+            ))
+            .with_example(RuleUsageExample::invalid(
+                "Using the `#️⃣` emoji for an attribute declaration",
+                indoc! {r#"
+                    <?php
+
+                    #️⃣[MyAttribute]
+                    class Foo {}
+                "#},
+            ))
+    }
+
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        match node {
+            Node::Program(program) => {
+                for trivia in &program.trivia.nodes {
+                    let Trivia { kind: TriviaKind::HashComment, value, .. } = trivia else {
+                        continue;
+                    };
+
+                    let comment = context.interner.lookup(value);
+                    if comment.starts_with("#️⃣") {
+                        let issue = Issue::new(context.level(), "Emoji-based hash (`#️⃣`) used instead of ASCII `#`.")
+                            .with_annotation(
+                                Annotation::primary(trivia.span()).with_message("This uses an emoji in place of `#`."),
+                            )
+                            .with_note(
+                                "While this may work in PHP, it can confuse readers and may break external tools.",
+                            )
+                            .with_help("Replace `#️⃣` with the normal ASCII `#`.");
+
+                        context.report_with_fix(issue, |plan| {
+                            plan.replace(
+                                trivia.span().start.offset..(trivia.span().start.offset + "#️⃣".len()),
+                                "#".to_string(),
+                                SafetyClassification::Safe,
+                            );
+                        });
+                    }
+                }
+
+                // Continue traversing the program to check for attribute declarations.
+                LintDirective::Continue
+            }
+            Node::AttributeList(attribute_list) => {
+                // Grab snippet for the attribute prefix
+                let code = context.interner.lookup(&context.semantics.source.content);
+                let range_start = attribute_list.hash_left_bracket.start.offset;
+                let range_end = attribute_list.hash_left_bracket.end.offset;
+                let attribute_list_code = &code[range_start..range_end];
+
+                if attribute_list_code.starts_with("#️⃣") {
+                    let issue =
+                        Issue::new(context.level(), "Emoji-based hash (`#️⃣`) used for an attribute declaration.")
+                            .with_annotation(
+                                Annotation::primary(attribute_list.hash_left_bracket.span())
+                                    .with_message("This uses an emoji in place of `#`."),
+                            )
+                            .with_note(
+                                "While this may work in PHP, it can confuse readers and may break external tools.",
+                            )
+                            .with_help("Use `#[` instead of `#️⃣[` for attributes.");
+
+                    context.report_with_fix(issue, |plan| {
+                        plan.replace(
+                            attribute_list.hash_left_bracket.span().to_range(),
+                            "#[".to_string(),
+                            SafetyClassification::Safe,
+                        );
+                    });
+                }
+
+                if context.php_version.is_supported(Feature::ClosureInConstantExpressions) {
+                    // PHP 8.5+ supports closures in constant expressions, which might contain
+                    // attributes inside them, therefore we need to traverse this node.
+                    LintDirective::Continue
+                } else {
+                    // No need to traverse further.
+                    LintDirective::Prune
+                }
+            }
+            _ => LintDirective::default(),
+        }
+    }
+}

--- a/crates/linter/tests/plugins/best_practices.rs
+++ b/crates/linter/tests/plugins/best_practices.rs
@@ -5,6 +5,7 @@ use mago_linter::plugin::best_practices::rules::loop_does_not_iterate::LoopDoesN
 use mago_linter::plugin::best_practices::rules::no_debug_symbols::NoDebugSymbolsRule;
 use mago_linter::plugin::best_practices::rules::no_empty_loop::NoEmptyLoopRule;
 use mago_linter::plugin::best_practices::rules::no_goto::NoGotoRule;
+use mago_linter::plugin::best_practices::rules::no_hash_emoji::NoHashEmojiRule;
 use mago_linter::plugin::best_practices::rules::no_multi_assignments::NoMultiAssignmentsRule;
 use mago_linter::plugin::best_practices::rules::no_unused_parameter::NoUnusedParameterRule;
 use mago_linter::plugin::best_practices::rules::use_while_instead_of_for::UseWhileInsteadOfForRule;
@@ -18,6 +19,7 @@ rule_test!(test_loop_does_not_iterate, LoopDoesNotIterateRule);
 rule_test!(test_no_debug_symbols, NoDebugSymbolsRule);
 rule_test!(test_no_empty_loop, NoEmptyLoopRule);
 rule_test!(test_no_goto, NoGotoRule);
+rule_test!(test_no_hash_emoji, NoHashEmojiRule);
 rule_test!(test_no_multi_assignments, NoMultiAssignmentsRule);
 rule_test!(test_no_unused_parameter, NoUnusedParameterRule);
 rule_test!(test_use_while_instead_of_for, UseWhileInsteadOfForRule);


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR extends the lexer to support the #️⃣ (hash emoji) as a valid alternative to the ASCII # symbol in comments and attribute declarations, and introduces a new linter rule (No Hash Emoji) that warns developers if they use the emoji-based character instead of the normal #.

## 🔍 Context & Motivation

Certain codebases or editors may inadvertently introduce the #️⃣ emoji in place of #, and although our lexer can parse it correctly, it may cause confusion for maintainers or break external tools expecting plain ASCII. We wanted to ensure compatibility in parsing while also discouraging this usage for practical reasons.

## 🛠️ Summary of Changes

- **Lexer**: Recognizes #️⃣ as equivalent to # for comments and attribute declarations.
- **Linter**: Added the No Hash Emoji rule, which issues a warning if #️⃣ is detected, suggesting replacing it with a standard ASCII #.

## 📂 Affected Areas

- [x] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Lexer

## 🔗 Related Issues or PRs

N/A

## 📝 Notes for Reviewers

N/A