### PR TITLE
feat(formatter): add options to control parentheses in new expressions, exit, and die

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.30"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -364,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.30"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
 dependencies = [
  "anstream",
  "anstyle",
@@ -767,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
 
 [[package]]
 name = "encode_unicode"
@@ -849,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1468,9 +1468,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libredox"
@@ -1619,6 +1619,7 @@ dependencies = [
  "mago-ast",
  "mago-interner",
  "mago-parser",
+ "mago-php-version",
  "mago-source",
  "mago-span",
  "mago-token",
@@ -1890,9 +1891,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -2238,9 +2239,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "powerfmt"
@@ -2501,9 +2502,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.10"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34b5020fcdea098ef7d95e9f89ec15952123a4a039badd09fabebe9e963e839"
+checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2921,9 +2922,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
 dependencies = [
  "filetime",
  "libc",

--- a/crates/formatter/Cargo.toml
+++ b/crates/formatter/Cargo.toml
@@ -18,6 +18,7 @@ mago-source = { workspace = true }
 mago-span = { workspace = true }
 mago-token = { workspace = true }
 mago-interner = { workspace = true }
+mago-php-version = { workspace = true }
 ahash = { workspace = true }
 serde = { workspace = true }
 bitflags = { workspace = true }

--- a/crates/formatter/src/format/call_arguments.rs
+++ b/crates/formatter/src/format/call_arguments.rs
@@ -13,8 +13,21 @@ use super::misc::is_string_word_type;
 
 pub(super) fn print_call_arguments<'a>(f: &mut Formatter<'a>, expression: &CallLikeNode<'a>) -> Document<'a> {
     let Some(argument_list) = expression.arguments() else {
-        return Document::empty();
+        return if (expression.is_instantiation() && f.settings.parentheses_in_new_expression)
+            || (expression.is_exit_or_die_construct() && f.settings.parentheses_in_exit_and_die)
+        {
+            Document::String("()")
+        } else {
+            Document::empty()
+        };
     };
+
+    if argument_list.arguments.is_empty()
+        && ((expression.is_instantiation() && !f.settings.parentheses_in_new_expression)
+            || (expression.is_exit_or_die_construct() && !f.settings.parentheses_in_exit_and_die))
+    {
+        return Document::Array(f.print_inner_comment(argument_list.span()));
+    }
 
     print_argument_list(f, argument_list)
 }

--- a/crates/formatter/src/format/call_node.rs
+++ b/crates/formatter/src/format/call_node.rs
@@ -16,6 +16,16 @@ pub(super) enum CallLikeNode<'a> {
 }
 
 impl<'a> CallLikeNode<'a> {
+    #[inline]
+    pub const fn is_instantiation(&self) -> bool {
+        matches!(self, CallLikeNode::Instantiation(_))
+    }
+
+    #[inline]
+    pub const fn is_exit_or_die_construct(&self) -> bool {
+        matches!(self, CallLikeNode::DieConstruct(_) | CallLikeNode::ExitConstruct(_))
+    }
+
     pub fn arguments(&self) -> Option<&'a ArgumentList> {
         match self {
             CallLikeNode::Call(call) => Some(match call {

--- a/crates/formatter/src/format/expression.rs
+++ b/crates/formatter/src/format/expression.rs
@@ -402,16 +402,12 @@ impl<'a> Format<'a> for PrintConstruct {
 
 impl<'a> Format<'a> for ExitConstruct {
     fn format(&'a self, f: &mut Formatter<'a>) -> Document<'a> {
-        // TODO: add support to check what syntax to use `exit` or `die`
-        // and whether to use parentheses or not if there are no arguments
         wrap!(f, self, ExitConstruct, { print_call_like_node(f, CallLikeNode::ExitConstruct(self)) })
     }
 }
 
 impl<'a> Format<'a> for DieConstruct {
     fn format(&'a self, f: &mut Formatter<'a>) -> Document<'a> {
-        // TODO: add support to check what syntax to use `exit` or `die`
-        // and whether to use parentheses or not if there are no arguments
         wrap!(f, self, DieConstruct, { print_call_like_node(f, CallLikeNode::DieConstruct(self)) })
     }
 }

--- a/crates/formatter/src/lib.rs
+++ b/crates/formatter/src/lib.rs
@@ -6,6 +6,7 @@ use mago_ast::Program;
 use mago_ast::Trivia;
 use mago_interner::StringIdentifier;
 use mago_interner::ThreadedInterner;
+use mago_php_version::PHPVersion;
 use mago_source::Source;
 use mago_span::Span;
 
@@ -43,9 +44,10 @@ pub fn format<'a>(
     interner: &'a ThreadedInterner,
     source: &'a Source,
     program: &'a Program,
+    php_version: PHPVersion,
     settings: FormatSettings,
 ) -> String {
-    let mut formatter = Formatter::new(interner, source, settings);
+    let mut formatter = Formatter::new(interner, source, php_version, settings);
 
     formatter.format(program)
 }
@@ -61,6 +63,7 @@ pub struct Formatter<'a> {
     interner: &'a ThreadedInterner,
     source: &'a Source,
     source_text: &'a str,
+    php_version: PHPVersion,
     settings: FormatSettings,
     stack: Vec<Node<'a>>,
     comments: Peekable<IntoIter<Trivia>>,
@@ -70,11 +73,17 @@ pub struct Formatter<'a> {
 }
 
 impl<'a> Formatter<'a> {
-    pub fn new(interner: &'a ThreadedInterner, source: &'a Source, settings: FormatSettings) -> Self {
+    pub fn new(
+        interner: &'a ThreadedInterner,
+        source: &'a Source,
+        php_version: PHPVersion,
+        settings: FormatSettings,
+    ) -> Self {
         Self {
             interner,
             source,
             source_text: interner.lookup(&source.content),
+            php_version,
             settings,
             stack: vec![],
             comments: vec![].into_iter().peekable(),

--- a/crates/formatter/src/settings.rs
+++ b/crates/formatter/src/settings.rs
@@ -560,6 +560,69 @@ pub struct FormatSettings {
     /// Default: false
     #[serde(default = "default_false")]
     pub space_before_enum_backing_type_hint_colon: bool,
+
+    /// Controls whether to include parentheses around instantiation expressions
+    /// when they are followed by a member access operator (`->`).
+    ///
+    /// This option reflects the behavior introduced in PHP 8.4,
+    /// where parentheses can be omitted in such cases.
+    ///
+    /// If the configured version for the formatter is earlier than PHP 8.4,
+    /// the value of the formatter is always considered to be true.
+    ///
+    /// For example:
+    ///
+    /// ```php
+    /// $foo = new Foo->bar(); // `false`
+    ///
+    /// // or
+    ///
+    /// $foo = (new Foo)->bar(); // `true`
+    /// ```
+    ///
+    /// Default: `false`
+    #[serde(default = "default_false")]
+    pub parentheses_around_new_in_member_access: bool,
+
+    /// Controls whether to include parentheses in `new` expressions, even when no arguments are provided.
+    ///
+    /// If enabled, the formatter will add parentheses to `new` expressions that don't have them, making them more explicit.
+    ///
+    /// For example:
+    ///
+    /// ```php
+    /// $foo = new Foo(); // `parentheses_in_new_expression = true`
+    ///
+    /// // or
+    ///
+    /// $foo = new Foo;   // `parentheses_in_new_expression = false`
+    /// ```
+    ///
+    /// Default: `true`
+    #[serde(default = "default_true")]
+    pub parentheses_in_new_expression: bool,
+
+    /// Controls whether to include parentheses in `exit` and `die` constructs,
+    /// making them resemble function calls.
+    ///
+    /// If enabled, the formatter will add parentheses to `exit` and `die` statements
+    /// that don't have them.
+    ///
+    /// For example:
+    ///
+    /// ```php
+    /// exit(); // `parentheses_in_exit_and_die = true`
+    /// die();  // `parentheses_in_exit_and_die = true`
+    ///
+    /// // or
+    ///
+    /// exit;   // `parentheses_in_exit_and_die = false`
+    /// die;    // `parentheses_in_exit_and_die = false`
+    /// ```
+    ///
+    /// Default: `true` (Add parentheses for consistency)
+    #[serde(default = "default_true")]
+    pub parentheses_in_exit_and_die: bool,
 }
 
 impl Default for FormatSettings {
@@ -597,6 +660,9 @@ impl Default for FormatSettings {
             expand_use_groups: true,
             remove_trailing_close_tag: true,
             space_before_enum_backing_type_hint_colon: false,
+            parentheses_around_new_in_member_access: false,
+            parentheses_in_new_expression: true,
+            parentheses_in_exit_and_die: true,
         }
     }
 }

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -1,6 +1,7 @@
 use mago_formatter::settings::FormatSettings;
 use mago_interner::ThreadedInterner;
 use mago_parser::parse_source;
+use mago_php_version::PHPVersion;
 use mago_source::Source;
 
 pub mod comment;
@@ -18,17 +19,38 @@ pub mod parens;
 /// * `expected` - The expected result of formatting the code
 /// * `settings` - The settings to use when formatting the code
 pub fn test_format(code: impl AsRef<str>, expected: &str, settings: FormatSettings) {
+    test_format_with_version(code, expected, PHPVersion::PHP84, settings);
+}
+
+/// Test that the given code is formatted to the expected result.
+///
+/// This function will parse the given code, format it, parse the formatted code, and then format it again
+/// to ensure that the formatter is idempotent.
+///
+/// # Arguments
+///
+/// * `code` - The code to format
+/// * `expected` - The expected result of formatting the code
+/// * `php_version` - The PHP version to use when formatting the code
+/// * `settings` - The settings to use when formatting the code
+pub fn test_format_with_version(
+    code: impl AsRef<str>,
+    expected: &str,
+    php_version: PHPVersion,
+    settings: FormatSettings,
+) {
     let interner = ThreadedInterner::new();
 
     let code_source = Source::standalone(&interner, "code.php", code.as_ref());
     let (code_program, error) = parse_source(&interner, &code_source);
     assert_eq!(error, None, "Error parsing code");
-    let formatted_code = mago_formatter::format(&interner, &code_source, &code_program, settings);
+    let formatted_code = mago_formatter::format(&interner, &code_source, &code_program, php_version, settings);
     pretty_assertions::assert_eq!(expected, formatted_code, "Formatted code does not match expected");
 
     let formatted_code_source = Source::standalone(&interner, "formatted_code.php", &formatted_code);
     let (formatted_code_program, error) = parse_source(&interner, &formatted_code_source);
     assert_eq!(error, None, "Error parsing formatted code");
-    let reformatted_code = mago_formatter::format(&interner, &formatted_code_source, &formatted_code_program, settings);
+    let reformatted_code =
+        mago_formatter::format(&interner, &formatted_code_source, &formatted_code_program, php_version, settings);
     pretty_assertions::assert_eq!(expected, reformatted_code, "Reformatted code does not match expected");
 }

--- a/crates/formatter/tests/parens/callee.rs
+++ b/crates/formatter/tests/parens/callee.rs
@@ -1,8 +1,10 @@
 use indoc::indoc;
 
 use mago_formatter::settings::FormatSettings;
+use mago_php_version::PHPVersion;
 
 use crate::test_format;
+use crate::test_format_with_version;
 
 #[test]
 pub fn test_callee_needs_parens() {
@@ -27,4 +29,83 @@ pub fn test_callee_needs_parens() {
     "#};
 
     test_format(code, expected, FormatSettings::default())
+}
+
+#[test]
+pub fn test_instantiation_with_member_access_parentheses() {
+    let code = indoc! {r#"
+        <?php
+
+        $a = (new Foo)->something();
+        $a = (new Foo())->something();
+        $a = (new Foo(1, 2))->something();
+        $a = (new Foo(1, 2))->something()->else()->other()->thing();
+    "#};
+
+    let expected_php83 = indoc! {r#"
+        <?php
+
+        $a = (new Foo())->something();
+        $a = (new Foo())->something();
+        $a = (new Foo(1, 2))->something();
+        $a = (new Foo(1, 2))
+            ->something()
+            ->else()
+            ->other()
+            ->thing();
+    "#};
+
+    let expected_php84 = indoc! {r#"
+        <?php
+
+        $a = new Foo()->something();
+        $a = new Foo()->something();
+        $a = new Foo(1, 2)->something();
+        $a = new Foo(1, 2)
+            ->something()
+            ->else()
+            ->other()
+            ->thing();
+    "#};
+
+    let expected_php83_without_parens = indoc! {r#"
+        <?php
+
+        $a = (new Foo)->something();
+        $a = (new Foo)->something();
+        $a = (new Foo(1, 2))->something();
+        $a = (new Foo(1, 2))
+            ->something()
+            ->else()
+            ->other()
+            ->thing();
+    "#};
+
+    let expected_php84_without_parens = indoc! {r#"
+        <?php
+
+        $a = (new Foo)->something();
+        $a = (new Foo)->something();
+        $a = new Foo(1, 2)->something();
+        $a = new Foo(1, 2)
+            ->something()
+            ->else()
+            ->other()
+            ->thing();
+    "#};
+
+    test_format_with_version(code, expected_php83, PHPVersion::PHP83, FormatSettings::default());
+    test_format_with_version(code, expected_php84, PHPVersion::PHP84, FormatSettings::default());
+    test_format_with_version(
+        code,
+        expected_php83_without_parens,
+        PHPVersion::PHP83,
+        FormatSettings { parentheses_in_new_expression: false, ..FormatSettings::default() },
+    );
+    test_format_with_version(
+        code,
+        expected_php84_without_parens,
+        PHPVersion::PHP84,
+        FormatSettings { parentheses_in_new_expression: false, ..FormatSettings::default() },
+    );
 }

--- a/crates/wasm/src/analysis.rs
+++ b/crates/wasm/src/analysis.rs
@@ -114,7 +114,13 @@ impl AnalysisResults {
         let mut formatted = None;
         if module.parse_error.is_none() {
             // Only format if there are no parse errors
-            formatted = Some(mago_formatter::format(&interner, &module.source, &program, format_settings));
+            formatted = Some(mago_formatter::format(
+                &interner,
+                &module.source,
+                &program,
+                lint_settings.php_version,
+                format_settings,
+            ));
         }
 
         let linter =

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -183,7 +183,7 @@ pub fn mago_format(code: String, format_settings: JsValue) -> Result<JsValue, Js
     }
 
     // Format the parsed program
-    let formatted = mago_formatter::format(&interner, &source, &program, settings);
+    let formatted = mago_formatter::format(&interner, &source, &program, PHPVersion::PHP84, settings);
 
     // Return the formatted string
     Ok(JsValue::from_str(&formatted))

--- a/docs/formatter/settings.md
+++ b/docs/formatter/settings.md
@@ -383,3 +383,47 @@ Controls whether a space is added before the colon in enum backing type hints.
   ```toml
   space_before_enum_backing_type_hint_colon = false
   ```
+
+### `parentheses_around_new_in_member_access`
+
+Controls whether to include parentheses around instantiation expressions when they are followed by a member access operator (`->`).
+
+This option reflects the behavior introduced in PHP 8.4, where parentheses can be omitted in such cases.
+
+If the configured version for the formatter is earlier than PHP 8.4, the value of this option is always considered to be `true`.
+
+- Default: `false`
+- Type: `boolean`
+- Example:
+
+  ```toml
+  parentheses_around_new_in_member_access = false
+  ```
+
+### `parentheses_in_new_expression`
+
+Controls whether to include parentheses in `new` expressions, even when no arguments are provided.
+
+If enabled, the formatter will add parentheses to `new` expressions that don't have them, making them more explicit.
+
+- Default: `true`
+- Type: `boolean`
+- Example:
+
+  ```toml
+  parentheses_in_new_expression = false
+  ```
+
+### `parentheses_in_exit_and_die`
+
+Controls whether to include parentheses in `exit` and `die` constructs, making them resemble function calls.
+
+If enabled, the formatter will add parentheses to `exit` and `die` statements that don't have them.
+
+- Default: `true`
+- Type: `boolean`
+- Example:
+
+  ```toml
+  parentheses_in_exit_and_die = false
+  ```

--- a/src/config/formatter.rs
+++ b/src/config/formatter.rs
@@ -143,6 +143,20 @@ pub struct FormatterConfiguration {
     /// Whether to add a space before the colon in enum backing type hints.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub space_before_enum_backing_type_hint_colon: Option<bool>,
+
+    /// Controls whether to include parentheses around instantiation expressions
+    /// when they are followed by a member access operator (`->`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parentheses_around_new_in_member_access: Option<bool>,
+
+    /// Controls whether to include parentheses in `new` expressions, even when no arguments are provided.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parentheses_in_new_expression: Option<bool>,
+
+    /// Controls whether to include parentheses in `exit` and `die` constructs,
+    /// making them resemble function calls.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parentheses_in_exit_and_die: Option<bool>,
 }
 
 impl FormatterConfiguration {
@@ -197,6 +211,15 @@ impl FormatterConfiguration {
             space_before_enum_backing_type_hint_colon: self
                 .space_before_enum_backing_type_hint_colon
                 .unwrap_or(default.space_before_enum_backing_type_hint_colon),
+            parentheses_around_new_in_member_access: self
+                .parentheses_around_new_in_member_access
+                .unwrap_or(default.parentheses_around_new_in_member_access),
+            parentheses_in_new_expression: self
+                .parentheses_in_new_expression
+                .unwrap_or(default.parentheses_in_new_expression),
+            parentheses_in_exit_and_die: self
+                .parentheses_in_exit_and_die
+                .unwrap_or(default.parentheses_in_exit_and_die),
         }
     }
 }


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR adds new configuration options to the formatter to control the use of parentheses in `new` expressions, `exit`, and `die` constructs. It also includes a breaking change that requires a PHP version to be specified when using the formatter.

## 🔍 Context & Motivation

This change is needed to provide users with more flexibility in how the formatter handles parentheses in different contexts. The new options allow for greater control over code style and consistency. The breaking change is necessary to support the new option that controls parentheses around instantiation in member access chains, as this behavior is version-dependent.

## 🛠️ Summary of Changes

- **Feature:** Added parentheses_around_new_in_member_access option to control parentheses around instantiation in member access chains.
- **Feature:** Added parentheses_in_new_expression option to control parentheses in new expressions, even without arguments.
- **Feature:** Added parentheses_in_exit_and_die option to control parentheses in exit and die constructs.
- **Breaking Change:** The format() function now requires a PHPVersion argument.
- **Docs:** Updated documentation to include the new options and the breaking change.


## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [x] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [x] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
