### PR TITLE
feat: introduce reference crate, and find cli command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1531,6 +1531,7 @@ dependencies = [
  "mago-names",
  "mago-parser",
  "mago-php-version",
+ "mago-reference",
  "mago-reflection",
  "mago-reflector",
  "mago-reporting",
@@ -1720,6 +1721,18 @@ version = "0.8.1"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "mago-reference"
+version = "0.8.1"
+dependencies = [
+ "mago-ast",
+ "mago-interner",
+ "mago-semantics",
+ "mago-span",
+ "mago-walker",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ mago-typing = { path = "crates/typing", version = "0.8.1" }
 mago-walker = { path = "crates/walker", version = "0.8.1" }
 mago-wasm = { path = "crates/wasm", version = "0.8.1" }
 mago-php-version = { path = "crates/php-version", version = "0.8.1" }
+mago-reference = { path = "crates/reference", version = "0.8.1" }
 dashmap = { version = "6.1.0" }
 tracing = { version = "0.1.40" }
 ahash = { version = "0.8.11" }
@@ -107,6 +108,7 @@ mago-formatter = { workspace = true }
 mago-parser = { workspace = true }
 mago-fixer = { workspace = true }
 mago-php-version = { workspace = true }
+mago-reference = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "time"] }
 clap = { workspace = true }

--- a/Justfile
+++ b/Justfile
@@ -49,6 +49,7 @@ publish:
     cargo publish -p mago-names --allow-dirty
     cargo publish -p mago-symbol-table --allow-dirty
     cargo publish -p mago-semantics --allow-dirty
+    cargo publish -p mago-reference --allow-dirty
     cargo publish -p mago-typing --allow-dirty
     cargo publish -p mago-reflector --allow-dirty
     cargo publish -p mago-linter --allow-dirty

--- a/crates/reference/Cargo.toml
+++ b/crates/reference/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "mago-reference"
+description = "Mago Reference is a library for analyzing PHP codebases by providing advanced symbol search capabilities."
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+mago-interner = { workspace = true }
+mago-span = { workspace = true }
+mago-ast = { workspace = true }
+mago-walker = { workspace = true }
+mago-semantics = { workspace = true }
+serde = { workspace = true }

--- a/crates/reference/src/internal/context.rs
+++ b/crates/reference/src/internal/context.rs
@@ -1,0 +1,23 @@
+use mago_interner::ThreadedInterner;
+use mago_semantics::Semantics;
+
+use crate::query::Query;
+use crate::Reference;
+
+#[derive(Debug, Clone)]
+pub struct Context<'a> {
+    pub interner: &'a ThreadedInterner,
+    pub query: &'a Query,
+    pub semantics: &'a Semantics,
+    pub references: Vec<Reference>,
+}
+
+impl<'a> Context<'a> {
+    pub fn new(interner: &'a ThreadedInterner, query: &'a Query, semantics: &'a Semantics) -> Self {
+        Self { interner, query, semantics, references: Vec::new() }
+    }
+
+    pub fn take_references(&mut self) -> Vec<Reference> {
+        std::mem::take(&mut self.references)
+    }
+}

--- a/crates/reference/src/internal/mod.rs
+++ b/crates/reference/src/internal/mod.rs
@@ -1,0 +1,2 @@
+pub mod context;
+pub mod walker;

--- a/crates/reference/src/internal/walker.rs
+++ b/crates/reference/src/internal/walker.rs
@@ -1,0 +1,365 @@
+use mago_ast::*;
+use mago_span::*;
+use mago_walker::Walker;
+
+use crate::internal::context::Context;
+use crate::Reference;
+use crate::ReferenceKind;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct ReferenceFindingWalker;
+
+impl<'a> Walker<Context<'a>> for ReferenceFindingWalker {
+    #[inline]
+    fn walk_use(&self, r#use: &Use, context: &mut Context<'a>) {
+        match &r#use.items {
+            UseItems::Sequence(use_item_sequence) => {
+                for item in &use_item_sequence.items.nodes {
+                    let item_name_id = item.name.value();
+                    let item_name = context.interner.lookup(&item_name_id);
+
+                    if context.query.matches(item_name) {
+                        context.references.push(Reference {
+                            value: item_name_id,
+                            kind: ReferenceKind::Import,
+                            span: item.name.span(),
+                        });
+                    }
+                }
+            }
+            UseItems::TypedSequence(typed_use_item_sequence) => {
+                for item in &typed_use_item_sequence.items.nodes {
+                    let item_name_id = item.name.value();
+                    let item_name = context.interner.lookup(&item_name_id);
+
+                    if context.query.matches(item_name) {
+                        context.references.push(Reference {
+                            value: item_name_id,
+                            kind: ReferenceKind::Import,
+                            span: item.name.span(),
+                        });
+                    }
+                }
+            }
+            UseItems::TypedList(typed_use_item_list) => {
+                let prefix_id = typed_use_item_list.namespace.value();
+                let prefix = context.interner.lookup(&prefix_id);
+
+                for item in &typed_use_item_list.items.nodes {
+                    let item_name_id = item.name.value();
+                    let item_name = context.interner.lookup(&item_name_id);
+                    let full_name = format!("{}\\{}", prefix, item_name);
+
+                    if context.query.matches(&full_name) {
+                        let full_name_id = context.interner.intern(&full_name);
+
+                        context.references.push(Reference {
+                            value: full_name_id,
+                            kind: ReferenceKind::Import,
+                            span: item.name.span(),
+                        });
+                    }
+                }
+            }
+            UseItems::MixedList(mixed_use_item_list) => {
+                let prefix_id = mixed_use_item_list.namespace.value();
+                let prefix = context.interner.lookup(&prefix_id);
+
+                for maybe_typed_item in &mixed_use_item_list.items.nodes {
+                    let item_name_id = maybe_typed_item.item.name.value();
+                    let item_name = context.interner.lookup(&item_name_id);
+                    let full_name = format!("{}\\{}", prefix, item_name);
+
+                    if context.query.matches(&full_name) {
+                        let full_name_id = context.interner.intern(&full_name);
+
+                        context.references.push(Reference {
+                            value: full_name_id,
+                            kind: ReferenceKind::Import,
+                            span: maybe_typed_item.item.name.span(),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn walk_in_class(&self, class: &Class, context: &mut Context<'a>) {
+        let class_name_id = context.semantics.names.get(&class.name);
+        let class_name = context.interner.lookup(class_name_id);
+
+        if context.query.matches(class_name) {
+            context.references.push(Reference {
+                value: *class_name_id,
+                kind: ReferenceKind::Definition,
+                span: class.name.span(),
+            });
+        }
+
+        if let Some(extends) = class.extends.as_ref() {
+            for extended in &extends.types.nodes {
+                let extended_name_id = context.semantics.names.get(&extended);
+                let extended_name = context.interner.lookup(extended_name_id);
+
+                if context.query.matches(extended_name) {
+                    context.references.push(Reference {
+                        value: *extended_name_id,
+                        kind: ReferenceKind::Extension,
+                        span: extended.span(),
+                    });
+                }
+            }
+        }
+
+        if let Some(implements) = class.implements.as_ref() {
+            for implemented in &implements.types.nodes {
+                let implemented_name_id = context.semantics.names.get(&implemented);
+                let implemented_name = context.interner.lookup(implemented_name_id);
+
+                if context.query.matches(implemented_name) {
+                    context.references.push(Reference {
+                        value: *implemented_name_id,
+                        kind: ReferenceKind::Implementation,
+                        span: implemented.span(),
+                    });
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn walk_in_interface(&self, interface: &Interface, context: &mut Context<'a>) {
+        let interface_name_id = context.semantics.names.get(&interface.name);
+        let interface_name = context.interner.lookup(interface_name_id);
+
+        if context.query.matches(interface_name) {
+            context.references.push(Reference {
+                value: *interface_name_id,
+                kind: ReferenceKind::Definition,
+                span: interface.name.span(),
+            });
+        }
+
+        if let Some(extends) = interface.extends.as_ref() {
+            for extended in &extends.types.nodes {
+                let extended_name_id = context.semantics.names.get(&extended);
+                let extended_name = context.interner.lookup(extended_name_id);
+
+                if context.query.matches(extended_name) {
+                    context.references.push(Reference {
+                        value: *extended_name_id,
+                        kind: ReferenceKind::Extension,
+                        span: extended.span(),
+                    });
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn walk_in_trait(&self, r#trait: &Trait, context: &mut Context<'a>) {
+        let trait_name_id = context.semantics.names.get(&r#trait.name);
+        let trait_name = context.interner.lookup(trait_name_id);
+
+        if context.query.matches(trait_name) {
+            context.references.push(Reference {
+                value: *trait_name_id,
+                kind: ReferenceKind::Definition,
+                span: r#trait.name.span(),
+            });
+        }
+    }
+
+    #[inline]
+    fn walk_in_enum(&self, r#enum: &Enum, context: &mut Context<'a>) {
+        let enum_name_id = context.semantics.names.get(&r#enum.name);
+        let enum_name = context.interner.lookup(enum_name_id);
+
+        if context.query.matches(enum_name) {
+            context.references.push(Reference {
+                value: *enum_name_id,
+                kind: ReferenceKind::Definition,
+                span: r#enum.name.span(),
+            });
+        }
+
+        if let Some(implements) = r#enum.implements.as_ref() {
+            for implemented in &implements.types.nodes {
+                let implemented_name_id = context.semantics.names.get(&implemented);
+                let implemented_name = context.interner.lookup(implemented_name_id);
+
+                if context.query.matches(implemented_name) {
+                    context.references.push(Reference {
+                        value: *implemented_name_id,
+                        kind: ReferenceKind::Implementation,
+                        span: implemented.span(),
+                    });
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn walk_in_function(&self, function: &Function, context: &mut Context<'a>) {
+        let function_name_id = context.semantics.names.get(&function.name);
+        let function_name = context.interner.lookup(function_name_id);
+
+        if context.query.matches(function_name) {
+            context.references.push(Reference {
+                value: *function_name_id,
+                kind: ReferenceKind::Definition,
+                span: function.name.span(),
+            });
+        }
+    }
+
+    #[inline]
+    fn walk_in_constant(&self, constant: &Constant, context: &mut Context<'a>) {
+        for item in &constant.items.nodes {
+            let item_name_id = context.semantics.names.get(&item.name);
+            let item_name = context.interner.lookup(item_name_id);
+
+            if context.query.matches(item_name) {
+                context.references.push(Reference {
+                    value: *item_name_id,
+                    kind: ReferenceKind::Definition,
+                    span: item.name.span(),
+                });
+            }
+        }
+    }
+
+    #[inline]
+    fn walk_in_trait_use(&self, trait_use: &TraitUse, context: &mut Context<'a>) {
+        for r#trait in &trait_use.trait_names.nodes {
+            let trait_name_id = context.semantics.names.get(&r#trait);
+            let trait_name = context.interner.lookup(trait_name_id);
+
+            if context.query.matches(trait_name) {
+                context.references.push(Reference {
+                    value: *trait_name_id,
+                    kind: ReferenceKind::Implementation,
+                    span: r#trait.span(),
+                });
+            }
+        }
+    }
+
+    #[inline]
+    fn walk_in_binary(&self, binary: &Binary, context: &mut Context<'a>) {
+        let Binary { operator: BinaryOperator::Instanceof(_), rhs, .. } = binary else {
+            return;
+        };
+
+        check_expression(rhs, context);
+    }
+
+    #[inline]
+    fn walk_in_hint(&self, hint: &Hint, context: &mut Context<'a>) {
+        let Hint::Identifier(identifier) = hint else {
+            return;
+        };
+
+        check_identifier(identifier, context);
+    }
+
+    #[inline]
+    fn walk_in_instantiation(&self, instantiation: &Instantiation, context: &mut Context<'a>) {
+        let Instantiation { class, .. } = instantiation;
+
+        check_expression(class, context);
+    }
+
+    #[inline]
+    fn walk_in_call(&self, call: &Call, context: &mut Context<'a>) {
+        let expression = match call {
+            Call::Function(function_call) => function_call.function.as_ref(),
+            Call::Method(method_call) => method_call.object.as_ref(),
+            Call::NullSafeMethod(null_safe_method_call) => null_safe_method_call.object.as_ref(),
+            Call::StaticMethod(static_method_call) => static_method_call.class.as_ref(),
+        };
+
+        check_expression(expression, context);
+    }
+
+    #[inline]
+    fn walk_in_closure_creation(&self, closure_creation: &ClosureCreation, context: &mut Context<'a>) {
+        let expression = match &closure_creation {
+            ClosureCreation::Function(function_closure_creation) => function_closure_creation.function.as_ref(),
+            ClosureCreation::Method(method_closure_creation) => method_closure_creation.object.as_ref(),
+            ClosureCreation::StaticMethod(static_method_closure_creation) => {
+                static_method_closure_creation.class.as_ref()
+            }
+        };
+
+        check_expression(expression, context);
+    }
+
+    #[inline]
+    fn walk_in_access(&self, access: &Access, context: &mut Context<'a>) {
+        let expression = match &access {
+            Access::Property(property_access) => property_access.object.as_ref(),
+            Access::NullSafeProperty(null_safe_property_access) => null_safe_property_access.object.as_ref(),
+            Access::StaticProperty(static_property_access) => static_property_access.class.as_ref(),
+            Access::ClassConstant(class_constant_access) => class_constant_access.class.as_ref(),
+        };
+
+        check_expression(expression, context);
+    }
+
+    #[inline]
+    fn walk_in_constant_access(&self, constant_access: &ConstantAccess, context: &mut Context<'a>) {
+        check_identifier(&constant_access.name, context);
+    }
+
+    #[inline]
+    fn walk_in_magic_constant(&self, magic_constant: &MagicConstant, context: &mut Context<'a>) {
+        let identifier_name_id = magic_constant.value().value;
+        let identifier_name = context.interner.lookup(&identifier_name_id);
+
+        if context.query.matches(identifier_name) {
+            context.references.push(Reference {
+                value: identifier_name_id,
+                kind: ReferenceKind::Usage,
+                span: magic_constant.span(),
+            });
+        }
+    }
+
+    fn walk_in_attribute(&self, attribute: &Attribute, context: &mut Context<'a>) {
+        let attribute_name_id = context.semantics.names.get(&attribute.name);
+        let attribute_name = context.interner.lookup(attribute_name_id);
+
+        if context.query.matches(attribute_name) {
+            context.references.push(Reference {
+                value: *attribute_name_id,
+                kind: ReferenceKind::Definition,
+                span: attribute.name.span(),
+            });
+        }
+    }
+}
+
+#[inline]
+fn check_expression(expression: &Expression, context: &mut Context<'_>) {
+    let Expression::Identifier(identifier) = expression else {
+        return;
+    };
+
+    check_identifier(identifier, context);
+}
+
+#[inline]
+fn check_identifier(identifier: &Identifier, context: &mut Context<'_>) {
+    let identifier_name_id = context.semantics.names.get(identifier);
+    let identifier_name = context.interner.lookup(identifier_name_id);
+
+    if context.query.matches(identifier_name) {
+        context.references.push(Reference {
+            value: *identifier_name_id,
+            kind: ReferenceKind::Usage,
+            span: identifier.span(),
+        });
+    }
+}

--- a/crates/reference/src/lib.rs
+++ b/crates/reference/src/lib.rs
@@ -1,0 +1,104 @@
+use serde::Deserialize;
+use serde::Serialize;
+
+use mago_interner::StringIdentifier;
+use mago_interner::ThreadedInterner;
+use mago_semantics::Semantics;
+use mago_span::HasSpan;
+use mago_span::Span;
+use mago_walker::Walker;
+
+use crate::internal::context::Context;
+use crate::internal::walker::ReferenceFindingWalker;
+use crate::query::Query;
+
+pub mod query;
+
+mod internal;
+
+/// Represents the kind of reference that is found in code.
+///
+/// Each variant corresponds to a specific way in which a symbol might be
+/// referred to in code. For instance, an import statement, a usage, or
+/// a definition site.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
+pub enum ReferenceKind {
+    /// Indicates where a symbol is imported into a scope.
+    Import,
+
+    /// Refers to places in code where the symbol is used.
+    Usage,
+
+    /// Points to the definition site(s) of the symbol.
+    Definition,
+
+    /// Identifies where a symbol (like an interface) is
+    /// implemented, or where a trait is applied.
+    Implementation,
+
+    /// Tracks places where a class is extended.
+    Extension,
+}
+
+/// Describes a single reference to a symbol in the source code.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
+pub struct Reference {
+    /// The identifier for the referenced symbol, as stored in the interner.
+    pub value: StringIdentifier,
+
+    /// The kind of reference—import, usage, definition, etc. (see [`ReferenceKind`]).
+    pub kind: ReferenceKind,
+
+    /// The [`Span`] in the source code where this reference appears.
+    pub span: Span,
+}
+
+/// Provides functionality for discovering references (imports, usages, definitions, etc.)
+/// of a symbol within a program’s semantics.
+///
+/// The [`ReferenceFinder`] can locate references by walking through the AST
+/// (via a [`Walker`]) and collecting relevant `Reference` items.
+#[derive(Debug, Clone)]
+pub struct ReferenceFinder<'a> {
+    /// The interner used to resolve symbol names (e.g., function names, class names, etc.).
+    interner: &'a ThreadedInterner,
+}
+
+impl<'a> ReferenceFinder<'a> {
+    /// Creates a new `ReferenceFinder` that uses the given [`ThreadedInterner`]
+    /// for string lookups and resolutions.
+    pub fn new(interner: &'a ThreadedInterner) -> Self {
+        Self { interner }
+    }
+
+    /// Finds all references that match the given [`Query`] within the provided [`Semantics`].
+    ///
+    /// This method:
+    /// 1. Creates a [`Context`] that holds the interner, the query, and the current semantics.
+    /// 2. Uses a specialized [`Walker`] (`ReferenceFindingWalker`) to traverse the AST of the program.
+    /// 3. Gathers references (e.g., [`ReferenceKind::Usage`], [`ReferenceKind::Definition`]) in the context.
+    /// 4. Returns all discovered references as a `Vec<Reference>`.
+    ///
+    /// # Parameters
+    ///
+    /// - `semantics`: The [`Semantics`] representing the parsed and analyzed code.
+    /// - `query`: A [`Query`] describing what symbol or reference type we’re looking for.
+    ///
+    /// # Returns
+    ///
+    /// A list of [`Reference`] objects describing where and how the symbol is referenced
+    /// in the code.
+    pub fn find(&self, semantics: &Semantics, query: Query) -> Vec<Reference> {
+        let mut context = Context::new(self.interner, &query, semantics);
+
+        ReferenceFindingWalker.walk_program(&semantics.program, &mut context);
+
+        context.take_references()
+    }
+}
+
+impl HasSpan for Reference {
+    fn span(&self) -> Span {
+        self.span
+    }
+}

--- a/crates/reference/src/query.rs
+++ b/crates/reference/src/query.rs
@@ -1,0 +1,250 @@
+use std::str::FromStr;
+
+/// Represents different ways to match input text.
+///
+/// - `Exact(String, bool)` matches if the text is exactly equal to the query string.
+/// - `StartsWith(String, bool)` matches if the text starts with the query string.
+/// - `Contains(String, bool)` matches if the text contains the query string.
+/// - `EndsWith(String, bool)` matches if the text ends with the query string.
+///
+/// The `bool` field indicates whether the match should be **case-sensitive** (`true`)
+/// or **case-insensitive** (`false`). By default, it is **case-insensitive** unless the
+/// query string is prefixed with `c:` (for “case-sensitive”) or `i:` (for “case-insensitive”).
+#[derive(Debug, Clone, PartialEq)]
+pub enum Query {
+    /// Variant for an exact match.
+    /// The second parameter specifies if it's case-sensitive.
+    Exact(String, bool),
+    /// Variant for matching if the text starts with the query.
+    /// The second parameter specifies if it's case-sensitive.
+    StartsWith(String, bool),
+    /// Variant for matching if the text contains the query.
+    /// The second parameter specifies if it's case-sensitive.
+    Contains(String, bool),
+    /// Variant for matching if the text ends with the query.
+    /// The second parameter specifies if it's case-sensitive.
+    EndsWith(String, bool),
+}
+
+impl Query {
+    /// Checks whether the given `text` matches this query.
+    ///
+    /// By default, matches are **case-insensitive** unless specified otherwise in the query.
+    /// If `case_sensitive` is `true`, the match must respect exact casing.
+    ///
+    /// # Arguments
+    ///
+    /// * `text` - The text to check against the query.
+    ///
+    /// # Returns
+    ///
+    /// Returns `true` if the text matches according to the query variant (respecting case sensitivity),
+    /// or `false` otherwise.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::str::FromStr;
+    /// # use mago_reference::query::Query;
+    ///
+    /// // Case-insensitive exact match example:
+    /// let query = Query::from_str("=Hello").unwrap();
+    /// assert!(query.matches("hello"));
+    ///
+    /// // Case-sensitive contains example:
+    /// let query = Query::from_str("c:ell").unwrap();
+    /// assert!(query.matches("Well")); // false
+    /// assert!(query.matches("ell"));  // true if text is exactly "ell"
+    /// ```
+    pub fn matches(&self, text: &str) -> bool {
+        match self {
+            Query::Exact(q, case_sensitive) => {
+                if *case_sensitive {
+                    text == q
+                } else {
+                    text.eq_ignore_ascii_case(q)
+                }
+            }
+            Query::StartsWith(q, case_sensitive) => {
+                if *case_sensitive {
+                    text.starts_with(q)
+                } else {
+                    text.to_ascii_lowercase().starts_with(&q.to_ascii_lowercase())
+                }
+            }
+            Query::Contains(q, case_sensitive) => {
+                if *case_sensitive {
+                    text.contains(q)
+                } else {
+                    text.to_ascii_lowercase().contains(&q.to_ascii_lowercase())
+                }
+            }
+            Query::EndsWith(q, case_sensitive) => {
+                if *case_sensitive {
+                    text.ends_with(q)
+                } else {
+                    text.to_ascii_lowercase().ends_with(&q.to_ascii_lowercase())
+                }
+            }
+        }
+    }
+}
+
+impl FromStr for Query {
+    type Err = ();
+
+    /// Parses a string slice into a `Query` with optional case sensitivity.
+    ///
+    /// The parsing follows a simple syntax:
+    ///
+    /// - **Case Sensitivity**:
+    ///   - If the string starts with `"c:"`, the query is **case-sensitive**.
+    ///   - If it starts with `"i:"`, the query is explicitly case-insensitive.
+    ///   - Otherwise, it defaults to **case-insensitive**.
+    ///
+    /// - **Match Variants**:
+    ///   - If, after removing any `c:` or `i:` prefix, the string starts with `=`
+    ///     => parsed as `Exact(...)`.
+    ///   - If it starts with `^`
+    ///     => parsed as `StartsWith(...)`.
+    ///   - If it ends with `$`
+    ///     => parsed as `EndsWith(...)`.
+    ///   - Otherwise, it is parsed as `Contains(...)`.
+    ///
+    /// Whitespace is trimmed, and an empty input results in an error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::str::FromStr;
+    /// # use mago_reference::query::Query;
+    ///
+    /// // Case-insensitive exact match
+    /// let query = Query::from_str("=Exact").unwrap();
+    /// if let Query::Exact(ref s, false) = query {
+    ///     assert_eq!(s, "Exact");
+    /// } else {
+    ///     panic!("Expected case-insensitive Exact variant");
+    /// }
+    ///
+    /// // Case-sensitive starts-with match
+    /// let query = Query::from_str("c:^Hello").unwrap();
+    /// if let Query::StartsWith(ref s, true) = query {
+    ///     assert_eq!(s, "Hello");
+    /// } else {
+    ///     panic!("Expected case-sensitive StartsWith variant");
+    /// }
+    /// ```
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // 1) Trim whitespace
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            return Err(());
+        }
+
+        // 2) Determine case sensitivity
+        let (remaining, case_sensitive) = if let Some(rest) = trimmed.strip_prefix("c:") {
+            (rest, true)
+        } else if let Some(rest) = trimmed.strip_prefix("i:") {
+            (rest, false)
+        } else {
+            (trimmed, false) // default case-insensitive
+        };
+
+        // 3) Inspect the resulting string to see which variant we need
+        // Lowercase not mandatory for case-sensitive scenario, but needed to check
+        // special prefix/suffix markers only. We'll treat them consistently.
+        let lower = remaining.to_ascii_lowercase();
+
+        if lower.is_empty() {
+            return Err(());
+        }
+
+        // Exact if starts with '='
+        if let Some(rest) = remaining.strip_prefix('=') {
+            Ok(Query::Exact(rest.to_string(), case_sensitive))
+        }
+        // StartsWith if starts with '^'
+        else if let Some(rest) = remaining.strip_prefix('^') {
+            Ok(Query::StartsWith(rest.to_string(), case_sensitive))
+        }
+        // EndsWith if ends with '$'
+        else if lower.ends_with('$') {
+            let query_str = &remaining[..remaining.len() - 1];
+            Ok(Query::EndsWith(query_str.to_string(), case_sensitive))
+        }
+        // Otherwise, it's Contains
+        else {
+            Ok(Query::Contains(remaining.to_string(), case_sensitive))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_case_sensitive_exact() {
+        let query = Query::from_str("c:=Hello").unwrap();
+        match &query {
+            Query::Exact(s, true) => assert_eq!(s, "Hello"),
+            _ => panic!("Expected case-sensitive Exact variant"),
+        }
+
+        assert!(query.matches("Hello"));
+        assert!(!query.matches("hello"));
+    }
+
+    #[test]
+    fn test_case_insensitive_default() {
+        // =Hello without c: => case-insensitive
+        let query = Query::from_str("=Hello").unwrap();
+        match &query {
+            Query::Exact(s, false) => assert_eq!(s, "Hello"),
+            _ => panic!("Expected case-insensitive Exact variant"),
+        }
+
+        assert!(query.matches("hello"));
+        assert!(query.matches("HELLO"));
+    }
+
+    #[test]
+    fn test_starts_with_case_sensitive() {
+        let query = Query::from_str("c:^Hell").unwrap();
+        match &query {
+            Query::StartsWith(s, true) => assert_eq!(s, "Hell"),
+            _ => panic!("Expected case-sensitive StartsWith variant"),
+        }
+        assert!(query.matches("Hellworld"));
+        assert!(!query.matches("helloworld")); // different case
+    }
+
+    #[test]
+    fn test_contains_case_insensitive() {
+        let query = Query::from_str("CoNtEnT").unwrap();
+        match &query {
+            Query::Contains(s, false) => assert_eq!(s, "CoNtEnT"),
+            _ => panic!("Expected case-insensitive Contains variant"),
+        }
+        assert!(query.matches("this content is here"));
+        assert!(query.matches("CONTENT!"));
+    }
+
+    #[test]
+    fn test_ends_with() {
+        let query = Query::from_str("something$").unwrap();
+        match &query {
+            Query::EndsWith(s, false) => assert_eq!(s, "something"),
+            _ => panic!("Expected ends-with, case-insensitive"),
+        }
+
+        assert!(query.matches("ANYTHING someThing"));
+    }
+
+    #[test]
+    fn test_empty_string_error() {
+        assert!(Query::from_str("  ").is_err());
+    }
+}

--- a/src/commands/find.rs
+++ b/src/commands/find.rs
@@ -1,0 +1,224 @@
+use std::process::ExitCode;
+use std::str::FromStr;
+
+use clap::Parser;
+use mago_interner::ThreadedInterner;
+use mago_reference::query::Query;
+use mago_reference::Reference;
+use mago_reference::ReferenceFinder;
+use mago_reference::ReferenceKind;
+use mago_reporting::reporter::Reporter;
+use mago_reporting::reporter::ReportingFormat;
+use mago_reporting::reporter::ReportingTarget;
+use mago_reporting::Annotation;
+use mago_reporting::Issue;
+use mago_semantics::Semantics;
+use mago_source::SourceCategory;
+use mago_source::SourceManager;
+
+use crate::config::Configuration;
+use crate::enum_variants;
+use crate::error::Error;
+use crate::source;
+use crate::utils::progress::create_progress_bar;
+use crate::utils::progress::remove_progress_bar;
+use crate::utils::progress::ProgressBarTheme;
+
+/// The `find` subcommand used to locate references to a symbol (or pattern) in the codebase.
+///
+/// # Overview
+///
+/// * Parses a **query** string into a [`Query`](mago_reference::query::Query),
+///   which can represent exact matches, substring, etc.
+/// * Optionally includes external sources (e.g., vendor or system files).
+/// * Uses a [`ReferenceFinder`] to locate all matching references in parallel.
+/// * Reports them at level `Info` via the chosen `ReportingTarget` and `ReportingFormat`.
+#[derive(Parser, Debug)]
+#[command(
+    name = "find",
+    about = "Find references to a symbol in the codebase",
+    long_about = r#"
+Searches for symbol references (imports, uses, definitions, etc.) in user-defined or external sources.
+
+The query syntax supports:
+
+  =Exact   : an exact match
+  ^Prefix  : a starts-with match
+   Substr  : a contains match
+   Suffix$ : an ends-with match
+
+A Query can be case-sensitive by prefixing with "c:" or case-insensitive with "i:",
+If no prefix is provided, the query is case-insensitive by default.
+"#
+)]
+pub struct FindCommand {
+    /// The query string, e.g. "=MyClass", "^myFunc", "partialName", "someName$".
+    #[arg(help = "The query specifying how references should match")]
+    pub query: String,
+
+    /// Whether to include external (vendor or system) files when searching for references.
+    #[arg(short, long, help = "Include external sources (e.g., vendor) in the search")]
+    pub include_external: bool,
+
+    /// Specify where the results should be reported (e.g. CLI, JSON, file).
+    #[arg(
+        long,
+        default_value_t,
+        help = "Specify where the results should be reported",
+        ignore_case = true,
+        value_parser = enum_variants!(ReportingTarget)
+    )]
+    pub reporting_target: ReportingTarget,
+
+    /// Choose the format (human-friendly, JSON, etc.) for reporting issues.
+    #[arg(
+        long,
+        default_value_t,
+        help = "Choose the format for reporting issues",
+        ignore_case = true,
+        value_parser = enum_variants!(ReportingFormat)
+    )]
+    pub reporting_format: ReportingFormat,
+}
+
+/// Executes the `find` command, returning an exit status code.
+///
+/// 1. Parses the user’s query into a [`Query`].
+/// 2. Loads relevant sources (internal only or including external).
+/// 3. Spawns tasks to find references across all sources in parallel.
+/// 4. Reports the discovered references using [`Reporter`].
+///
+/// If the query string is invalid, returns `ExitCode::FAILURE`.
+pub async fn execute(command: FindCommand, configuration: Configuration) -> Result<ExitCode, Error> {
+    let interner = ThreadedInterner::new();
+
+    // Attempt to parse the query from user input
+    let query = match Query::from_str(&command.query) {
+        Ok(query) => query,
+        Err(_) => {
+            tracing::error!("Failed to parse query: \"{}\"", command.query);
+            eprintln!("Error: Invalid query syntax. Examples:\n  =Exact   ^Prefix   partial   suffix$");
+            eprintln!("Optionally prefix with 'c:' for case-sensitive or 'i:' for case-insensitive.");
+            return Ok(ExitCode::FAILURE);
+        }
+    };
+
+    // Load the source files
+    let source_manager = source::load(
+        &interner,
+        &configuration.source,
+        command.include_external,
+        /* ??? disable built-ins? */ false,
+    )
+    .await?;
+
+    // Gather references
+    let references =
+        find_references(&interner, &configuration, &source_manager, query, command.include_external).await?;
+
+    // Convert references to issues, then report
+    Reporter::new(interner.clone(), source_manager, command.reporting_target).report(
+        references.into_iter().map(|reference| reference_to_issue(&interner, reference)).collect::<Vec<_>>(),
+        command.reporting_format,
+    )?;
+
+    Ok(ExitCode::SUCCESS)
+}
+
+/// Finds references to a symbol or pattern across multiple source files.
+///
+/// # Parameters
+/// - `interner`: The global string interner for symbol lookups.
+/// - `configuration`: Holds user-defined settings (e.g., target PHP version).
+/// - `manager`: The [`SourceManager`] for loading and iterating code.
+/// - `query`: The parsed [`Query`] representing how to match references.
+/// - `include_externals`: If `true`, includes external (vendor/system) sources.
+///
+/// # Returns
+/// A list of all [`Reference`](mago_reference::Reference) matches discovered.
+///
+/// This function spawns parallel tasks (one per source file) to build a [`Semantics`]
+/// and run the [`ReferenceFinder`].
+pub async fn find_references(
+    interner: &ThreadedInterner,
+    configuration: &Configuration,
+    manager: &SourceManager,
+    query: Query,
+    include_externals: bool,
+) -> Result<Vec<Reference>, Error> {
+    let php_version = configuration.php_version;
+
+    // Choose which sources to analyze
+    let sources: Vec<_> = if include_externals {
+        manager.source_ids_for_category(SourceCategory::UserDefined).collect()
+    } else {
+        manager.source_ids_except_category(SourceCategory::BuiltIn).collect()
+    };
+
+    let length = sources.len();
+    let progress_bar = create_progress_bar(length, "🔎  Scanning", ProgressBarTheme::Yellow);
+
+    // Spawn tasks to find references in each source
+    let mut handles = Vec::with_capacity(length);
+    for source_id in sources {
+        let interner = interner.clone();
+        let manager = manager.clone();
+        let progress_bar = progress_bar.clone();
+        let query = query.clone();
+
+        handles.push(tokio::spawn(async move {
+            // 1) Load the source code
+            let source = manager.load(&source_id)?;
+            // 2) Build semantics
+            let semantics = Semantics::build(&interner, php_version, source);
+            // 3) Use the reference finder
+            let references = ReferenceFinder::new(&interner).find(&semantics, query);
+
+            // Increment progress after finishing this file
+            progress_bar.inc(1);
+
+            Result::<_, Error>::Ok(references)
+        }));
+    }
+
+    // Collect all results
+    let mut all_references = Vec::with_capacity(length);
+    for handle in handles {
+        all_references.extend(handle.await??);
+    }
+
+    remove_progress_bar(progress_bar);
+
+    Ok(all_references)
+}
+
+/// Converts a discovered [`Reference`](mago_reference::Reference) into an [`Issue`],
+/// suitable for CLI display at the `Note` level.
+pub fn reference_to_issue(interner: &ThreadedInterner, reference: Reference) -> Issue {
+    let symbol_name = interner.lookup(&reference.value);
+
+    match reference.kind {
+        ReferenceKind::Import => Issue::note(format!("Reference: imported symbol `{}`", symbol_name)).with_annotation(
+            Annotation::primary(reference.span).with_message(format!("This import references `{}`.", symbol_name)),
+        ),
+
+        ReferenceKind::Usage => Issue::note(format!("Reference: used symbol `{}`", symbol_name)).with_annotation(
+            Annotation::primary(reference.span).with_message(format!("Symbol `{}` is used here.", symbol_name)),
+        ),
+
+        ReferenceKind::Definition => Issue::note(format!("Reference: definition of `{}`", symbol_name))
+            .with_annotation(
+                Annotation::primary(reference.span).with_message(format!("Symbol `{}` is defined here.", symbol_name)),
+            ),
+
+        ReferenceKind::Implementation => Issue::note(format!("Reference: implementation of `{}`", symbol_name))
+            .with_annotation(
+                Annotation::primary(reference.span)
+                    .with_message(format!("Symbol `{}` is implemented here.", symbol_name)),
+            ),
+
+        ReferenceKind::Extension => Issue::note(format!("Reference: extension of `{}`", symbol_name)).with_annotation(
+            Annotation::primary(reference.span).with_message(format!("Class `{}` is extended here.", symbol_name)),
+        ),
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,12 +4,14 @@ use clap::builder::Styles;
 use clap::Parser;
 
 use crate::commands::ast::AstCommand;
+use crate::commands::find::FindCommand;
 use crate::commands::fix::FixCommand;
 use crate::commands::format::FormatCommand;
 use crate::commands::lint::LintCommand;
 use crate::commands::self_update::SelfUpdateCommand;
 
 pub mod ast;
+pub mod find;
 pub mod fix;
 pub mod format;
 pub mod lint;
@@ -56,6 +58,8 @@ pub enum MagoCommand {
     Fix(FixCommand),
     #[command(name = "format")]
     Format(FormatCommand),
+    #[command(name = "find")]
+    Find(FindCommand),
     #[command(name = "self-update")]
     SelfUpdate(SelfUpdateCommand),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,13 @@
 use std::process::ExitCode;
 
 use clap::Parser;
-use consts::MAXIMUM_PHP_VERSION;
-use consts::MINIMUM_PHP_VERSION;
 use tokio::runtime::Builder;
 use tracing::level_filters::LevelFilter;
 
 use crate::commands::MagoCommand;
 use crate::config::Configuration;
+use crate::consts::MAXIMUM_PHP_VERSION;
+use crate::consts::MINIMUM_PHP_VERSION;
 use crate::error::Error;
 use crate::utils::logger::initialize_logger;
 
@@ -60,6 +60,7 @@ pub fn run() -> Result<ExitCode, Error> {
         MagoCommand::Fix(cmd) => runtime.block_on(commands::fix::execute(cmd, configuration)),
         MagoCommand::Format(cmd) => runtime.block_on(commands::format::execute(cmd, configuration)),
         MagoCommand::Ast(cmd) => runtime.block_on(commands::ast::execute(cmd)),
+        MagoCommand::Find(find) => runtime.block_on(commands::find::execute(find, configuration)),
         MagoCommand::SelfUpdate(cmd) => commands::self_update::execute(cmd),
     }
 }


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR introduces a new crate, **mago_reference**, which implements advanced symbol reference searching capabilities for PHP projects. It adds a new CLI command, `mago find [query]`, that allows users to locate symbol references (including imports, uses, definitions, etc.) in both user-defined and external sources.

## 🔍 Context & Motivation

The motivation behind this change is to enhance code analysis for PHP projects by providing a robust, flexible search tool. Developers can now quickly locate symbol references across large codebases using an expressive query syntax. This feature is particularly valuable for navigating complex projects and for integration with future Language Server Protocol (LSP) workflows.

## 🛠️ Summary of Changes

- **Feature:** Introduced the new **mago_reference** crate, which focuses on symbol reference search functionality.
- **Feature:** Added the `mago find [query]` CLI command to locate symbol references in PHP projects.

## 📂 Affected Areas

- [x] CLI
- [ ] Documentation
- [ ] Linter
- [ ] Formatter
- [ ] Composer Plugin
- [ ] Dependencies
- [x] Other (mago_reference crate)

## 🔗 Related Issues or PRs

N/A

## 📝 Notes for Reviewers

- The **mago_reference** crate is currently focused solely on searching for symbol references without performing any code modifications.
- The query syntax has been designed to be intuitive and flexible, supporting both case-sensitive and case-insensitive searches. If no prefix is provided, the default is case-insensitive.
- The CLI command `mago find` provides a detailed help message with usage instructions and available options.
- Future enhancements may include additional search capabilities or integration with LSP features, but those are out of scope for this PR.

---

<img width="1714" alt="Screenshot 2025-02-05 at 13 33 10" src="https://github.com/user-attachments/assets/fc2e159b-1c69-4245-a567-a58fbbd709a3" />
<img width="1725" alt="Screenshot 2025-02-05 at 13 33 23" src="https://github.com/user-attachments/assets/e592b46c-209d-4a1c-9f94-3a360d08b98c" />

---

<img width="1176" alt="Screenshot 2025-02-05 at 13 34 36" src="https://github.com/user-attachments/assets/3fe5de50-55d6-4b05-90f2-47b12a8db8ca" />

