### PR TITLE
feat(formatter): hug single instantiation arguments

### DIFF
--- a/crates/formatter/tests/format/arguments.rs
+++ b/crates/formatter/tests/format/arguments.rs
@@ -30,3 +30,56 @@ pub fn test_expand_last_argument() {
 
     test_format(code, expected, FormatSettings::default());
 }
+
+#[test]
+pub fn test_hug_new() {
+    let code = indoc! {r#"
+        <?php
+
+        function something(): void {
+            $result = App::call(new DeployMosquito(new WebhookData(artifactUuid: $uuid, deploymentTarget: $target, service: Service::ERP)));
+        }
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        function something(): void
+        {
+            $result = App::call(new DeployMosquito(new WebhookData(
+                artifactUuid: $uuid,
+                deploymentTarget: $target,
+                service: Service::ERP,
+            )));
+        }
+    "#};
+
+    test_format(code, expected, FormatSettings::default());
+}
+
+#[test]
+pub fn test_hug_new_with_few_simple_args() {
+    let code = indoc! {r#"
+        <?php
+
+        function something(): void {
+          return Vec\values(
+              new FilesystemIterator($directory, FilesystemIterator::CURRENT_AS_PATHNAME | FilesystemIterator::SKIP_DOTS),
+          );
+        }
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        function something(): void
+        {
+            return Vec\values(new FilesystemIterator(
+                $directory,
+                FilesystemIterator::CURRENT_AS_PATHNAME | FilesystemIterator::SKIP_DOTS,
+            ));
+        }
+    "#};
+
+    test_format(code, expected, FormatSettings::default());
+}


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR refines the formatter's behavior regarding "hugging" instantiation expressions within argument lists. It introduces logic to determine when to hug a `new` expression, based on the characteristics of the expression and its arguments.

## 🔍 Context & Motivation

Previously, the formatter never "hugged" new expressions within argument lists. This could lead to inconsistent and sometimes less readable formatting.

This PR aims to improve the readability and consistency of formatting new expressions in argument lists by introducing specific rules for when to hug them. This ensures that the formatting is both compact and clear.

## 🛠️ Summary of Changes

- **Feature:** Introduced logic for "hugging" new expressions within argument lists:
  - Now hugs new expressions if they are a simple class instantiation without arguments.
  - Now hugs new expressions if they have a single non-named argument that is huggable or an instantiation itself (e.g., new Foo(new Bar())).
  - Now hugs new expressions if they have multiple arguments and all are named.
  - Now hugs new expressions if they have less than 4 non-named arguments, all of which are simple expressions.
- **Tests:** Updated existing tests to reflect the new formatting behavior.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Related to #81 

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
