### PR TITLE
fix(formatter): better handling of member access chains

### DIFF
--- a/crates/formatter/src/format/misc.rs
+++ b/crates/formatter/src/format/misc.rs
@@ -9,6 +9,7 @@ use crate::document::Group;
 use crate::document::Line;
 use crate::document::Separator;
 use crate::format::Format;
+use crate::format::call::collect_member_access_chain;
 use crate::format::statement::print_statement_sequence;
 use crate::settings::BraceStyle;
 
@@ -67,6 +68,12 @@ pub(super) fn should_hug_expression<'a>(f: &Formatter<'a>, expression: &'a Expre
         return false;
     }
 
+    if let Expression::Call(_) = expression {
+        // Don't hug calls if they are part of a member access chain
+        return collect_member_access_chain(expression)
+            .is_none_or(|chain| chain.accesses.len() < f.settings.method_chain_break_threshold);
+    }
+
     matches!(
         expression,
         Expression::Array(_)
@@ -74,9 +81,9 @@ pub(super) fn should_hug_expression<'a>(f: &Formatter<'a>, expression: &'a Expre
             | Expression::List(_)
             | Expression::Closure(_)
             | Expression::ClosureCreation(_)
-            | Expression::Call(_)
             | Expression::AnonymousClass(_)
             | Expression::Match(_)
+            | Expression::Call(_)
     )
 }
 

--- a/crates/formatter/tests/format/call.rs
+++ b/crates/formatter/tests/format/call.rs
@@ -31,3 +31,28 @@ pub fn test_class_member_access_chain() {
 
     test_format(code, expected, FormatSettings::default());
 }
+
+#[test]
+pub fn test_chain_inside_conditional() {
+    let code = indoc! {r#"
+        <?php
+
+        $interval = $report->finished_at
+          ? CarbonInterval::make($report->finished_at->diffInSeconds($report->created_at), 'seconds',
+          )->cascade()->cascade()->forHumans(['parts' => 1, 'options' => Carbon::CEIL])
+          : null;
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        $interval = $report->finished_at
+            ? CarbonInterval::make($report->finished_at->diffInSeconds($report->created_at), 'seconds')
+                ->cascade()
+                ->cascade()
+                ->forHumans(['parts' => 1, 'options' => Carbon::CEIL])
+            : null;
+    "#};
+
+    test_format(code, expected, FormatSettings { ..FormatSettings::default() });
+}

--- a/crates/formatter/tests/parens/callee.rs
+++ b/crates/formatter/tests/parens/callee.rs
@@ -48,11 +48,7 @@ pub fn test_instantiation_with_member_access_parentheses() {
         $a = (new Foo())->something();
         $a = (new Foo())->something();
         $a = (new Foo(1, 2))->something();
-        $a = (new Foo(1, 2))
-            ->something()
-            ->else()
-            ->other()
-            ->thing();
+        $a = (new Foo(1, 2))->something()->else()->other()->thing();
     "#};
 
     let expected_php84 = indoc! {r#"
@@ -61,11 +57,7 @@ pub fn test_instantiation_with_member_access_parentheses() {
         $a = new Foo()->something();
         $a = new Foo()->something();
         $a = new Foo(1, 2)->something();
-        $a = new Foo(1, 2)
-            ->something()
-            ->else()
-            ->other()
-            ->thing();
+        $a = new Foo(1, 2)->something()->else()->other()->thing();
     "#};
 
     let expected_php83_without_parens = indoc! {r#"
@@ -74,11 +66,7 @@ pub fn test_instantiation_with_member_access_parentheses() {
         $a = (new Foo)->something();
         $a = (new Foo)->something();
         $a = (new Foo(1, 2))->something();
-        $a = (new Foo(1, 2))
-            ->something()
-            ->else()
-            ->other()
-            ->thing();
+        $a = (new Foo(1, 2))->something()->else()->other()->thing();
     "#};
 
     let expected_php84_without_parens = indoc! {r#"
@@ -87,11 +75,7 @@ pub fn test_instantiation_with_member_access_parentheses() {
         $a = (new Foo)->something();
         $a = (new Foo)->something();
         $a = new Foo(1, 2)->something();
-        $a = new Foo(1, 2)
-            ->something()
-            ->else()
-            ->other()
-            ->thing();
+        $a = new Foo(1, 2)->something()->else()->other()->thing();
     "#};
 
     test_format_with_version(code, expected_php83, PHPVersion::PHP83, FormatSettings::default());


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR refines the formatting of method call chains by adding support for static method calls at the beginning of chains, adjusting the handling of arguments within chains, and modifying the line breaking behavior of chains.

## 🔍 Context & Motivation

These changes aim to improve the readability and consistency of method call chain formatting.

- Adding static method calls to chains provides a more complete handling of chained calls.
- Preventing argument "hugging" for chained calls allows for better visual flow and avoids unnecessary compactness.
- Using softlines instead of hardlines between chain members provides more flexibility in formatting, allowing chains to stay on a single line when possible.
- Adjusting the parent node breaking behavior ensures that regular method chains don't force unnecessary line breaks in the surrounding code.

## 🛠️ Summary of Changes

- **Feature:** Added support for static method calls at the beginning of method chains (e.g., Foo::bar()->baz()).
- **Change:** Arguments that are method chains are no longer "hugged" by parentheses, allowing for better formatting.
- **Change:** Replaced hardlines with softlines between method chain members, enabling single-line formatting when possible.
- **Change:** Method chains no longer force parent nodes to break into multiple lines unless they start with a static method call.
- **Tests:** Added new tests to cover the updated method chain formatting behavior.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Related to #81

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
