### PR TITLE
feat(formatter): expand last instantiation argument

### DIFF
--- a/crates/formatter/src/format/call_arguments.rs
+++ b/crates/formatter/src/format/call_arguments.rs
@@ -428,6 +428,17 @@ fn could_expand_argument_value(argument_value: &Expression, arrow_chain_recursio
             Expression::Call(_) | Expression::Conditional(_) => !arrow_chain_recursion,
             _ => false,
         },
+        Expression::Instantiation(instantiation) => {
+            let Expression::Identifier(_) = instantiation.class.as_ref() else {
+                return false;
+            };
+
+            let Some(arguments) = instantiation.arguments.as_ref() else {
+                return false;
+            };
+
+            arguments.arguments.len() > 1 && arguments.arguments.iter().all(|a| matches!(a, Argument::Named(_)))
+        }
         _ => false,
     }
 }

--- a/crates/formatter/tests/format/arguments.rs
+++ b/crates/formatter/tests/format/arguments.rs
@@ -83,3 +83,26 @@ pub fn test_hug_new_with_few_simple_args() {
 
     test_format(code, expected, FormatSettings::default());
 }
+
+#[test]
+pub fn test_hug_last_new_with_named_args() {
+    let code = indoc! {r#"
+        <?php
+
+        $foo = (new \Lcobucci\JWT\Validation\Validator())->assert($token, new SignedWith(
+            signer: new Sha256(),
+            key: InMemory::plainText($this->jwtKey),
+        ));
+    "#};
+
+    let expected = indoc! {r#"
+        <?php
+
+        $foo = new \Lcobucci\JWT\Validation\Validator()->assert($token, new SignedWith(
+            signer: new Sha256(),
+            key: InMemory::plainText($this->jwtKey),
+        ));
+    "#};
+
+    test_format(code, expected, FormatSettings::default());
+}


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR enhances the formatter's argument expansion logic to support expanding the last argument in a function call when it is a new expression with multiple named arguments.

## 🔍 Context & Motivation

The formatter already has logic to expand the last argument in a function call under certain conditions, such as when it's an array or a similar expression. This helps improve readability by preventing overly long lines and deeply nested expressions.

This PR extends this logic to also expand the last argument when it is a new expression with multiple named arguments. This is because such expressions can also become quite lengthy and benefit from being expanded for better visual clarity.

## 🛠️ Summary of Changes

- **Feature:** Added support for expanding the last argument in a function call when it is a new expression with multiple named arguments.
- **Tests:** Added a new test case to verify the behavior of the formatter with the new argument expansion logic.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Related to #81 

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
