### PR TITLE
fix(formatter): fix formatting trailing and dangling comments

### DIFF
--- a/crates/formatter/tests/comment/mod.rs
+++ b/crates/formatter/tests/comment/mod.rs
@@ -1,1 +1,2 @@
 pub mod multiline;
+pub mod single_line;

--- a/crates/formatter/tests/comment/single_line.rs
+++ b/crates/formatter/tests/comment/single_line.rs
@@ -1,0 +1,66 @@
+use indoc::indoc;
+
+use mago_formatter::settings::FormatSettings;
+
+use crate::test_format;
+
+#[test]
+pub fn test_dangling_block_comments() {
+    let code = indoc! {r#"
+        <?php
+
+        class Foo
+        {
+            public function bar(): void
+            {
+                // This is a comment
+            }
+        }
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        class Foo
+        {
+            public function bar(): void
+            {
+                // This is a comment
+            }
+        }
+    "#};
+
+    test_format(code, expected, FormatSettings::default())
+}
+
+#[test]
+pub fn test_opening_tag_trailing_comments() {
+    let code = indoc! {r#"
+        <?php // some comment
+
+        echo 'Hello, world!';
+    "#};
+
+    let expected = indoc! {r#"
+        <?php // some comment
+
+        echo 'Hello, world!';
+    "#};
+
+    test_format(code, expected, FormatSettings::default())
+}
+
+#[test]
+pub fn test_opening_tag_trailing_comments_no_new_line() {
+    let code = indoc! {r#"
+        <?php // some comment
+        echo 'Hello, world!';
+    "#};
+
+    let expected = indoc! {r#"
+        <?php // some comment
+        echo 'Hello, world!';
+    "#};
+
+    test_format(code, expected, FormatSettings::default())
+}

--- a/src/config/formatter.rs
+++ b/src/config/formatter.rs
@@ -1,5 +1,7 @@
 use config::builder::BuilderState;
 use config::ConfigBuilder;
+use config::Value;
+use config::ValueKind;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -174,6 +176,6 @@ impl FormatterConfiguration {
 
 impl ConfigurationEntry for FormatterConfiguration {
     fn configure<St: BuilderState>(self, builder: ConfigBuilder<St>) -> Result<ConfigBuilder<St>, Error> {
-        Ok(builder)
+        builder.set_default("format.excludes", Value::new(None, ValueKind::Array(vec![]))).map_err(Error::from)
     }
 }


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fix formatting trailing comments after an opening tag ( e.g `<?php` ) and dangling comments inside of blocks.

## 🔍 Context & Motivation

N/A

## 🛠️ Summary of Changes

N/A

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

N/A

## 📝 Notes for Reviewers

N/A