### PR TITLE
formatter: improve the handling of comments around argument lists

### DIFF
--- a/crates/formatter/tests/cases/argument_list_comments/after.php
+++ b/crates/formatter/tests/cases/argument_list_comments/after.php
@@ -1,0 +1,13 @@
+<?php
+
+$this->maxDate( /* trailing */
+    /* leading v1 */ value1: data_get($employee, 'customEffectiveDate'), // trailing v1
+    /* leading v2 */ value2: data_get($employee, 'employeeStatusDate'), // trailing v2
+/* leading */ ) /* trailing */;
+
+$this->maxDate( /* trailing */
+    /* leading v1 */ value1: data_get($employee, 'customEffectiveDate'),
+    /* leading v2 */ value2: data_get($employee, 'employeeStatusDate'),
+);
+
+$this->maxDate([1, 2]); /// foo

--- a/crates/formatter/tests/cases/argument_list_comments/before.php
+++ b/crates/formatter/tests/cases/argument_list_comments/before.php
@@ -1,0 +1,19 @@
+<?php
+
+$this->maxDate( /* trailing */
+    /* leading v1 */ value1: data_get($employee, 'customEffectiveDate'), // trailing v1
+    /* leading v2 */ value2: data_get($employee, 'employeeStatusDate'), // trailing v2
+/* leading */) /* trailing */;
+
+
+$this->maxDate( /* trailing */
+    /* leading v1 */ value1: data_get($employee, 'customEffectiveDate'),
+    /* leading v2 */ value2: data_get($employee, 'employeeStatusDate'),
+);
+
+
+$this->maxDate( /// foo
+[1, 2]); 
+
+
+

--- a/crates/formatter/tests/cases/argument_list_comments/settings.inc
+++ b/crates/formatter/tests/cases/argument_list_comments/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings::default()

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -98,3 +98,4 @@ test_case!(nesting_wrap_more_narrow);
 test_case!(nesting_wrap_narrow);
 test_case!(nesting_wrap_super_narrow);
 test_case!(awaitable);
+test_case!(argument_list_comments);


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR improves the handling of comments within and around argument lists in function calls. It ensures that comments are properly formatted and preserved in their original positions relative to the parentheses and arguments.

## 🔍 Context & Motivation

The previous formatting logic for argument lists didn't handle comments around parentheses and within the list consistently. This could lead to misplacement of comments, especially in cases with complex argument lists or multiple comments.

## 🛠️ Summary of Changes

- **Feature:** Improved comment handling in argument lists.
- **Tests:** Added a new test case (argument_list_comments) to verify the correct formatting of comments in various positions within and around argument lists.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Closes #81 