### PR TITLE
fix: versions always mismatching when detecting release

### DIFF
--- a/composer/InstallMagoBinaryCommand.php
+++ b/composer/InstallMagoBinaryCommand.php
@@ -111,14 +111,14 @@ final class InstallMagoBinaryCommand extends BaseCommand
 
     private function detectMagoReleaseId(HttpDownloader $httpDownloader): string
     {
-        $version = InstalledVersions::getVersion(MagoPlugin::PACKAGE_NAME);
+        $version = InstalledVersions::getPrettyVersion(MagoPlugin::PACKAGE_NAME);
 
         $response = $httpDownloader->get($this->buildGithubApiUri('/releases?per_page=99999999999999999'));
         $json = $response->decodeJson();
 
         foreach ($json as $release) {
             if ($release['tag_name'] === $version) {
-                return $release['id'];
+                return (string) $release['id'];
             }
         }
 


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR fixes the composer plugin always installing the latest binary.

The issue is that `InstalledVersions::getVersion()` returned `0.10.0.0` and the `tag_name` from github is `0.10.0`.

By using `InstalledVersions::getPrettyVersion()` we get `0.10.0` instead.

Also cast `$release['id']` to string to ensure it is a string.
(`Mago\InstallMagoBinaryCommand::detectMagoReleaseId(): Return value must be of type string, int returned`)

## 🔍 Context & Motivation

I had some issues with mago 0.11.0, and wanted to stay in 0.10.0 but it kept installing the latest binary.

## 🛠️ Summary of Changes

- **Bug Fix:** Fix composer installer to install correct binary

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [x] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 📝 Notes for Reviewers

I have never used these composer utils before, so I might be doing something wrong. When I tested it worked as expected.
