### PR TITLE
feat(formatter): add `space_before_enum_backing_type_hint_colon` option

### DIFF
--- a/crates/formatter/src/format/mod.rs
+++ b/crates/formatter/src/format/mod.rs
@@ -1124,8 +1124,11 @@ impl<'a> Format<'a> for Enum {
                 Document::space(),
                 self.name.format(f),
                 if let Some(backing_type_hint) = &self.backing_type_hint {
-                    // TODO: add an option to add a space before the colon
-                    backing_type_hint.format(f)
+                    if f.settings.space_before_enum_backing_type_hint_colon {
+                        Document::Array(vec![Document::space(), backing_type_hint.format(f)])
+                    } else {
+                        backing_type_hint.format(f)
+                    }
                 } else {
                     Document::empty()
                 },

--- a/crates/formatter/src/settings.rs
+++ b/crates/formatter/src/settings.rs
@@ -544,6 +544,22 @@ pub struct FormatSettings {
     /// Default: true
     #[serde(default = "default_true")]
     pub remove_trailing_close_tag: bool,
+
+    /// Whether to add a space before the colon in enum backing type hints.
+    ///
+    /// Example:
+    ///
+    /// ```php
+    /// enum Foo: int {}
+    ///
+    /// // or
+    ///
+    /// enum Foo : int {}
+    /// ```
+    ///
+    /// Default: false
+    #[serde(default = "default_false")]
+    pub space_before_enum_backing_type_hint_colon: bool,
 }
 
 impl Default for FormatSettings {
@@ -580,6 +596,7 @@ impl Default for FormatSettings {
             separate_use_types: true,
             expand_use_groups: true,
             remove_trailing_close_tag: true,
+            space_before_enum_backing_type_hint_colon: false,
         }
     }
 }

--- a/crates/formatter/tests/format/mod.rs
+++ b/crates/formatter/tests/format/mod.rs
@@ -401,3 +401,55 @@ pub fn test_closing_tag_removed() {
 
     test_format(code, expected, FormatSettings { remove_trailing_close_tag: true, ..Default::default() })
 }
+
+#[test]
+pub fn test_no_space_before_enum_backing_type_colon() {
+    let code = indoc! {r#"
+        <?php
+
+        enum Foo: int {
+            case bar;
+        }
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        enum Foo: int
+        {
+            case bar;
+        }
+    "#};
+
+    test_format(
+        code,
+        expected,
+        FormatSettings { space_before_enum_backing_type_hint_colon: false, ..Default::default() },
+    )
+}
+
+#[test]
+pub fn test_space_before_enum_backing_type_colon() {
+    let code = indoc! {r#"
+        <?php
+
+        enum Foo: int {
+            case bar;
+        }
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        enum Foo : int
+        {
+            case bar;
+        }
+    "#};
+
+    test_format(
+        code,
+        expected,
+        FormatSettings { space_before_enum_backing_type_hint_colon: true, ..Default::default() },
+    )
+}

--- a/docs/formatter/settings.md
+++ b/docs/formatter/settings.md
@@ -371,3 +371,15 @@ Whether to remove the trailing `?>` tag from PHP files.
   ```toml
   remove_trailing_close_tag = true
   ```
+
+### `space_before_enum_backing_type_hint_colon`
+
+Controls whether a space is added before the colon in enum backing type hints.
+
+- Default: `true`
+- Type: `boolean`
+- Example:
+
+  ```toml
+  space_before_enum_backing_type_hint_colon = false
+  ```

--- a/src/config/formatter.rs
+++ b/src/config/formatter.rs
@@ -139,6 +139,10 @@ pub struct FormatterConfiguration {
     /// Whether to remove the trailing close tag.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub remove_trailing_close_tag: Option<bool>,
+
+    /// Whether to add a space before the colon in enum backing type hints.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub space_before_enum_backing_type_hint_colon: Option<bool>,
 }
 
 impl FormatterConfiguration {
@@ -190,6 +194,9 @@ impl FormatterConfiguration {
             separate_use_types: self.separate_use_types.unwrap_or(default.separate_use_types),
             expand_use_groups: self.expand_use_groups.unwrap_or(default.expand_use_groups),
             remove_trailing_close_tag: self.remove_trailing_close_tag.unwrap_or(default.remove_trailing_close_tag),
+            space_before_enum_backing_type_hint_colon: self
+                .space_before_enum_backing_type_hint_colon
+                .unwrap_or(default.space_before_enum_backing_type_hint_colon),
         }
     }
 }


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR adds a new formatter option `space_before_enum_backing_type_hint_colon` to control whether a space should be added before the colon in enum type hints (e.g., `enum Foo: int` vs `enum Foo : int`).

## 🔍 Context & Motivation

Currently, the formatter does not add a space before the colon in enum type hints. However, some users may prefer to have a space for better readability. This PR introduces a configuration option to accommodate this preference, making the formatter more flexible.

## 🛠️ Summary of Changes

- **Feature:** Added space_before_enum_backing_type_hint_colon option to the formatter.
- **Tests:** Added new tests to verify the behavior of the new option.
- **Docs:** Updated formatter settings documentation to include the new option.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [x] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [x] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
