### PR TITLE
docs: add ci recipes

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -19,6 +19,11 @@
     - [Analysis](linter/plugins/analysis.md)
     - [Best Practices](linter/plugins/best-practices.md)
 
+<!-- Recipes -->
+
+- [Recipes](recipes/)
+  - [CI](recipes/ci.md) 
+
 <!-- Contributing -->
 <!--
 

--- a/docs/recipes/ci.md
+++ b/docs/recipes/ci.md
@@ -1,0 +1,27 @@
+# Continous Integration
+
+This section describes how to set up Mago in a CI environment.
+
+## GitHub Actions
+
+Mago can be installed in GitHub Actions using the `setup-mago`
+action.
+
+```yaml
+name: Code Quality
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup Mago 
+      uses: nhedger/setup-mago@v1
+    - name: Run Mago 
+      run: |
+        mago format --dry-run
+        mago lint --reporting-format=github
+```


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR adds a Recipes section to the docs, as well as instructions for setting up Mago in GitHub Actions

## 🔍 Context & Motivation

Improve the CI experience

## 🛠️ Summary of Changes

- **Docs:** Added CI recipes

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [x] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

n/a

## 📝 Notes for Reviewers

n/a
