### PR TITLE
feat(formatter): add `remove_trailing_close_tag` option

### DIFF
--- a/crates/formatter/src/document/group.rs
+++ b/crates/formatter/src/document/group.rs
@@ -18,6 +18,7 @@ impl GroupIdentifierBuilder {
         Self { id: GroupIdentifier(0) }
     }
 
+    #[inline]
     pub fn next_id(&mut self) -> GroupIdentifier {
         self.id += 1;
         self.id
@@ -25,6 +26,7 @@ impl GroupIdentifierBuilder {
 }
 
 impl AddAssign<usize> for GroupIdentifier {
+    #[inline]
     fn add_assign(&mut self, rhs: usize) {
         self.0 += rhs;
     }

--- a/crates/formatter/src/document/mod.rs
+++ b/crates/formatter/src/document/mod.rs
@@ -37,6 +37,16 @@ pub enum Document<'a> {
     /// Include this anywhere to force all parent groups to break.
     BreakParent,
     Align(Align<'a>),
+    /// Trim all newlines from the end of the document.
+    Trim(Trim),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub enum Trim {
+    /// Trims trailing whitespace characters (spaces and tabs) from the end of the document.
+    Whitespace,
+    /// Removes all newline characters from the end of the document.
+    Newlines,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
@@ -323,5 +333,6 @@ fn print_doc_to_debug(doc: &Document) -> String {
         Document::Align(Align { alignment, contents }) => {
             format!("dedentToRoot(align({:?}, {}))", alignment, print_doc_to_debug(&Document::Array(contents.clone())))
         }
+        Document::Trim(_) => "trim".to_string(),
     }
 }

--- a/crates/formatter/src/format/mod.rs
+++ b/crates/formatter/src/format/mod.rs
@@ -171,12 +171,12 @@ impl<'a> Format<'a> for ClosingTag {
         f.scripting_mode = false;
 
         wrap!(f, self, ClosingTag, {
-            let last_index = self.span.end.offset;
-            // todo: put this behind a setting
-            if f.skip_spaces_and_new_lines(Some(last_index), false).is_none() {
+            if f.settings.remove_trailing_close_tag
+                && f.skip_spaces_and_new_lines(Some(self.span.end.offset), false).is_none()
+            {
                 f.scripting_mode = true;
 
-                Document::empty()
+                Document::Trim(Trim::Newlines)
             } else {
                 Document::Array(vec![Document::LineSuffixBoundary, Document::String("?>")])
             }

--- a/crates/formatter/src/lib.rs
+++ b/crates/formatter/src/lib.rs
@@ -27,6 +27,18 @@ mod parens;
 mod printer;
 mod utils;
 
+/// Format the given program.
+///
+/// # Arguments
+///
+/// * `interner` - The interner to use for string interning.
+/// * `source` - The source to use for the program.
+/// * `program` - A `Program` struct representing the AST of the program to format.
+/// * `settings` - A `FormatSettings` struct that contains the settings to use for formatting.
+///
+/// # Returns
+///
+/// The formatted program as a string.
 pub fn format<'a>(
     interner: &'a ThreadedInterner,
     source: &'a Source,
@@ -38,11 +50,13 @@ pub fn format<'a>(
     formatter.format(program)
 }
 
+#[derive(Debug)]
 struct ArgumentState {
     expand_first_argument: bool,
     expand_last_argument: bool,
 }
 
+#[derive(Debug)]
 pub struct Formatter<'a> {
     interner: &'a ThreadedInterner,
     source: &'a Source,
@@ -93,43 +107,52 @@ impl<'a> Formatter<'a> {
         self.interner.lookup(string)
     }
 
+    #[inline]
     fn as_str(&self, string: impl AsRef<str>) -> &'a str {
         self.interner.interned_str(string)
     }
 
+    #[inline]
     fn enter_node(&mut self, node: Node<'a>) {
         self.stack.push(node);
     }
 
+    #[inline]
     fn leave_node(&mut self) {
         self.stack.pop();
     }
 
+    #[inline]
     fn current_node(&self) -> Node<'a> {
         self.stack[self.stack.len() - 1]
     }
 
+    #[inline]
     fn parent_node(&self) -> Node<'a> {
         self.stack[self.stack.len() - 2]
     }
 
+    #[inline]
     fn grandparent_node(&self) -> Option<Node<'a>> {
         let len = self.stack.len();
 
         (len > 2).then(|| self.stack[len - 2 - 1])
     }
 
+    #[inline]
     fn great_grandparent_node(&self) -> Option<Node<'a>> {
         let len = self.stack.len();
         (len > 3).then(|| self.stack[len - 3 - 1])
     }
 
+    #[inline]
     fn nth_parent_kind(&self, n: usize) -> Option<Node<'a>> {
         let len = self.stack.len();
 
         (len > n).then(|| self.stack[len - n - 1])
     }
 
+    #[inline]
     fn is_previous_line_empty(&self, start_index: usize) -> bool {
         let idx = start_index - 1;
         let idx = self.skip_spaces(Some(idx), true);
@@ -139,10 +162,12 @@ impl<'a> Formatter<'a> {
         idx != idx2
     }
 
+    #[inline]
     fn is_next_line_empty(&self, span: Span) -> bool {
         self.is_next_line_empty_after_index(span.end.offset)
     }
 
+    #[inline]
     fn is_next_line_empty_after_index(&self, start_index: usize) -> bool {
         let mut old_idx = None;
         let mut idx = Some(start_index);
@@ -158,6 +183,7 @@ impl<'a> Formatter<'a> {
         idx.is_some_and(|idx| self.has_newline(idx, /* backwards */ false))
     }
 
+    #[inline]
     fn skip_single_line_comments(&self, start_index: Option<usize>) -> Option<usize> {
         let start_index = start_index?;
         if start_index + 1 >= self.source_text.len() {
@@ -174,20 +200,24 @@ impl<'a> Formatter<'a> {
         }
     }
 
+    #[inline]
     fn skip_to_line_end(&self, start_index: Option<usize>) -> Option<usize> {
         let mut index = self.skip(start_index, false, |c| matches!(c, b' ' | b'\t' | b',' | b';'));
         index = self.skip_single_line_comments(index);
         index
     }
 
+    #[inline]
     fn skip_spaces(&self, start_index: Option<usize>, backwards: bool) -> Option<usize> {
         self.skip(start_index, backwards, |c| matches!(c, b' ' | b'\t'))
     }
 
+    #[inline]
     fn skip_spaces_and_new_lines(&self, start_index: Option<usize>, backwards: bool) -> Option<usize> {
         self.skip(start_index, backwards, |c| matches!(c, b' ' | b'\t' | b'\r' | b'\n'))
     }
 
+    #[inline]
     fn skip_everything_but_new_line(&self, start_index: Option<usize>, backwards: bool) -> Option<usize> {
         self.skip(start_index, backwards, |c| !matches!(c, b'\r' | b'\n'))
     }
@@ -220,6 +250,7 @@ impl<'a> Formatter<'a> {
         None
     }
 
+    #[inline]
     fn skip_newline(&self, start_index: Option<usize>, backwards: bool) -> Option<usize> {
         let start_index = start_index?;
         let c = if backwards {
@@ -235,6 +266,7 @@ impl<'a> Formatter<'a> {
         Some(start_index)
     }
 
+    #[inline]
     fn has_newline(&self, start_index: usize, backwards: bool) -> bool {
         if (backwards && start_index == 0) || (!backwards && start_index == self.source_text.len()) {
             return false;
@@ -245,10 +277,12 @@ impl<'a> Formatter<'a> {
         idx != idx2
     }
 
+    #[inline]
     fn split_lines(slice: &'a str) -> Vec<&'a str> {
         slice.split_inclusive('\n').map(|line| line.trim_end_matches('\n').trim_end_matches('\r')).collect()
     }
 
+    #[inline]
     fn skip_leading_whitespace_up_to(s: &'a str, indent: usize) -> &'a str {
         let mut position = 0;
         for (count, (i, b)) in s.bytes().enumerate().enumerate() {

--- a/crates/formatter/src/settings.rs
+++ b/crates/formatter/src/settings.rs
@@ -538,6 +538,12 @@ pub struct FormatSettings {
     /// ```
     #[serde(default = "default_true")]
     pub expand_use_groups: bool,
+
+    /// Whether to remove the trailing close tag.
+    ///
+    /// Default: true
+    #[serde(default = "default_true")]
+    pub remove_trailing_close_tag: bool,
 }
 
 impl Default for FormatSettings {
@@ -573,6 +579,7 @@ impl Default for FormatSettings {
             sort_uses: true,
             separate_use_types: true,
             expand_use_groups: true,
+            remove_trailing_close_tag: true,
         }
     }
 }

--- a/crates/formatter/src/utils.rs
+++ b/crates/formatter/src/utils.rs
@@ -125,7 +125,7 @@ pub fn will_break(document: &mut Document<'_>) -> bool {
         | Document::Align(Align { contents, .. }) => check_array(contents),
         Document::Fill(doc) => check_array(&mut doc.parts),
         Document::Line(doc) => doc.hard,
-        Document::String(_) | Document::LineSuffixBoundary => false,
+        Document::String(_) | Document::LineSuffixBoundary | Document::Trim(_) => false,
     }
 }
 

--- a/crates/formatter/tests/format/mod.rs
+++ b/crates/formatter/tests/format/mod.rs
@@ -361,3 +361,43 @@ pub fn test_php_85_constant_attributes() {
 
     test_format(code, expected, FormatSettings::default())
 }
+
+#[test]
+pub fn test_closing_tag_preserved() {
+    let code = indoc! {r#"
+        <?php
+
+        echo 'Hello, world!';
+
+        ?>
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        echo 'Hello, world!';
+
+        ?>
+    "#};
+
+    test_format(code, expected, FormatSettings { remove_trailing_close_tag: false, ..Default::default() })
+}
+
+#[test]
+pub fn test_closing_tag_removed() {
+    let code = indoc! {r#"
+        <?php
+
+        echo 'Hello, world!';
+
+        ?>
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        echo 'Hello, world!';
+    "#};
+
+    test_format(code, expected, FormatSettings { remove_trailing_close_tag: true, ..Default::default() })
+}

--- a/docs/formatter/settings.md
+++ b/docs/formatter/settings.md
@@ -359,3 +359,15 @@ Whether to expand grouped use statements into individual statements.
   ```toml
   expand_use_groups = false
   ```
+
+### `remove_trailing_close_tag`
+
+Whether to remove the trailing `?>` tag from PHP files.
+
+- Default: `true`
+- Type: `boolean`
+- Example:
+
+  ```toml
+  remove_trailing_close_tag = true
+  ```

--- a/src/config/formatter.rs
+++ b/src/config/formatter.rs
@@ -135,6 +135,10 @@ pub struct FormatterConfiguration {
     /// Whether to expand `use` groups.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expand_use_groups: Option<bool>,
+
+    /// Whether to remove the trailing close tag.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remove_trailing_close_tag: Option<bool>,
 }
 
 impl FormatterConfiguration {
@@ -185,6 +189,7 @@ impl FormatterConfiguration {
             sort_uses: self.sort_uses.unwrap_or(default.sort_uses),
             separate_use_types: self.separate_use_types.unwrap_or(default.separate_use_types),
             expand_use_groups: self.expand_use_groups.unwrap_or(default.expand_use_groups),
+            remove_trailing_close_tag: self.remove_trailing_close_tag.unwrap_or(default.remove_trailing_close_tag),
         }
     }
 }


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR introduces a new formatter option `remove_trailing_close_tag` to control whether the trailing `?>` tag should be removed from PHP files.

## 🔍 Context & Motivation

Previously, the formatter always removed the trailing `?>` tag from PHP files. This behavior is consistent with the PSR/PER coding standard, but it can be undesirable in some cases. This PR adds an option to make this behavior configurable, allowing users to choose whether to keep or remove the trailing closing tag.

Additionally, the previous implementation sometimes left trailing newlines when removing the closing tag, which could lead to inconsistent formatting after a second run of the formatter. This PR fixes this issue by ensuring that trailing newlines are removed at the same time the closing tag is removed.

## 🛠️ Summary of Changes

- **Feature:** Added remove_trailing_close_tag option to the formatter.
- **Bug Fix:** Fixed inconsistent removal of trailing newlines when removing the closing tag.
- **Docs:**  Updated formatter settings documentation to include the new option.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [x] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [x] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
