### PR TITLE
feat(formatter): add support for fluent member access chain

### DIFF
--- a/crates/formatter/tests/format/call.rs
+++ b/crates/formatter/tests/format/call.rs
@@ -1,0 +1,33 @@
+use indoc::indoc;
+
+use mago_formatter::settings::FormatSettings;
+
+use crate::test_format;
+
+#[test]
+pub fn test_class_member_access_chain() {
+    let code = indoc! {r#"
+        <?php
+
+        expect($response->dto())->toBeInstanceOf(QuoteData::class)->aircraft_type->toBe($aircraftType)->status->toBe($status)
+            ->customer_id->toBe($customerId)->account_id->toBe($accountId)->salesperson_id->toBe($salespersonId)->price
+            ->toBe($price)->currency->toBe('EUR')->id->toBe($id);
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        expect($response->dto())
+            ->toBeInstanceOf(QuoteData::class)
+            ->aircraft_type->toBe($aircraftType)
+            ->status->toBe($status)
+            ->customer_id->toBe($customerId)
+            ->account_id->toBe($accountId)
+            ->salesperson_id->toBe($salespersonId)
+            ->price->toBe($price)
+            ->currency->toBe('EUR')
+            ->id->toBe($id);
+    "#};
+
+    test_format(code, expected, FormatSettings::default());
+}

--- a/crates/formatter/tests/format/mod.rs
+++ b/crates/formatter/tests/format/mod.rs
@@ -7,6 +7,7 @@ use crate::test_format;
 pub mod arguments;
 pub mod assignment;
 pub mod binaryish;
+pub mod call;
 pub mod control_structure;
 pub mod expression;
 pub mod mixed;


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR enhances the formatter to support fluent member access chains and expands the handling of member access chains to include property accesses in addition to method calls.

## 🔍 Context & Motivation

This change is motivated by the desire to improve the formatting of chained method and property access expressions. The addition of fluent member access chains allows for more concise and readable formatting when a pattern of alternating property access and method calls is detected. Expanding the handling of member access chains to include property access ensures that the formatter can handle a wider range of expressions and produce more consistent output.

## 🛠️ Summary of Changes

- **Feature:** Added support for fluent member access chains, allowing for more concise formatting of alternating property access and method calls.
- **Feature:** Expanded member access chain handling to include property accesses in addition to method calls.
- **Tests:** Added new tests to verify the behavior of the formatter with fluent member access chains and property accesses in chains.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

related to #81 

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
