### PR TITLE
feat(cli): add `mago init` command with `composer.json` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ checksum = "37672978ae0febce7516ae0a85b53e6185159a9a28787391eb63fc44ec36037d"
 dependencies = [
  "async-fs",
  "futures-lite",
- "thiserror",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -692,6 +692,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror 1.0.69",
+ "zeroize",
 ]
 
 [[package]]
@@ -1519,11 +1532,13 @@ dependencies = [
  "clap",
  "colored",
  "config",
+ "dialoguer",
  "diffy",
  "futures",
  "glob-match",
  "indicatif",
  "mago-ast",
+ "mago-composer",
  "mago-fixer",
  "mago-formatter",
  "mago-interner",
@@ -2122,7 +2137,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 2.0.11",
  "ucd-trie",
 ]
 
@@ -2289,7 +2304,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.11",
  "tokio",
  "tracing",
 ]
@@ -2308,7 +2323,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.11",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2789,6 +2804,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2962,11 +2983,31 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.11",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3789,7 +3830,7 @@ dependencies = [
  "displaydoc",
  "indexmap",
  "memchr",
- "thiserror",
+ "thiserror 2.0.11",
  "time",
 ]
 
@@ -3801,5 +3842,5 @@ checksum = "8e7c724c3a8e5833aad6b7028f4f0989fa3a640ce799bf8c352f417b8ef9db3e"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
- "thiserror",
+ "thiserror 2.0.11",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ colored = "3.0.0"
 blake3 = "1.5.5"
 memchr = "2.7.4"
 parking_lot = "0.12.3"
+dialoguer = "0.11.0"
 
 [lints]
 workspace = true
@@ -106,6 +107,7 @@ mago-parser = { workspace = true }
 mago-fixer = { workspace = true }
 mago-php-version = { workspace = true }
 mago-reference = { workspace = true }
+mago-composer = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "time"] }
 clap = { workspace = true }
@@ -126,6 +128,7 @@ tempfile = { workspace = true }
 tracing-subscriber = { workspace = true }
 indicatif = { workspace = true }
 colored = { workspace = true }
+dialoguer = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 openssl = { workspace = true }

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -14,24 +14,45 @@ Once Mago is installed, navigate to your project directory:
 cd /path/to/your/project
 ```
 
-### Create a Configuration File
+### Initialize Mago
 
-In your project directory, create a `mago.toml` file. This configuration file will allow you to customize Mago's behavior for your project.
+Use the `mago init` command to interactively generate a `mago.toml` configuration file:
+
+```bash
+mago init
+```
+
+This command will guide you through setting up source paths, external dependencies, PHP version, and framework plugins.
+It can also automatically detect and use settings from an existing `composer.json` file.
+
+### (Optionally) Manually Create a Configuration File
+
+If you prefer to manually configure Mago, you can create a `mago.toml` file in your project directory:
 
 ```bash
 touch mago.toml
 ```
 
-### Configure Mago
-
-Edit the `mago.toml` file to define your source paths, formatter settings, linter rules, and plugins. For detailed guidance, refer to the [Configuration Guide](getting-started/configuration.md).
+Then, edit the `mago.toml` file to define your source paths, formatter settings, linter rules, and plugins. For detailed guidance, refer to the [Configuration Guide](getting-started/configuration.md).
 
 Example `mago.toml`:
 
 ```toml
+php_version = "8.4"
+
 [source]
 paths = ["src", "tests"]
 includes = ["vendor"]
+excludes = []
+
+[format]
+print_width = 120
+tab_width = 4
+use_tabs = false
+
+[linter]
+default_plugins = true
+plugins = ["php-unit"]
 ```
 
 ## Step 3: Start Using Mago
@@ -49,7 +70,7 @@ After setting up your configuration, you can start using Mago's powerful command
 mago lint
 
 # Fix linting issues
-mago fix
+mago lint --fix
 
 # Run the formatter
 mago format

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,0 +1,474 @@
+use std::path::Path;
+use std::process::ExitCode;
+use std::str::FromStr;
+
+use clap::Parser;
+use dialoguer::Confirm;
+use dialoguer::Input;
+use dialoguer::MultiSelect;
+use dialoguer::theme::ColorfulTheme;
+
+use mago_composer::AutoloadPsr4value;
+use mago_composer::ComposerPackage;
+use mago_composer::ComposerPackageAutoloadDevPsr4value;
+use mago_php_version::PHPVersion;
+
+use crate::config::Configuration;
+use crate::consts::COMPOSER_JSON_FILE;
+use crate::consts::CONFIGURATION_FILE;
+use crate::consts::DEFAULT_PHP_VERSION;
+use crate::error::Error;
+use crate::utils::version::extract_minimum_php_version;
+
+/// Template for generating the mago.toml configuration file.
+const CONFIGURATION_TEMPLATE: &str = r#"
+# Mago configuration file
+# For more information, see https://mago.carthage.software/#/getting-started/configuration
+php_version = "{php_version}"
+
+[source]
+paths = [{paths}]
+includes = [{includes}]
+excludes = [{excludes}]
+
+[format]
+print_width = 120
+tab_width = 4
+use_tabs = false
+
+[linter]
+default_plugins = true
+plugins = [{plugins}]
+"#;
+
+const SYMFONY_PLUGIN: &str = "symfony";
+const LARAVEL_PLUGIN: &str = "laravel";
+const PHPUNIT_PLUGIN: &str = "php-unit";
+
+/// Available plugin options for PHP frameworks and libraries.
+const PLUGIN_OPTIONS: [&str; 3] = [LARAVEL_PLUGIN, SYMFONY_PLUGIN, PHPUNIT_PLUGIN];
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "init",
+    about = "Initialize the configuration for Mago",
+    long_about = r#"
+Initialize a new Mago configuration file (mago.toml) in the current workspace.
+
+This command guides you through the process of setting up Mago for your PHP project.
+It can automatically detect and use settings from an existing composer.json file,
+or help you configure settings manually including:
+
+- PHP version to target
+- Source code paths to analyze
+- External dependency paths
+- Paths to exclude from analysis
+- Framework-specific plugins to enable (Laravel, Symfony, PHPUnit)
+
+The generated configuration will be written to mago.toml in the current workspace.
+"#
+)]
+pub struct InitCommand;
+
+/// Executes the `init` command, returning an exit status code.
+///
+/// This function coordinates the overall configuration creation process:
+/// 1. Checks if a configuration file already exists
+/// 2. Detects if composer.json is available and should be used
+/// 3. Gathers configuration data (either from composer.json or user input)
+/// 4. Generates and writes the configuration file
+///
+/// # Arguments
+///
+/// * `_command` - The init command instance with any parameters
+/// * `configuration` - The current configuration context
+///
+/// # Returns
+///
+/// A result containing the exit code or an error
+pub async fn execute(_command: InitCommand, configuration: Configuration) -> Result<ExitCode, Error> {
+    let theme = ColorfulTheme::default();
+
+    // Check if configuration file already exists
+    let configuration_file = configuration.source.workspace.join(CONFIGURATION_FILE);
+    if configuration_file.exists() {
+        tracing::info!("Configuration file already exists at {}", configuration_file.display());
+
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    // Find composer.json and decide whether to use it
+    let composer_file = configuration.source.workspace.join(COMPOSER_JSON_FILE);
+    let use_composer = composer_file.exists() && should_use_composer(&composer_file)?;
+
+    // Generate configuration content
+    let configuration = if use_composer {
+        generate_config_from_composer(&composer_file)?
+    } else {
+        generate_config_from_user_input(&theme)?
+    };
+
+    // Confirm and write the configuration file
+    write_configuration_if_confirmed(&theme, &configuration_file, &configuration)?;
+
+    Ok(ExitCode::SUCCESS)
+}
+
+/// Asks the user if they want to use the detected composer.json file for configuration.
+///
+/// # Arguments
+///
+/// * `composer_file` - Path to the composer.json file
+///
+/// # Returns
+///
+/// A result containing a boolean indicating whether to use composer.json or an error
+fn should_use_composer(composer_file: &Path) -> Result<bool, Error> {
+    let theme = ColorfulTheme::default();
+
+    tracing::info!("Found `composer.json` file at {}", composer_file.display());
+
+    let should_use_composer =
+        Confirm::with_theme(&theme).with_prompt("Use `composer.json` to configure Mago?").default(true).interact()?;
+
+    Ok(should_use_composer)
+}
+
+/// Generates configuration content based on composer.json file.
+///
+/// # Arguments
+///
+/// * `composer_file` - Path to the composer.json file
+///
+/// # Returns
+///
+/// A result containing the configuration content as a string or an error
+fn generate_config_from_composer(composer_file: &Path) -> Result<String, Error> {
+    // Parse composer.json
+    let composer_json = std::fs::read_to_string(composer_file).map_err(Error::ReadingComposerJson)?;
+    let composer = ComposerPackage::from_str(&composer_json).map_err(Error::ParsingComposerJson)?;
+
+    // Extract PHP version
+    let php_version = extract_php_version_from_composer(&composer);
+
+    // Extract paths from autoload configuration
+    let paths = extract_paths_from_composer(&composer);
+
+    // Standard include path for Composer projects
+    let includes = vec!["vendor".to_string()];
+
+    // Detect and enable appropriate plugins based on dependencies
+    let plugins = detect_plugins_from_composer(&composer);
+
+    // Generate configuration content
+    Ok(CONFIGURATION_TEMPLATE
+        .replace("{php_version}", &php_version)
+        .replace("{paths}", &quote_format_strings(paths))
+        .replace("{includes}", &quote_format_strings(includes))
+        .replace("{excludes}", "")
+        .replace("{plugins}", &quote_format_strings(plugins)))
+}
+
+/// Extracts the PHP version from composer package requirements.
+///
+/// # Arguments
+///
+/// * `composer` - Parsed composer.json content
+///
+/// # Returns
+///
+/// The PHP version as a string
+fn extract_php_version_from_composer(composer: &ComposerPackage) -> String {
+    match composer.require.get("php") {
+        Some(version_constraint) => match extract_minimum_php_version(version_constraint) {
+            Some(version) => version,
+            None => DEFAULT_PHP_VERSION.to_string(),
+        },
+        None => DEFAULT_PHP_VERSION.to_string(),
+    }
+}
+
+/// Extracts source code paths from composer autoload configuration.
+///
+/// # Arguments
+///
+/// * `composer` - Parsed composer.json content
+///
+/// # Returns
+///
+/// A vector of path strings
+fn extract_paths_from_composer(composer: &ComposerPackage) -> Vec<String> {
+    let mut paths = match composer.autoload.as_ref() {
+        Some(autoload) => autoload.psr_4.iter().flat_map(|(_, v)| get_autoload_value(v)).collect::<Vec<_>>(),
+        None => vec![],
+    };
+
+    if let Some(autoload) = composer.autoload_dev.as_ref() {
+        paths.extend(autoload.psr_4.iter().flat_map(|(_, v)| get_autoload_dev_value(v)));
+    }
+
+    paths
+}
+
+/// Detects which plugins should be enabled based on composer dependencies.
+///
+/// # Arguments
+///
+/// * `composer` - Parsed composer.json content
+///
+/// # Returns
+///
+/// A vector of plugin names to enable
+fn detect_plugins_from_composer(composer: &ComposerPackage) -> Vec<String> {
+    let mut plugins = vec![];
+
+    // Detect Symfony framework
+    if has_package_prefix(composer, "symfony/") || has_package_prefix(composer, "symfony-") {
+        plugins.push(SYMFONY_PLUGIN.to_string());
+    }
+
+    // Detect Laravel framework
+    if has_package_prefix(composer, "laravel/") || has_package_prefix(composer, "illuminate/") {
+        plugins.push(LARAVEL_PLUGIN.to_string());
+    }
+
+    // Detect PHPUnit
+    if has_exact_package(composer, "phpunit/phpunit") || has_exact_package(composer, "symfony/phpunit-bridge") {
+        plugins.push(PHPUNIT_PLUGIN.to_string());
+    }
+
+    plugins
+}
+
+/// Checks if the composer dependencies include a package with the given prefix.
+///
+/// # Arguments
+///
+/// * `composer` - Parsed composer.json content
+/// * `prefix` - Package name prefix to check for
+///
+/// # Returns
+///
+/// Boolean indicating if a matching package was found
+fn has_package_prefix(composer: &ComposerPackage, prefix: &str) -> bool {
+    composer.require.iter().any(|(k, _)| k.starts_with(prefix))
+        || composer.require_dev.iter().any(|(k, _)| k.starts_with(prefix))
+}
+
+/// Checks if the composer dependencies include an exact package name.
+///
+/// # Arguments
+///
+/// * `composer` - Parsed composer.json content
+/// * `package_name` - Exact package name to check for
+///
+/// # Returns
+///
+/// Boolean indicating if the package was found
+fn has_exact_package(composer: &ComposerPackage, package_name: &str) -> bool {
+    composer.require.iter().any(|(k, _)| k.eq(package_name))
+        || composer.require_dev.iter().any(|(k, _)| k.eq(package_name))
+}
+
+/// Extracts PSR-4 autoload paths from composer configuration.
+///
+/// # Arguments
+///
+/// * `autoload` - Autoload value from composer.json
+///
+/// # Returns
+///
+/// A vector of path strings
+fn get_autoload_value(autoload: &AutoloadPsr4value) -> Vec<String> {
+    match autoload {
+        AutoloadPsr4value::Array(items) => items.iter().map(|p| p.to_string()).collect(),
+        AutoloadPsr4value::String(path) => vec![path.to_string()],
+    }
+}
+
+/// Extracts PSR-4 autoload-dev paths from composer configuration.
+///
+/// # Arguments
+///
+/// * `autoload` - Autoload-dev value from composer.json
+///
+/// # Returns
+///
+/// A vector of path strings
+fn get_autoload_dev_value(autoload: &ComposerPackageAutoloadDevPsr4value) -> Vec<String> {
+    match autoload {
+        ComposerPackageAutoloadDevPsr4value::Array(items) => items.iter().map(|p| p.to_string()).collect(),
+        ComposerPackageAutoloadDevPsr4value::String(path) => vec![path.to_string()],
+    }
+}
+
+/// Generates configuration content based on user input.
+///
+/// # Arguments
+///
+/// * `theme` - Dialoguer theme for input prompts
+///
+/// # Returns
+///
+/// A result containing the configuration content as a string or an error
+fn generate_config_from_user_input(theme: &ColorfulTheme) -> Result<String, Error> {
+    // Collect source paths
+    let paths = prompt_for_paths(theme, "Paths to include for analysis (comma-separated, e.g., src,tests)")?;
+
+    // Collect include paths for external dependencies
+    let includes =
+        prompt_for_paths(theme, "Paths to include for external dependencies (comma-separated, e.g., vendor)")?;
+
+    // Collect exclude paths
+    let excludes = prompt_for_paths(theme, "Paths to exclude from analysis (comma-separated, e.g., src/Generated)")?;
+
+    // Prompt for PHP version
+    let php_version = prompt_for_php_version(theme)?;
+
+    // Select plugins
+    let plugins = prompt_for_plugins(theme)?;
+
+    // Generate configuration content
+    Ok(CONFIGURATION_TEMPLATE
+        .replace("{php_version}", &php_version)
+        .replace("{paths}", &quote_format_strings(paths))
+        .replace("{includes}", &quote_format_strings(includes))
+        .replace("{excludes}", &quote_format_strings(excludes))
+        .replace("{plugins}", &quote_format_strings(plugins)))
+}
+
+/// Prompts the user for a comma-separated list of paths.
+///
+/// # Arguments
+///
+/// * `theme` - Dialoguer theme for input prompts
+/// * `prompt` - Prompt message to display
+///
+/// # Returns
+///
+/// A result containing a vector of paths or an error
+fn prompt_for_paths(theme: &ColorfulTheme, prompt: &str) -> Result<Vec<String>, Error> {
+    let input = Input::<String>::with_theme(theme)
+        .with_prompt(prompt)
+        .validate_with(|v: &String| paths_validator(v))
+        .allow_empty(true)
+        .interact()?;
+
+    Ok(input.split(',').map(|e| e.trim().to_string()).filter(|e| !e.is_empty()).collect())
+}
+
+/// Prompts the user for the PHP version to target.
+///
+/// # Arguments
+///
+/// * `theme` - Dialoguer theme for input prompts
+///
+/// # Returns
+///
+/// A result containing the PHP version as a string or an error
+fn prompt_for_php_version(theme: &ColorfulTheme) -> Result<String, Error> {
+    let php_version: String = Input::<String>::with_theme(theme)
+        .with_prompt("PHP version to target (e.g., 8.3, 8.4)")
+        .allow_empty(true)
+        .validate_with(|v: &String| {
+            if v.is_empty() {
+                return Ok(());
+            }
+
+            match PHPVersion::from_str(v) {
+                Ok(_) => Ok(()),
+                Err(error) => Err(error.to_string()),
+            }
+        })
+        .interact()?;
+
+    Ok(if php_version.is_empty() { DEFAULT_PHP_VERSION.to_string() } else { php_version })
+}
+
+/// Prompts the user to select which plugins to enable.
+///
+/// # Arguments
+///
+/// * `theme` - Dialoguer theme for input prompts
+///
+/// # Returns
+///
+/// A result containing a vector of selected plugin names or an error
+fn prompt_for_plugins(theme: &ColorfulTheme) -> Result<Vec<String>, Error> {
+    let selected_indices = MultiSelect::with_theme(theme)
+        .with_prompt("Select framework and library plugins to enable")
+        .items(&PLUGIN_OPTIONS)
+        .interact()?;
+
+    Ok(selected_indices.iter().map(|&idx| PLUGIN_OPTIONS[idx].to_string()).collect())
+}
+
+/// Validates path input to ensure it's properly formatted.
+///
+/// # Arguments
+///
+/// * `v` - Input string containing comma-separated paths
+///
+/// # Returns
+///
+/// Ok if valid, Err with message if invalid
+fn paths_validator(v: &str) -> Result<(), &'static str> {
+    if v.is_empty() {
+        return Ok(());
+    }
+
+    if v.contains(|c: char| c.is_whitespace()) {
+        return Err("Paths cannot contain whitespaces. Use commas to separate multiple paths.");
+    }
+
+    let paths = v.split(',').map(|p| p.trim()).collect::<Vec<_>>();
+
+    if paths.iter().all(|p| !p.is_empty()) {
+        return Ok(());
+    }
+
+    Err("Paths cannot be empty.")
+}
+
+/// Confirms with the user and writes the configuration file.
+///
+/// # Arguments
+///
+/// * `theme` - Dialoguer theme for confirmation prompt
+/// * `configuration_file` - Path where the configuration should be written
+/// * `configuration` - Configuration content to write
+///
+/// # Returns
+///
+/// A result with () or an error
+fn write_configuration_if_confirmed(
+    theme: &ColorfulTheme,
+    configuration_file: &Path,
+    configuration: &str,
+) -> Result<(), Error> {
+    let should_write =
+        Confirm::with_theme(theme).with_prompt("Write configuration to `mago.toml`?").default(true).interact()?;
+
+    if should_write {
+        tracing::info!("Writing configuration to {}", configuration_file.display());
+        std::fs::write(configuration_file, configuration.trim()).map_err(Error::WritingConfiguration)?;
+        tracing::info!("Configuration file created successfully!");
+    } else {
+        tracing::warn!("Configuration not saved.");
+    }
+
+    Ok(())
+}
+
+/// Formats a vector of strings as quoted, comma-separated values for TOML.
+///
+/// # Arguments
+///
+/// * `items` - Vector of strings to format
+///
+/// # Returns
+///
+/// A string of quoted, comma-separated values
+fn quote_format_strings(items: Vec<String>) -> String {
+    items.iter().filter(|p| !p.is_empty()).map(|p| format!("\"{}\"", p)).collect::<Vec<_>>().join(", ")
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -14,6 +14,7 @@ use crate::commands::ast::AstCommand;
 use crate::commands::find::FindCommand;
 use crate::commands::fix::FixCommand;
 use crate::commands::format::FormatCommand;
+use crate::commands::init::InitCommand;
 use crate::commands::lint::LintCommand;
 use crate::commands::self_update::SelfUpdateCommand;
 use crate::error::Error;
@@ -22,6 +23,7 @@ pub mod ast;
 pub mod find;
 pub mod fix;
 pub mod format;
+pub mod init;
 pub mod lint;
 pub mod self_update;
 
@@ -38,6 +40,9 @@ pub const CLAP_STYLING: Styles = Styles::styled()
 /// The main Mago CLI command.
 #[derive(Parser, Debug)]
 pub enum MagoCommand {
+    /// Initialize the configuration for Mago.
+    #[command(name = "init")]
+    Init(InitCommand),
     /// Analyze the abstract syntax tree (AST) of PHP code.
     #[command(name = "ast")]
     Ast(AstCommand),

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -36,6 +36,9 @@ pub const ENVIRONMENT_PREFIX: &str = "MAGO";
 /// The name of the configuration file for mago.
 pub const CONFIGURATION_FILE: &str = "mago.toml";
 
+/// The name of `composer.json` file.
+pub const COMPOSER_JSON_FILE: &str = "composer.json";
+
 /// The minimum stack size for each thread (8 MB).
 pub const MINIMUM_STACK_SIZE: usize = 8 * 1024 * 1024;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,6 +64,7 @@ pub fn run() -> Result<ExitCode, Error> {
     };
 
     match command {
+        MagoCommand::Init(cmd) => runtime.block_on(commands::init::execute(cmd, configuration)),
         MagoCommand::Lint(cmd) => runtime.block_on(commands::lint::execute(cmd, configuration)),
         MagoCommand::Fix(cmd) => runtime.block_on(commands::fix::execute(cmd, configuration)),
         MagoCommand::Format(cmd) => runtime.block_on(commands::format::execute(cmd, configuration)),

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -8,6 +8,7 @@ use crate::error::Error;
 
 pub mod logger;
 pub mod progress;
+pub mod version;
 
 /// Applies changes to the source file.
 ///

--- a/src/utils/version.rs
+++ b/src/utils/version.rs
@@ -1,0 +1,73 @@
+use std::str::FromStr;
+
+use mago_php_version::PHPVersion;
+
+pub fn extract_minimum_php_version(version_constraint: &str) -> Option<String> {
+    // Remove any whitespace and split by logical OR operator
+    let trimmed_constraint = version_constraint.replace(" ", "");
+    let constraints = trimmed_constraint.split("||").collect::<Vec<_>>();
+
+    // For each constraint, try to extract the minimum version
+    let mut min_versions = Vec::new();
+    for constraint in constraints {
+        if let Some(version) = extract_version_from_constraint(constraint) {
+            min_versions.push(version);
+        }
+    }
+
+    // If we found any valid versions, return the minimum
+    if !min_versions.is_empty() {
+        min_versions.sort();
+
+        return Some(min_versions[0].to_string());
+    }
+
+    None
+}
+
+fn extract_version_from_constraint(constraint: &str) -> Option<PHPVersion> {
+    // Handle common version constraint patterns
+
+    // Case: >=8.0
+    if constraint.starts_with(">=") {
+        let version_str = constraint.trim_start_matches(">=");
+
+        return PHPVersion::from_str(version_str).ok();
+    }
+
+    // Case: >8.0 (we add 0.0.1 to get the minimum allowed version)
+    if constraint.starts_with(">") {
+        let version_str = constraint.trim_start_matches(">");
+        if let Ok(version) = PHPVersion::from_str(version_str) {
+            // Increment the patch version to get the minimum allowed
+            return Some(PHPVersion::new(
+                version.major(),
+                version.minor(),
+                version.patch().checked_add(1).unwrap_or(0),
+            ));
+        }
+    }
+
+    // Case: ~8.1 (compatible with 8.1.x)
+    if constraint.starts_with("~") {
+        let version_str = constraint.trim_start_matches("~");
+
+        return PHPVersion::from_str(version_str).ok();
+    }
+
+    // Case: ^8.1 (compatible with 8.x.y where x >= 1)
+    if constraint.starts_with("^") {
+        let version_str = constraint.trim_start_matches("^");
+
+        return PHPVersion::from_str(version_str).ok();
+    }
+
+    // Case: 8.1.* or 8.1
+    if !constraint.starts_with("<") && !constraint.contains(">") {
+        let version_str = constraint.replace(".*", "").replace("*", "");
+
+        return PHPVersion::from_str(&version_str).ok();
+    }
+
+    None
+}


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR adds a new `mago init` command to the Mago CLI, providing an interactive way to initialize a `mago.toml` configuration file. It also updates the documentation to guide users through the new initialization process.

## 🔍 Context & Motivation

This change is motivated by the desire to simplify the initial setup of Mago for new users. By providing an interactive command, users can easily generate a basic `mago.toml` configuration file tailored to their project, without having to manually create and edit the file. This improves the user experience and makes it easier to get started with Mago.

## 🛠️ Summary of Changes

- **Feature:** Added mago init command to interactively generate a mago.toml configuration file.
- **Docs:** Updated the "Getting Started" guide to include the mago init command and explain how to use it.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [x] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [x] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Closes #6 

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
