### PR TITLE
fix(formatter): fix alignment of indented php code within html

### DIFF
--- a/crates/ast/src/ast/construct.rs
+++ b/crates/ast/src/ast/construct.rs
@@ -102,6 +102,30 @@ pub struct DieConstruct {
     pub arguments: Option<ArgumentList>,
 }
 
+impl Construct {
+    #[must_use]
+    #[inline(always)]
+    pub const fn is_import(&self) -> bool {
+        matches!(
+            self,
+            Construct::Include(_) | Construct::IncludeOnce(_) | Construct::Require(_) | Construct::RequireOnce(_)
+        )
+    }
+
+    #[must_use]
+    #[inline(always)]
+    pub const fn has_bounds(&self) -> bool {
+        !matches!(
+            self,
+            Construct::Include(_)
+                | Construct::IncludeOnce(_)
+                | Construct::Require(_)
+                | Construct::RequireOnce(_)
+                | Construct::Print(_)
+        )
+    }
+}
+
 impl HasSpan for Construct {
     fn span(&self) -> Span {
         match self {

--- a/crates/ast/src/ast/terminator.rs
+++ b/crates/ast/src/ast/terminator.rs
@@ -23,6 +23,20 @@ pub enum Terminator {
     TagPair(ClosingTag, OpeningTag),
 }
 
+impl Terminator {
+    #[must_use]
+    #[inline(always)]
+    pub const fn is_semicolon(&self) -> bool {
+        matches!(self, Terminator::Semicolon(_))
+    }
+
+    #[must_use]
+    #[inline(always)]
+    pub const fn is_closing_tag(&self) -> bool {
+        matches!(self, Terminator::ClosingTag(_))
+    }
+}
+
 impl HasSpan for Terminator {
     fn span(&self) -> Span {
         match self {

--- a/crates/formatter/src/document/mod.rs
+++ b/crates/formatter/src/document/mod.rs
@@ -36,6 +36,13 @@ pub enum Document<'a> {
     Fill(Fill<'a>),
     /// Include this anywhere to force all parent groups to break.
     BreakParent,
+    Align(Align<'a>),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct Align<'a> {
+    pub alignment: &'a str,
+    pub contents: Vec<Document<'a>>,
 }
 
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
@@ -313,5 +320,8 @@ fn print_doc_to_debug(doc: &Document) -> String {
             format!("fill([{}])", parts.iter().map(|p| print_doc_to_debug(p)).collect::<Vec<_>>().join(", "))
         }
         Document::BreakParent => "breakParent".to_string(),
+        Document::Align(Align { alignment, contents }) => {
+            format!("dedentToRoot(align({:?}, {}))", alignment, print_doc_to_debug(&Document::Array(contents.clone())))
+        }
     }
 }

--- a/crates/formatter/src/parens.rs
+++ b/crates/formatter/src/parens.rs
@@ -254,6 +254,10 @@ impl<'a> Formatter<'a> {
             return true;
         }
 
+        if let Expression::Construct(construct) = expression {
+            return !construct.has_bounds();
+        }
+
         !matches!(
             expression,
             Expression::Literal(_)
@@ -262,7 +266,6 @@ impl<'a> Formatter<'a> {
                 | Expression::ArrayAccess(_)
                 | Expression::Variable(_)
                 | Expression::Identifier(_)
-                | Expression::Construct(_)
                 | Expression::Call(_)
                 | Expression::Access(_)
                 | Expression::ClosureCreation(_)

--- a/crates/formatter/src/settings.rs
+++ b/crates/formatter/src/settings.rs
@@ -642,7 +642,8 @@ impl MethodChainBreakingStyle {
 }
 
 impl EndOfLine {
-    pub fn as_str(&self) -> &'static str {
+    #[inline(always)]
+    pub const fn as_str(&self) -> &'static str {
         match self {
             Self::Crlf => "\r\n",
             Self::Cr => "\r",

--- a/crates/formatter/src/utils.rs
+++ b/crates/formatter/src/utils.rs
@@ -1,6 +1,7 @@
 use mago_ast::*;
 
 use crate::Formatter;
+use crate::document::Align;
 use crate::document::Document;
 use crate::document::IndentIfBreak;
 use crate::document::Separator;
@@ -117,10 +118,11 @@ pub fn will_break(document: &mut Document<'_>) -> bool {
             check_array(&mut group.contents)
         }
         Document::IfBreak(d) => will_break(&mut d.break_contents),
-        Document::Array(arr)
-        | Document::Indent(arr)
-        | Document::LineSuffix(arr)
-        | Document::IndentIfBreak(IndentIfBreak { contents: arr, .. }) => check_array(arr),
+        Document::Array(contents)
+        | Document::Indent(contents)
+        | Document::LineSuffix(contents)
+        | Document::IndentIfBreak(IndentIfBreak { contents, .. })
+        | Document::Align(Align { contents, .. }) => check_array(contents),
         Document::Fill(doc) => check_array(&mut doc.parts),
         Document::Line(doc) => doc.hard,
         Document::String(_) | Document::LineSuffixBoundary => false,

--- a/crates/formatter/tests/format/mixed.rs
+++ b/crates/formatter/tests/format/mixed.rs
@@ -1,0 +1,186 @@
+use indoc::indoc;
+
+use mago_formatter::settings::FormatSettings;
+
+use crate::test_format;
+
+#[test]
+pub fn test_parenthesis_around_closure() {
+    let code = indoc! {r#"
+        <?php
+
+        $result = ($fib = function($n) use (&$fib) {
+            return $n <= 1 ? $n : $fib($n - 1) + $fib($n - 2);
+        })(10);
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        $result = ($fib = function ($n) use (&$fib) {
+            return $n <= 1 ? $n : ($fib($n - 1) + $fib($n - 2));
+        })(10);
+    "#};
+
+    test_format(code, expected, FormatSettings::default())
+}
+
+#[test]
+pub fn test_keyword_as_method_name() {
+    let code = indoc! {r#"
+        <?php
+
+        $unit = $unitNode?->print($context);
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        $unit = $unitNode?->print($context);
+    "#};
+
+    test_format(code, expected, FormatSettings::default())
+}
+
+#[test]
+pub fn test_long_attribute() {
+    let code = indoc! {r#"
+        <?php
+
+        #[Route('route/path', name: 'very_very_very_very_very_very_long_route_name', methods: ['GET'])]
+        class Foo {}
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        #[Route(
+            'route/path',
+            name: 'very_very_very_very_very_very_long_route_name',
+            methods: ['GET'],
+        )]
+        class Foo
+        {
+        }
+    "#};
+
+    test_format(code, expected, FormatSettings { print_width: 80, ..FormatSettings::default() })
+}
+
+#[test]
+pub fn test_parenthesis_around_construct() {
+    let code = indoc! {r#"
+        <?php
+
+        (require_once __DIR__ . '/../bootstrap/app.php')->handleRequest(Request::capture());
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        (require_once __DIR__ . '/../bootstrap/app.php')->handleRequest(Request::capture());
+    "#};
+
+    test_format(code, expected, FormatSettings::default())
+}
+
+#[test]
+pub fn test_interpolated_strings_are_preserved() {
+    let code = indoc! {r#"
+        <?php
+
+        "$foo[$index_var]";
+        "${foo[$index_var]}";
+        "{$foo[$index_var]}";
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        "$foo[$index_var]";
+        "${foo[$index_var]}";
+        "{$foo[$index_var]}";
+    "#};
+
+    test_format(code, expected, FormatSettings::default())
+}
+
+#[test]
+pub fn test_closure_creation_is_not_broken_like_argument_lists() {
+    let code = indoc! {r#"
+        <?php
+
+        return $this->longMethodName(
+
+
+                                $this->longPropertyName->evenLongerMethodNameNowCausesTheDotsToWrapWithComma(...),
+
+                        );
+
+
+        return $this->longMethodName(
+            $this->longPropertyName->evenLongerMethodNameNowCausesTheDotsToWrapWithComma(1, 2),
+                );
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        return $this->longMethodName($this->longPropertyName->evenLongerMethodNameNowCausesTheDotsToWrapWithComma(...));
+
+        return $this->longMethodName($this->longPropertyName->evenLongerMethodNameNowCausesTheDotsToWrapWithComma(
+            1,
+            2,
+        ));
+    "#};
+
+    test_format(code, expected, FormatSettings { print_width: 40, ..FormatSettings::default() })
+}
+
+#[test]
+pub fn test_parenthesis_are_preserved() {
+    let code = indoc! {r#"
+        <?php
+
+        var_dump((1 ? 2 : 3) ?: 4);
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        var_dump((1 ? 2 : 3) ?: 4);
+    "#};
+
+    test_format(code, expected, FormatSettings { print_width: 40, ..FormatSettings::default() })
+}
+
+#[test]
+pub fn test_attributes_are_preserved() {
+    let code = indoc! {r#"
+        <?php
+
+        #[ATTRIBUTE]
+        function aaa(
+          int $bbb,
+          // this comment causes attribute to dissappear
+          int $ccc
+        ) {
+          var_dump('test');
+        }
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        #[ATTRIBUTE]
+        function aaa(
+            int $bbb,
+            // this comment causes attribute to dissappear
+            int $ccc,
+        ) {
+            var_dump('test');
+        }
+    "#};
+
+    test_format(code, expected, FormatSettings { print_width: 40, ..FormatSettings::default() })
+}

--- a/crates/formatter/tests/format/mod.rs
+++ b/crates/formatter/tests/format/mod.rs
@@ -9,6 +9,7 @@ pub mod assignment;
 pub mod binaryish;
 pub mod control_structure;
 pub mod expression;
+pub mod mixed;
 pub mod statement;
 pub mod string;
 
@@ -65,6 +66,47 @@ pub fn test_inline_html() {
 }
 
 #[test]
+pub fn test_inline_html_alignment() {
+    let code = indoc! {r#"
+        <?php if ($foo) { ?>
+            <?= strtr($this->trace, [
+                '#DD0000' => 'var(--string)',
+            '#007700' => 'var(--keyword)',
+                '#0000BB' => 'var(--default)',
+                '#FF8000' => 'var(--comment)',
+            ]) ?>
+
+            <?= strtr($this->trace, [
+                    '#DD0000' => 'var(--string)',
+                 '#007700' => 'var(--keyword)',
+                     '#0000BB' => 'var(--default)',
+                    '#FF8000' => 'var(--comment)',
+                ]); ?>
+        <?php } ?>
+    "#};
+
+    let expected = indoc! {r#"
+        <?php if ($foo) { ?>
+            <?= strtr($this->trace, [
+                '#DD0000' => 'var(--string)',
+                '#007700' => 'var(--keyword)',
+                '#0000BB' => 'var(--default)',
+                '#FF8000' => 'var(--comment)',
+            ]) ?>
+
+            <?= strtr($this->trace, [
+                '#DD0000' => 'var(--string)',
+                '#007700' => 'var(--keyword)',
+                '#0000BB' => 'var(--default)',
+                '#FF8000' => 'var(--comment)',
+            ]); ?>
+        <?php }
+    "#};
+
+    test_format(code, expected, FormatSettings::default())
+}
+
+#[test]
 pub fn test_inline_php() {
     let code = indoc! {r#"
         <div class="mx-2 mb-1 mt-<?= $marginTop ?>">
@@ -113,6 +155,130 @@ pub fn test_inline_echo_statements() {
             ]); ?>
             </div>
         <?php }
+    "#};
+
+    test_format(code, expected, FormatSettings::default());
+}
+
+#[test]
+pub fn test_html_template() {
+    let code = indoc! {r#"
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <title>Extremely Nested PHP Template</title>
+        </head>
+        <body>
+            <h1>Welcome to the Jungle!</h1>
+            <?php
+            $level1 = "Level 1";
+          ?>
+            <div class="level1">
+                <?php echo $level1; /* hrrr */?>
+                <?php
+
+          // This is a comment
+                $level2 = "Level 2";
+                    // Another comment
+              ?>
+                <p>
+                    <?php echo $level2;?>
+                    <ul>
+                        <?php
+                        $items = ['item1', 'item2', 'item3'];
+                        foreach ($items as $item):
+                      ?>
+                        <li>
+                            <?php echo $item;?>
+                            <?php
+                            $level3 = "Level 3";
+                          ?>
+                            <span class="level3">
+                                <?php echo $level3;?>
+                                <?php if (true):?>
+                                    <div class="level4">
+                                        <?php
+                                        $level4 = "Level 4";
+                                        echo $level4;
+                                      ?>
+                                        <?php for ($i = 0; $i < 3; $i++):?>
+                                            <p>
+                                                <?php
+                                                $level5 = "Level 5";
+                                                echo $level5. " - ". $i;
+                                              ?>
+                                            </p>
+                                        <?php endfor;?>
+                                    </div>
+                                <?php endif;?>
+                            </span>
+                        </li>
+                        <?php endforeach;?>
+                    </ul>
+                </p>
+            </div>
+        </body>
+        </html>
+    "#};
+
+    let expected = indoc! {r#"
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <title>Extremely Nested PHP Template</title>
+        </head>
+        <body>
+            <h1>Welcome to the Jungle!</h1>
+            <?php
+            $level1 = 'Level 1';
+            ?>
+            <div class="level1">
+                <?php echo $level1 /* hrrr */; ?>
+                <?php
+
+                // This is a comment
+                $level2 = 'Level 2';
+                // Another comment
+                ?>
+                <p>
+                    <?php echo $level2; ?>
+                    <ul>
+                        <?php
+                        $items = ['item1', 'item2', 'item3'];
+                        foreach ($items as $item): ?>
+                        <li>
+                            <?php echo $item; ?>
+                            <?php
+                            $level3 = 'Level 3';
+                            ?>
+                            <span class="level3">
+                                <?php echo $level3; ?>
+                                <?php if (true): ?>
+                                    <div class="level4">
+                                        <?php
+                                        $level4 = 'Level 4';
+                                        echo $level4;
+                                        ?>
+                                        <?php for ($i = 0; $i < 3; $i++): ?>
+                                            <p>
+                                                <?php
+                                                $level5 = 'Level 5';
+                                                echo $level5 . ' - ' . $i;
+                                                ?>
+                                            </p>
+                                        <?php endfor; ?>
+                                    </div>
+                                <?php endif; ?>
+                            </span>
+                        </li>
+                        <?php endforeach; ?>
+                    </ul>
+                </p>
+            </div>
+        </body>
+        </html>
     "#};
 
     test_format(code, expected, FormatSettings::default());

--- a/crates/source/src/lib.rs
+++ b/crates/source/src/lib.rs
@@ -181,6 +181,23 @@ impl Source {
         self.lines.get(line).copied()
     }
 
+    /// Retrieve the byte offset for the end of the given line.
+    ///
+    /// # Parameters
+    ///
+    /// - `line`: The line number to retrieve the end offset for.
+    ///
+    /// # Returns
+    ///
+    /// The byte offset for the end of the given line (0-based index).
+    pub fn get_line_end_offset(&self, line: usize) -> Option<usize> {
+        match self.lines.get(line + 1) {
+            Some(&end) => Some(end - 1),
+            None if line == self.lines.len() - 1 => Some(self.size),
+            _ => None,
+        }
+    }
+
     /// Retrieve the column number for the given byte offset.
     ///
     /// # Parameters


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR adds the `Align` document type to the formatter and fixes bugs related to the indentation and alignment of PHP code within HTML files. It also includes several new tests to ensure the correctness of the formatter.

## 🔍 Context & Motivation

The formatter was not handling the indentation and alignment of PHP code within HTML files correctly. This was due to the lack of a proper mechanism to align the content based on the indentation of the opening tag. This PR introduces the `Align` document type, which allows for more precise control over indentation and alignment, similar to the `align` type in Prettier.js. This change ensures that PHP code within HTML files is formatted consistently and correctly.

## 🛠️ Summary of Changes

- **Feature:** Added `Align` document type to the formatter.
- **Bug Fix:** Fixed incorrect indentation and alignment of PHP code within HTML files.
- **Refactor:** Updated the `Indent` struct and related functions to better handle indentation and alignment.
- **Tests:** Added new tests for the `Align` document type and other formatting scenarios.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Tests
- [ ] Other (please specify):
