### PR TITLE
feat(formatter): sort, expand, and separate use statements

### DIFF
--- a/crates/ast/src/ast/use.rs
+++ b/crates/ast/src/ast/use.rs
@@ -94,6 +94,18 @@ pub struct UseItemAlias {
     pub identifier: LocalIdentifier,
 }
 
+impl UseType {
+    #[inline(always)]
+    pub const fn is_function(&self) -> bool {
+        matches!(self, UseType::Function(_))
+    }
+
+    #[inline(always)]
+    pub const fn is_const(&self) -> bool {
+        matches!(self, UseType::Const(_))
+    }
+}
+
 impl HasSpan for Use {
     fn span(&self) -> Span {
         self.r#use.span().join(self.terminator.span())

--- a/crates/formatter/src/format/statement.rs
+++ b/crates/formatter/src/format/statement.rs
@@ -3,14 +3,27 @@ use mago_span::HasSpan;
 
 use crate::Formatter;
 use crate::document::Document;
+use crate::document::Group;
 use crate::document::Line;
 use crate::format::Format;
 
 pub fn print_statement_sequence<'a>(f: &mut Formatter<'a>, stmts: &'a Sequence<Statement>) -> Vec<Document<'a>> {
+    let mut use_statements: Vec<&'a Use> = Vec::new();
     let mut parts = vec![];
 
     let last_non_noop_index = stmts.iter().rposition(|stmt| !matches!(stmt, Statement::Noop(_)));
     for (i, stmt) in stmts.iter().enumerate() {
+        if let Statement::Use(use_stmt) = stmt {
+            use_statements.push(use_stmt);
+            continue;
+        }
+
+        if !use_statements.is_empty() {
+            parts.extend(print_use_statements(f, std::mem::take(&mut use_statements)));
+            parts.push(Document::Line(Line::hardline()));
+            parts.push(Document::Line(Line::hardline()));
+        }
+
         let mut should_add_space = false;
 
         let should_add_new_line = match stmt {
@@ -59,5 +72,336 @@ pub fn print_statement_sequence<'a>(f: &mut Formatter<'a>, stmts: &'a Sequence<S
         }
     }
 
+    if !use_statements.is_empty() {
+        parts.extend(print_use_statements(f, use_statements));
+    }
+
     parts
+}
+
+fn print_use_statements<'a>(f: &mut Formatter<'a>, stmts: Vec<&'a Use>) -> Vec<Document<'a>> {
+    let should_sort = f.settings.sort_uses;
+    let should_separate = f.settings.separate_use_types;
+    let should_expand = f.settings.expand_use_groups;
+
+    let mut all_expanded_items: Vec<ExpandedUseItem<'a>> = Vec::new();
+    for use_stmt in stmts {
+        all_expanded_items.extend(expand_use(f, use_stmt, should_expand));
+    }
+
+    if should_sort {
+        all_expanded_items.sort_by(|a, b| {
+            let a_type_order = match a.use_type {
+                None => 0,
+                Some(ty) => {
+                    if ty.is_function() {
+                        1
+                    } else {
+                        2
+                    }
+                }
+            };
+            let b_type_order = match b.use_type {
+                None => 0,
+                Some(ty) => {
+                    if ty.is_function() {
+                        1
+                    } else {
+                        2
+                    }
+                }
+            };
+
+            if a_type_order != b_type_order {
+                return a_type_order.cmp(&b_type_order);
+            }
+
+            let mut a_full_name = a.namespace.join("\\");
+            if !a_full_name.is_empty() {
+                a_full_name.push('\\');
+            }
+            a_full_name.push_str(a.name);
+
+            let mut b_full_name = b.namespace.join("\\");
+            if !b_full_name.is_empty() {
+                b_full_name.push('\\');
+            }
+            b_full_name.push_str(b.name);
+
+            a_full_name.to_lowercase().cmp(&b_full_name.to_lowercase())
+        });
+    }
+
+    let mut grouped_items: Vec<Vec<ExpandedUseItem<'a>>> = Vec::new();
+    if should_separate {
+        #[derive(PartialEq, Eq)]
+        enum UseTypeDiscriminant {
+            Function,
+            Const,
+        }
+
+        let mut current_group: Vec<ExpandedUseItem<'a>> = Vec::new();
+        let mut current_type: Option<UseTypeDiscriminant> = None;
+
+        for item in all_expanded_items {
+            let item_type = item
+                .use_type
+                .map(|ty| if ty.is_function() { UseTypeDiscriminant::Function } else { UseTypeDiscriminant::Const });
+
+            if current_type != item_type {
+                if !current_group.is_empty() {
+                    grouped_items.push(std::mem::take(&mut current_group));
+                }
+
+                current_type = item_type;
+            }
+            current_group.push(item);
+        }
+        if !current_group.is_empty() {
+            grouped_items.push(current_group);
+        }
+    } else {
+        grouped_items.push(all_expanded_items);
+    }
+
+    let mut result_docs: Vec<Document<'a>> = Vec::new();
+    let grouped_items_count = grouped_items.len();
+    for (index, group) in grouped_items.into_iter().enumerate() {
+        let is_last_grouped_items = index + 1 == grouped_items_count;
+
+        let group_count = group.len();
+        for (item_index, item) in group.into_iter().enumerate() {
+            let is_last_group = item_index + 1 == group_count;
+
+            if should_expand {
+                let mut parts = vec![];
+                parts.push(item.original_node.r#use.format(f));
+                parts.push(Document::space());
+
+                if let Some(ty) = item.use_type {
+                    parts.push(ty.format(f));
+                    parts.push(Document::space());
+                }
+
+                let joined_namespace = item.namespace.join("\\");
+
+                if !joined_namespace.is_empty() {
+                    parts.push(Document::String(f.as_str(joined_namespace)));
+                    parts.push(Document::String("\\"));
+                }
+
+                parts.push(Document::String(item.name));
+
+                if let Some(alias) = item.alias {
+                    parts.push(Document::space());
+                    parts.push(Document::String("as "));
+                    parts.push(Document::String(alias));
+                }
+
+                parts.push(item.original_node.terminator.format(f));
+                result_docs.push(Document::Group(Group::new(parts)));
+            } else {
+                result_docs.push(item.original_node.format(f));
+            }
+
+            if !is_last_grouped_items || !is_last_group {
+                result_docs.push(Document::Line(Line::hardline()));
+            }
+        }
+
+        if !is_last_grouped_items {
+            result_docs.push(Document::Line(Line::hardline()));
+        }
+    }
+    result_docs
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+struct ExpandedUseItem<'a> {
+    use_type: Option<&'a UseType>,
+    namespace: Vec<&'a str>,
+    name: &'a str,
+    alias: Option<&'a str>,
+    original_node: &'a Use,
+}
+
+fn expand_use<'a>(f: &mut Formatter<'a>, use_stmt: &'a Use, should_expand: bool) -> Vec<ExpandedUseItem<'a>> {
+    let mut expanded_items = Vec::new();
+
+    fn expand_items<'a>(
+        f: &mut Formatter<'a>,
+        items: &'a UseItems,
+        current_namespace: Vec<&'a str>,
+        use_type: Option<&'a UseType>,
+        expanded_items: &mut Vec<ExpandedUseItem<'a>>,
+        original_node: &'a Use,
+        should_expand: bool,
+    ) {
+        match items {
+            UseItems::Sequence(seq) => {
+                if should_expand {
+                    for item in seq.items.iter() {
+                        expand_single_item(f, item, current_namespace.clone(), use_type, expanded_items, original_node);
+                    }
+                } else {
+                    // If not expanding, create *one* ExpandedUseItem for the entire sequence.
+                    expanded_items.push(ExpandedUseItem {
+                        use_type,
+                        namespace: current_namespace,
+                        name: "", // We don't need name/alias when not expanding.
+                        alias: None,
+                        original_node,
+                    });
+                }
+            }
+            UseItems::TypedSequence(seq) => {
+                if should_expand {
+                    for item in seq.items.iter() {
+                        expand_single_item(
+                            f,
+                            item,
+                            current_namespace.clone(),
+                            Some(&seq.r#type),
+                            expanded_items,
+                            original_node,
+                        );
+                    }
+                } else {
+                    expanded_items.push(ExpandedUseItem {
+                        use_type,
+                        namespace: current_namespace,
+                        name: "", // We don't need name/alias when not expanding.
+                        alias: None,
+                        original_node,
+                    });
+                }
+            }
+            UseItems::TypedList(list) => {
+                if should_expand {
+                    let mut new_namespace = current_namespace.clone();
+                    new_namespace.push(f.interner.lookup(&list.namespace.value()));
+                    for item in list.items.iter() {
+                        expand_single_item(
+                            f,
+                            item,
+                            new_namespace.clone(),
+                            Some(&list.r#type),
+                            expanded_items,
+                            original_node,
+                        );
+                    }
+                } else {
+                    expanded_items.push(ExpandedUseItem {
+                        use_type,
+                        namespace: current_namespace,
+                        name: "", // We don't need name/alias when not expanding.
+                        alias: None,
+                        original_node,
+                    });
+                }
+            }
+            UseItems::MixedList(list) => {
+                if should_expand {
+                    let mut new_namespace = current_namespace.clone();
+                    new_namespace.push(f.interner.lookup(&list.namespace.value()));
+                    for maybe_typed_item in list.items.iter() {
+                        expand_single_item(
+                            f,
+                            &maybe_typed_item.item,
+                            new_namespace.clone(),
+                            maybe_typed_item.r#type.as_ref(),
+                            expanded_items,
+                            original_node,
+                        );
+                    }
+                } else {
+                    expanded_items.push(ExpandedUseItem {
+                        use_type,
+                        namespace: current_namespace,
+                        name: "", // We don't need name/alias when not expanding.
+                        alias: None,
+                        original_node,
+                    });
+                }
+            }
+        }
+    }
+
+    fn expand_single_item<'a>(
+        f: &mut Formatter<'a>,
+        item: &'a UseItem,
+        mut current_namespace: Vec<&'a str>,
+        use_type: Option<&'a UseType>,
+        expanded_items: &mut Vec<ExpandedUseItem<'a>>,
+        original_node: &'a Use,
+    ) {
+        let mut parts = f.interner.lookup(&item.name.value()).split("\\").collect::<Vec<_>>();
+        // SAFETY: split always returns at least one element
+        let name = unsafe { parts.pop().unwrap_unchecked() };
+        current_namespace.extend(parts);
+
+        expanded_items.push(ExpandedUseItem {
+            use_type,
+            namespace: current_namespace,
+            name,
+            alias: item.alias.as_ref().map(|a| f.interner.lookup(&a.identifier.value)),
+            original_node,
+        });
+    }
+
+    expand_items(f, &use_stmt.items, Vec::new(), None, &mut expanded_items, use_stmt, should_expand); // Pass should_expand
+    expanded_items
+}
+
+pub fn sort_use_items<'a>(f: &mut Formatter<'a>, items: impl Iterator<Item = &'a UseItem>) -> Vec<&'a UseItem> {
+    let mut items = items.collect::<Vec<_>>();
+    items.sort_by(|a, b| {
+        let a_name = f.interner.lookup(&a.name.value());
+        let b_name = f.interner.lookup(&b.name.value());
+
+        a_name.to_lowercase().cmp(&b_name.to_lowercase())
+    });
+
+    items
+}
+
+pub fn sort_maybe_typed_use_items<'a>(
+    f: &mut Formatter<'a>,
+    items: impl Iterator<Item = &'a MaybeTypedUseItem>,
+) -> Vec<&'a MaybeTypedUseItem> {
+    let mut items = items.collect::<Vec<_>>();
+    items.sort_by(|a, b| {
+        let a_type_order = match &a.r#type {
+            None => 0,
+            Some(ty) => {
+                if ty.is_function() {
+                    1
+                } else {
+                    2
+                }
+            }
+        };
+
+        let b_type_order = match &b.r#type {
+            None => 0,
+            Some(ty) => {
+                if ty.is_function() {
+                    1
+                } else {
+                    2
+                }
+            }
+        };
+
+        if a_type_order != b_type_order {
+            return a_type_order.cmp(&b_type_order);
+        }
+
+        let a_name = f.interner.lookup(&a.item.name.value());
+        let b_name = f.interner.lookup(&b.item.name.value());
+
+        a_name.to_lowercase().cmp(&b_name.to_lowercase())
+    });
+
+    items
 }

--- a/crates/formatter/src/settings.rs
+++ b/crates/formatter/src/settings.rs
@@ -486,6 +486,58 @@ pub struct FormatSettings {
     /// Default: false
     #[serde(default = "default_false")]
     pub line_before_binary_operator: bool,
+
+    /// Whether to sort use statements alphabetically.
+    ///
+    /// Default: true
+    #[serde(default = "default_true")]
+    pub sort_uses: bool,
+
+    /// Whether to insert a blank line between different types of use statements
+    /// (e.g., classes, functions, constants).
+    ///
+    /// Default: true
+    ///
+    /// Example:
+    ///
+    /// ```php
+    /// use Foo\Bar;
+    /// use Foo\Baz;
+    ///
+    /// use function Foo\bar;
+    /// use function Foo\baz;
+    ///
+    /// use const Foo\A;
+    /// use const Foo\B;
+    ///
+    /// // or, if separate_use_types is false:
+    ///
+    /// use Foo\Bar;
+    /// use Foo\Baz;
+    /// use function Foo\bar;
+    /// use function Foo\baz;
+    /// use const Foo\A;
+    /// use const Foo\B;
+    /// ```
+    #[serde(default = "default_true")]
+    pub separate_use_types: bool,
+
+    /// Whether to expand grouped use statements into individual statements.
+    ///
+    /// Default: true
+    ///
+    /// Example:
+    ///
+    /// ```php
+    /// use Foo\{Bar, Baz};
+    ///
+    /// // or, if expand_use_groups is true:
+    ///
+    /// use Foo\Bar;
+    /// use Foo\Baz;
+    /// ```
+    #[serde(default = "default_true")]
+    pub expand_use_groups: bool,
 }
 
 impl Default for FormatSettings {
@@ -518,6 +570,9 @@ impl Default for FormatSettings {
             space_concatenation: true,
             method_chain_breaking_style: MethodChainBreakingStyle::NextLine,
             line_before_binary_operator: false,
+            sort_uses: true,
+            separate_use_types: true,
+            expand_use_groups: true,
         }
     }
 }

--- a/crates/formatter/tests/format/mod.rs
+++ b/crates/formatter/tests/format/mod.rs
@@ -8,6 +8,7 @@ pub mod assignment;
 pub mod binaryish;
 pub mod control_structure;
 pub mod expression;
+pub mod statement;
 pub mod string;
 
 #[test]

--- a/crates/formatter/tests/format/statement.rs
+++ b/crates/formatter/tests/format/statement.rs
@@ -1,0 +1,390 @@
+use indoc::indoc;
+
+use mago_formatter::settings::FormatSettings;
+
+use crate::test_format;
+
+#[test]
+pub fn test_use_basic_sorting() {
+    let code = indoc! {r#"
+        <?php
+
+        use B;
+        use A;
+        use function D;
+        use function C;
+        use const F;
+        use const E;
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        use A;
+        use B;
+        use function C;
+        use function D;
+        use const E;
+        use const F;
+    "#};
+
+    test_format(
+        code,
+        expected,
+        FormatSettings { sort_uses: true, separate_use_types: false, ..FormatSettings::default() },
+    );
+}
+
+#[test]
+pub fn test_use_sorting_with_separation() {
+    let code = indoc! {r#"
+        <?php
+
+        use B;
+        use A;
+        use function D;
+        use function C;
+        use const F;
+        use const E;
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        use A;
+        use B;
+
+        use function C;
+        use function D;
+
+        use const E;
+        use const F;
+    "#};
+
+    test_format(
+        code,
+        expected,
+        FormatSettings { sort_uses: true, separate_use_types: true, ..FormatSettings::default() },
+    );
+}
+
+#[test]
+pub fn test_use_sorting_with_expansion() {
+    let code = indoc! {r#"
+        <?php
+
+        use Example\B;
+        use Example\{A, C};
+        use function Example\e;
+        use function Example\{d, f};
+        use const Example\H;
+        use const Example\{G, I};
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        use Example\A;
+        use Example\B;
+        use Example\C;
+        use function Example\d;
+        use function Example\e;
+        use function Example\f;
+        use const Example\G;
+        use const Example\H;
+        use const Example\I;
+    "#};
+
+    test_format(
+        code,
+        expected,
+        FormatSettings {
+            sort_uses: true,
+            expand_use_groups: true,
+            separate_use_types: false,
+            ..FormatSettings::default()
+        },
+    );
+}
+
+#[test]
+pub fn test_use_sorting_separation_expansion() {
+    let code = indoc! {r#"
+        <?php
+
+        use B;
+        use A;
+        use Foo\{Bar, Baz};
+        use function D;
+        use function C;
+        use function Qux\{Quuz\Corgi, Quux};
+        use const F;
+        use const E;
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        use A;
+        use B;
+        use Foo\Bar;
+        use Foo\Baz;
+
+        use function C;
+        use function D;
+        use function Qux\Quux;
+        use function Qux\Quuz\Corgi;
+
+        use const E;
+        use const F;
+    "#};
+
+    test_format(code, expected, FormatSettings::default());
+}
+
+#[test]
+pub fn test_use_no_changes() {
+    let code = indoc! {r#"
+        <?php
+
+        use B;
+        use A;
+        use function D;
+        use function C;
+        use const F;
+        use const E;
+        use Foo\{Bar, Baz};
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        use B;
+        use A;
+        use function D;
+        use function C;
+        use const F;
+        use const E;
+        use Foo\{Bar, Baz};
+    "#};
+
+    test_format(
+        code,
+        expected,
+        FormatSettings {
+            expand_use_groups: false,
+            sort_uses: false,
+            separate_use_types: false,
+            ..FormatSettings::default()
+        },
+    );
+}
+
+#[test]
+pub fn test_use_mixed_use_list() {
+    let code = indoc! {r#"
+        <?php
+
+        use MyNamespace\{
+            const C,
+            function F as funcF,
+            A,
+            B,
+            function G,
+            const D as constD,
+        };
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        use MyNamespace\{A, B, function F as funcF, function G, const C, const D as constD};
+    "#};
+
+    test_format(code, expected, FormatSettings { expand_use_groups: false, ..FormatSettings::default() });
+}
+
+#[test]
+pub fn test_use_mixed_use_list_expanded() {
+    let code = indoc! {r#"
+        <?php
+
+        use MyNamespace\{
+            const C,
+            function F as funcF,
+            A,
+            B,
+            function G,
+            const D as constD,
+        };
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        use MyNamespace\A;
+        use MyNamespace\B;
+
+        use function MyNamespace\F as funcF;
+        use function MyNamespace\G;
+
+        use const MyNamespace\C;
+        use const MyNamespace\D as constD;
+    "#};
+
+    test_format(
+        code,
+        expected,
+        FormatSettings {
+            sort_uses: true,
+            expand_use_groups: true,
+            separate_use_types: true,
+            ..FormatSettings::default()
+        },
+    );
+}
+
+#[test]
+pub fn test_use_typed_use_list_expanded() {
+    let code = indoc! {r#"
+        <?php
+
+        use function MyNamespace\{
+            F as funcF,
+            G,
+        };
+        use const MyNamespace2\{
+            C,
+            D as constD,
+        };
+
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        use function MyNamespace\F as funcF;
+        use function MyNamespace\G;
+
+        use const MyNamespace2\C;
+        use const MyNamespace2\D as constD;
+    "#};
+
+    test_format(
+        code,
+        expected,
+        FormatSettings {
+            sort_uses: true,
+            expand_use_groups: true,
+            separate_use_types: true,
+            ..FormatSettings::default()
+        },
+    );
+}
+
+#[test]
+pub fn test_use_nested_namespaces_expanded() {
+    let code = indoc! {r#"
+        <?php
+
+        use Foo\Bar\Baz;
+        use Foo\Bar;
+        use Foo;
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        use Foo;
+        use Foo\Bar;
+        use Foo\Bar\Baz;
+    "#};
+
+    test_format(
+        code,
+        expected,
+        FormatSettings { sort_uses: true, expand_use_groups: true, ..FormatSettings::default() },
+    );
+}
+
+#[test]
+pub fn test_adds_empty_line_after_use() {
+    let code = indoc! {r#"
+        <?php
+
+        use Foo;
+        class A extends Foo {}
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        use Foo;
+
+        class A extends Foo
+        {
+        }
+    "#};
+
+    test_format(code, expected, FormatSettings::default());
+}
+
+#[test]
+pub fn test_leaves_single_empty_line_after_use() {
+    let code = indoc! {r#"
+        <?php
+
+        use Foo;
+
+
+
+        class A extends Foo
+        {
+        }
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        use Foo;
+
+        class A extends Foo
+        {
+        }
+    "#};
+
+    test_format(code, expected, FormatSettings::default());
+}
+
+#[test]
+pub fn test_docs_before_use_are_preserved() {
+    let code = indoc! {r#"
+        <?php
+
+        /**
+         * This is a doc comment
+         */
+
+        use Foo; // This is a use statement
+
+        class A extends Foo
+        {
+        }
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        /**
+         * This is a doc comment
+         */
+
+        use Foo; // This is a use statement
+
+        class A extends Foo
+        {
+        }
+    "#};
+
+    test_format(code, expected, FormatSettings::default());
+}

--- a/docs/formatter/settings.md
+++ b/docs/formatter/settings.md
@@ -323,3 +323,39 @@ Controls whether a line break is added before or after binary operators when bre
   ```
 
 > This setting will always be false if the rhs of the binary operator has a leading comment.
+
+### `sort_uses`
+
+Whether to sort use statements alphabetically.
+
+- Default: `true`
+- Type: `boolean`
+- Example:
+
+  ```toml
+  sort_uses = true
+  ```
+
+### `separate_use_types`
+
+Whether to insert a blank line between different types of use statements (e.g., classes, functions, constants).
+
+- Default: `true`
+- Type: `boolean`
+- Example:
+
+  ```toml
+  separate_use_types = false
+  ```
+
+### `expand_use_groups`
+
+Whether to expand grouped use statements into individual statements.
+
+- Default: `true`
+- Type: `boolean`
+- Example:
+
+  ```toml
+  expand_use_groups = false
+  ```

--- a/src/config/formatter.rs
+++ b/src/config/formatter.rs
@@ -123,6 +123,18 @@ pub struct FormatterConfiguration {
     /// Whether to add a line before a binary operator or after if it is broken.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub line_before_binary_operator: Option<bool>,
+
+    /// Whether to sort `use` statements.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sort_uses: Option<bool>,
+
+    /// Whether to separate `use` statements by type.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub separate_use_types: Option<bool>,
+
+    /// Whether to expand `use` groups.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expand_use_groups: Option<bool>,
 }
 
 impl FormatterConfiguration {
@@ -170,6 +182,9 @@ impl FormatterConfiguration {
             line_before_binary_operator: self
                 .line_before_binary_operator
                 .unwrap_or(default.line_before_binary_operator),
+            sort_uses: self.sort_uses.unwrap_or(default.sort_uses),
+            separate_use_types: self.separate_use_types.unwrap_or(default.separate_use_types),
+            expand_use_groups: self.expand_use_groups.unwrap_or(default.expand_use_groups),
         }
     }
 }


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR introduces three new settings to the formatter: `sort_uses`, `separate_use_types`, and `expand_use_groups`. These settings control the formatting of use statements in PHP code, allowing for sorting, grouping by type (function, const, or regular), and expanding grouped use statements into individual statements.

## 🔍 Context & Motivation

Currently, the formatter has limited control over use statement formatting. This PR addresses user requests for more control over the organization of imports, enhancing code readability and maintainability. It provides options similar to those found in other popular code formatters and linters (e.g., isort in Python, various linters in JavaScript).  Sorting and grouping imports can significantly improve the structure and clarity of large codebases.

## 🛠️ Summary of Changes

- **Feature:** Added sort_uses, separate_use_types, and expand_use_groups settings to control use statement formatting.
- **Feature:** Implemented sorting, grouping, and expansion logic for use statements.
- **Docs:** Updated documentation to reflect the new settings (Note: A separate documentation PR will follow if needed, or this entry can point to the updated files within this PR if docs are included).

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [x] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [x] Documentation
- [ ] Other (please specify):

## ⭐ Example:

### Before:

```php
<?php

declare(strict_types=1);

namespace FormattingUseStatementsExample;

use Mago\Example\Sample\Sample3Trait;
use function Mago\Example\Sample\sample_function_2;
use Mago\Example\Sample\Sample1Class;
use Mago\Example\Sample\Sample2Interface;
use function Mago\Example\Sample\sample_function_1;
use const Mago\Example\Sample\SAMPLE_CONSTANT;
use Mago\Example\{
    Sample\Sample4Class,
    function Sample\sample_function_3,
    const Sample\SAMPLE_CONSTANT_2
};
class Example {}
```

### After:

```php
<?php

declare(strict_types=1);

namespace FormattingUseStatementsExample;

use Mago\Example\Sample\Sample1Class;
use Mago\Example\Sample\Sample2Interface;
use Mago\Example\Sample\Sample3Trait;
use Mago\Example\Sample\Sample4Class;

use function Mago\Example\Sample\sample_function_1;
use function Mago\Example\Sample\sample_function_2;
use function Mago\Example\Sample\sample_function_3;

use const Mago\Example\Sample\SAMPLE_CONSTANT;
use const Mago\Example\Sample\SAMPLE_CONSTANT_2;

class Example
{
}
```
