### PR TITLE
feat(cli): allow excluding patterns from formatter

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -132,6 +132,8 @@ The extensions option specifies the file extensions to include in the search.
 ### Formatter Configuration
 
 The `[format]` section customizes how Mago formats your PHP code, including settings like line width, tab width, and indentation style.
+In addition to common formatting options, you can specify an optional `excludes` key to define patterns that should be excluded from formatting.
+This allows you to, for example, skip formatting for generated files or other patterns while still processing them for linting.
 
 For more details on the available formatter settings, see the [Formatter Settings](/formatter/settings.md) page.
 
@@ -141,6 +143,7 @@ For more details on the available formatter settings, see the [Formatter Setting
 
   ```toml
   [format]
+  excludes = ["**/src/**/*.generated.php"]
   print_width = 80
   tab_width = 2
   ```

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -52,9 +52,11 @@ pub struct FormatCommand {
 /// # Returns
 ///
 /// Exit code: `0` if successful or no changes were needed, `1` if issues were found during the check.
-pub async fn execute(command: FormatCommand, configuration: Configuration) -> Result<ExitCode, Error> {
+pub async fn execute(command: FormatCommand, mut configuration: Configuration) -> Result<ExitCode, Error> {
     // Initialize the interner for managing identifiers.
     let interner = ThreadedInterner::new();
+
+    configuration.source.excludes.extend(std::mem::take(&mut configuration.format.excludes));
 
     // Load sources
     let source_manager = if !command.path.is_empty() {

--- a/src/config/formatter.rs
+++ b/src/config/formatter.rs
@@ -12,6 +12,11 @@ use crate::error::Error;
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct FormatterConfiguration {
+    /// A list of patterns to exclude from formatting.
+    ///
+    /// Defaults to `[]`.
+    pub excludes: Vec<String>,
+
     /// Specify the maximum line length that the printer will wrap on.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub print_width: Option<usize>,


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR adds support for an `excludes` configuration option under the `[format]` section in `mago.toml`. With this new option, users can specify files, directories, or glob patterns that will be excluded from formatting operations. These files will not be modified during the formatting process, but they remain active for linting and other analysis tasks.

## 🔍 Context & Motivation

Several users have requested more granular control over formatting behavior. In many projects, there are files or directories (such as generated files ) that should not be reformatted by the tool. Prior to this change, Mago would format every file found during its scan, which sometimes led to unintended modifications.

By introducing an `excludes` option under `[format]`, users now have the ability to tailor the formatting process. They can exclude specific paths or patterns from being formatted while still including them in other operations like linting. This enhancement improves both performance and user control.

## 🛠️ Summary of Changes

- **Feature:** Added support for the excludes key under the [format] section in mago.toml. This option accepts an array of file/directory patterns to exclude from formatting.
- **Docs:** Updated the configuration documentation to mention the new excludes option under `[format]`.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [x] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

closes #28

## 📝 Notes for Reviewers

N/A
