### PR TITLE
revert: remove  emoji support in lexer and update NoHashEmojiRule

### DIFF
--- a/crates/lexer/src/internal/consts.rs
+++ b/crates/lexer/src/internal/consts.rs
@@ -1,8 +1,5 @@
 use mago_token::TokenKind;
 
-pub const HASH_EMOJI_LEN: usize = 7;
-pub const HASH_EMOJI_BYTES: [u8; 7] = [35, 239, 184, 143, 226, 131, 163];
-
 pub const CAST_TYPES: [(&[u8], TokenKind); 12] = [
     (b"(int)", TokenKind::IntCast),
     (b"(integer)", TokenKind::IntegerCast),

--- a/crates/lexer/src/lib.rs
+++ b/crates/lexer/src/lib.rs
@@ -10,8 +10,6 @@ use mago_token::TokenKind;
 
 use crate::error::SyntaxError;
 use crate::input::Input;
-use crate::internal::consts::HASH_EMOJI_BYTES;
-use crate::internal::consts::HASH_EMOJI_LEN;
 use crate::internal::macros::float_exponent;
 use crate::internal::macros::float_separator;
 use crate::internal::macros::number_separator;
@@ -395,31 +393,25 @@ impl<'a, 'i> Lexer<'a, 'i> {
                         (TokenKind::LeftParenthesis, 1)
                     }
                     [b'#', ..] => {
-                        if self.input.is_at(&HASH_EMOJI_BYTES, false)
-                            && matches!(self.input.peek(HASH_EMOJI_LEN, 1), [b'['])
-                        {
-                            (TokenKind::HashLeftBracket, HASH_EMOJI_LEN + 1)
-                        } else {
-                            let mut length = 1;
-                            loop {
-                                match self.input.peek(length, 3) {
-                                    [b'\n' | b'\r', ..] => {
-                                        break;
-                                    }
-                                    [w, b'?', b'>'] if w.is_ascii_whitespace() => {
-                                        break;
-                                    }
-                                    [b'?', b'>', ..] | [] => {
-                                        break;
-                                    }
-                                    [_, ..] => {
-                                        length += 1;
-                                    }
+                        let mut length = 1;
+                        loop {
+                            match self.input.peek(length, 3) {
+                                [b'\n' | b'\r', ..] => {
+                                    break;
+                                }
+                                [w, b'?', b'>'] if w.is_ascii_whitespace() => {
+                                    break;
+                                }
+                                [b'?', b'>', ..] | [] => {
+                                    break;
+                                }
+                                [_, ..] => {
+                                    length += 1;
                                 }
                             }
-
-                            (TokenKind::HashComment, length)
                         }
+
+                        (TokenKind::HashComment, length)
                     }
                     [b'\\', ..] => (TokenKind::NamespaceSeparator, 1),
                     [start_of_identifier!(), ..] => 'identifier: {

--- a/crates/lexer/tests/tokenizer.rs
+++ b/crates/lexer/tests/tokenizer.rs
@@ -22,20 +22,7 @@ fn test_shebang() -> Result<(), SyntaxError> {
 #[test]
 fn test_emoji_attribute() -> Result<(), SyntaxError> {
     let code = "<?php #️⃣[Foo] class Bar {}".as_bytes();
-    let expected = vec![
-        TokenKind::OpenTag,
-        TokenKind::Whitespace,
-        TokenKind::HashLeftBracket,
-        TokenKind::Identifier,
-        TokenKind::RightBracket,
-        TokenKind::Whitespace,
-        TokenKind::Class,
-        TokenKind::Whitespace,
-        TokenKind::Identifier,
-        TokenKind::Whitespace,
-        TokenKind::LeftBrace,
-        TokenKind::RightBrace,
-    ];
+    let expected = vec![TokenKind::OpenTag, TokenKind::Whitespace, TokenKind::HashComment];
 
     test_lexer(code, expected).map_err(|err| {
         panic!("unexpected error: {}", err);

--- a/crates/linter/src/plugin/best_practices/rules/no_hash_emoji.rs
+++ b/crates/linter/src/plugin/best_practices/rules/no_hash_emoji.rs
@@ -1,7 +1,6 @@
 use indoc::indoc;
 use mago_ast::*;
 use mago_fixer::SafetyClassification;
-use mago_php_version::feature::Feature;
 use mago_reporting::*;
 use mago_span::HasSpan;
 
@@ -11,11 +10,6 @@ use crate::definition::RuleUsageExample;
 use crate::directive::LintDirective;
 use crate::rule::Rule;
 
-/// A rule that discourages using the `#️⃣` emoji in place of the ASCII `#`
-/// for comments or attribute declarations.
-///
-/// Although `#️⃣` may work in PHP or Mago, it can confuse readers and may
-/// break third-party tools that expect a simple ASCII hash symbol.
 #[derive(Clone, Debug)]
 pub struct NoHashEmojiRule;
 
@@ -25,12 +19,11 @@ impl Rule for NoHashEmojiRule {
             .with_description(indoc! {"
                 Discourages usage of the `#️⃣` emoji in place of the ASCII `#`.
 
-                While this emoji might look visually appealing, it can cause confusion for
-                other developers and potentially break external tools that do not handle
-                emoji characters in code.
+                While PHP allows the use of emojis in comments, it is generally discouraged to use them in place of the normal ASCII `#` symbol.
+                This is because it can confuse readers and may break external tools that expect the normal ASCII `#` symbol.
             "})
             .with_example(RuleUsageExample::valid(
-                "Using a normal `#` symbol for comments",
+                "Using a normal `#` symbol for comments.",
                 indoc! {r#"
                     <?php
 
@@ -38,7 +31,7 @@ impl Rule for NoHashEmojiRule {
                 "#},
             ))
             .with_example(RuleUsageExample::invalid(
-                "Using the `#️⃣` emoji for comments",
+                "Using the `#️⃣` emoji for comments.",
                 indoc! {r#"
                     <?php
 
@@ -46,7 +39,7 @@ impl Rule for NoHashEmojiRule {
                 "#},
             ))
             .with_example(RuleUsageExample::invalid(
-                "Using the `#️⃣` emoji for an attribute declaration",
+                "Trying to use `#️⃣` for attribute declarations ( parsed as a comment ).",
                 indoc! {r#"
                     <?php
 
@@ -57,75 +50,39 @@ impl Rule for NoHashEmojiRule {
     }
 
     fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
-        match node {
-            Node::Program(program) => {
-                for trivia in &program.trivia.nodes {
-                    let Trivia { kind: TriviaKind::HashComment, value, .. } = trivia else {
-                        continue;
-                    };
+        let Node::Program(program) = node else { return LintDirective::default() };
 
-                    let comment = context.interner.lookup(value);
-                    if comment.starts_with("#️⃣") {
-                        let issue = Issue::new(context.level(), "Emoji-based hash (`#️⃣`) used instead of ASCII `#`.")
-                            .with_annotation(
-                                Annotation::primary(trivia.span()).with_message("This uses an emoji in place of `#`."),
-                            )
-                            .with_note(
-                                "While this may work in PHP, it can confuse readers and may break external tools.",
-                            )
-                            .with_help("Replace `#️⃣` with the normal ASCII `#`.");
+        for trivia in &program.trivia.nodes {
+            let Trivia { kind: TriviaKind::HashComment, value, .. } = trivia else {
+                continue;
+            };
 
-                        context.report_with_fix(issue, |plan| {
-                            plan.replace(
-                                trivia.span().start.offset..(trivia.span().start.offset + "#️⃣".len()),
-                                "#".to_string(),
-                                SafetyClassification::Safe,
-                            );
-                        });
-                    }
-                }
-
-                // Continue traversing the program to check for attribute declarations.
-                LintDirective::Continue
+            let comment = context.interner.lookup(value);
+            if !comment.starts_with("#️⃣") {
+                continue;
             }
-            Node::AttributeList(attribute_list) => {
-                // Grab snippet for the attribute prefix
-                let code = context.interner.lookup(&context.semantics.source.content);
-                let range_start = attribute_list.hash_left_bracket.start.offset;
-                let range_end = attribute_list.hash_left_bracket.end.offset;
-                let attribute_list_code = &code[range_start..range_end];
 
-                if attribute_list_code.starts_with("#️⃣") {
-                    let issue =
-                        Issue::new(context.level(), "Emoji-based hash (`#️⃣`) used for an attribute declaration.")
-                            .with_annotation(
-                                Annotation::primary(attribute_list.hash_left_bracket.span())
-                                    .with_message("This uses an emoji in place of `#`."),
-                            )
-                            .with_note(
-                                "While this may work in PHP, it can confuse readers and may break external tools.",
-                            )
-                            .with_help("Use `#[` instead of `#️⃣[` for attributes.");
+            let mut issue = Issue::new(context.level(), "Emoji-based hash (`#️⃣`) used instead of ASCII `#`.")
+                .with_annotation(Annotation::primary(trivia.span()).with_message("This uses an emoji in place of `#`."))
+                .with_note(
+                    "While this might render similarly in some editors, it can confuse readers or break tooling.",
+                )
+                .with_help("Replace `#️⃣` with `#`.");
 
-                    context.report_with_fix(issue, |plan| {
-                        plan.replace(
-                            attribute_list.hash_left_bracket.span().to_range(),
-                            "#[".to_string(),
-                            SafetyClassification::Safe,
-                        );
-                    });
-                }
-
-                if context.php_version.is_supported(Feature::ClosureInConstantExpressions) {
-                    // PHP 8.5+ supports closures in constant expressions, which might contain
-                    // attributes inside them, therefore we need to traverse this node.
-                    LintDirective::Continue
-                } else {
-                    // No need to traverse further.
-                    LintDirective::Prune
-                }
+            if comment.starts_with("#️⃣[") {
+                issue = issue.with_note("`#️⃣[` does not parse as an attribute in PHP; use `#[` instead.");
             }
-            _ => LintDirective::default(),
+
+            context.report_with_fix(issue, |plan| {
+                plan.replace(
+                    trivia.span().start.offset..(trivia.span().start.offset + "#️⃣".len()),
+                    "#".to_string(),
+                    SafetyClassification::Safe,
+                );
+            });
         }
+
+        // We don't need to walk further for this rule
+        LintDirective::Abort
     }
 }


### PR DESCRIPTION
Previously, we extended the lexer to parse the  emoji for attribute declarations. However, PHP does not support it for attributes, so we are reverting that lexer change. We also updated `NoHashEmojiRule` to clearly warn that using  in attributes doesn’t parse at all, while still discouraging its use in comments for clarity and tooling compatibility.

## 📌 What Does This PR Do?

This PR removes the previously added lexer support for the #️⃣ emoji in attribute declarations (since PHP does not actually parse it) and updates the `NoHashEmojiRule` to reflect that #️⃣ in attributes is entirely invalid. The rule now clearly warns that the emoji will not parse in attributes and can confuse or break tooling in comments as well.

## 🔍 Context & Motivation

- We want to revert the lexer changes to avoid misleading users into believing they can use #️⃣ for attributes.
- The linter rule now explicitly warns developers that #️⃣ doesn’t work for attributes and is discouraged in comments for clarity.

## 🛠️ Summary of Changes

- **Revert**: Removed lexer handling of #️⃣ for attribute declarations.
- **Update**: `NoHashEmojiRule` to reflect that usage in attributes is invalid in PHP and that using #️⃣ in comments remains discouraged.

## 📂 Affected Areas

- [x] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Lexer

## 🔗 Related Issues or PRs

partially reverts #67 

## 📝 Notes for Reviewers

N/A