### PR TITLE
feat(formatter): introduce an option to add a space before `!` prefix operator

### DIFF
--- a/crates/ast/src/ast/unary.rs
+++ b/crates/ast/src/ast/unary.rs
@@ -103,6 +103,11 @@ impl UnaryPrefixOperator {
     }
 
     #[inline]
+    pub const fn is_not(&self) -> bool {
+        matches!(self, Self::Not(_))
+    }
+
+    #[inline]
     pub fn as_str<'a>(&self, interner: &'a ThreadedInterner) -> &'a str {
         match self {
             UnaryPrefixOperator::ErrorControl(_) => "@",

--- a/crates/formatter/src/internal/format/expression.rs
+++ b/crates/formatter/src/internal/format/expression.rs
@@ -104,7 +104,7 @@ impl<'a> Format<'a> for Binary {
 impl<'a> Format<'a> for UnaryPrefix {
     fn format(&'a self, f: &mut FormatterState<'a>) -> Document<'a> {
         wrap!(f, self, UnaryPrefix, {
-            if self.operator.is_cast() {
+            if self.operator.is_cast() || (self.operator.is_not() && f.settings.space_after_not_operator) {
                 Document::Group(Group::new(vec![self.operator.format(f), Document::space(), self.operand.format(f)]))
             } else {
                 Document::Group(Group::new(vec![self.operator.format(f), self.operand.format(f)]))

--- a/crates/formatter/src/settings.rs
+++ b/crates/formatter/src/settings.rs
@@ -599,6 +599,24 @@ pub struct FormatSettings {
     /// Default: `true` (Add parentheses for consistency)
     #[serde(default = "default_true")]
     pub parentheses_in_exit_and_die: bool,
+
+    /// Controls whether to add a space after `!` operator and before the expression.
+    ///
+    /// If enabled, the formatter will add a space after `!` operator and before the expression.
+    ///
+    /// For example:
+    ///
+    /// ```php
+    /// $foo = ! $bar; // `space_after_not_operator = true`
+    ///
+    /// // or
+    ///
+    /// $foo = !$bar;  // `space_after_not_operator = false`
+    /// ```
+    ///
+    /// Default: `false`
+    #[serde(default = "default_false")]
+    pub space_after_not_operator: bool,
 }
 
 impl Default for FormatSettings {
@@ -637,6 +655,7 @@ impl Default for FormatSettings {
             parentheses_around_new_in_member_access: false,
             parentheses_in_new_expression: true,
             parentheses_in_exit_and_die: true,
+            space_after_not_operator: false,
         }
     }
 }

--- a/crates/formatter/tests/cases/space_after_not_operator/after.php
+++ b/crates/formatter/tests/cases/space_after_not_operator/after.php
@@ -1,0 +1,9 @@
+<?php
+
+// not operator needs a space after it
+$a = ! $b;
+// but not other prefix operators
+$a = ~$b;
+$a = &$b;
+$a = ++$b;
+$a = --$b;

--- a/crates/formatter/tests/cases/space_after_not_operator/before.php
+++ b/crates/formatter/tests/cases/space_after_not_operator/before.php
@@ -1,0 +1,9 @@
+<?php
+
+// not operator needs a space after it
+$a = !$b;
+// but not other prefix operators
+$a = ~$b;
+$a = &$b;
+$a = ++$b;
+$a = --$b;

--- a/crates/formatter/tests/cases/space_after_not_operator/settings.inc
+++ b/crates/formatter/tests/cases/space_after_not_operator/settings.inc
@@ -1,0 +1,4 @@
+FormatSettings {
+  space_after_not_operator: true,
+  ..Default::default()
+}

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -99,3 +99,4 @@ test_case!(nesting_wrap_narrow);
 test_case!(nesting_wrap_super_narrow);
 test_case!(awaitable);
 test_case!(argument_list_comments);
+test_case!(space_after_not_operator);

--- a/docs/formatter/settings.md
+++ b/docs/formatter/settings.md
@@ -403,3 +403,17 @@ If enabled, the formatter will add parentheses to `exit` and `die` statements th
   ```toml
   parentheses_in_exit_and_die = false
   ```
+
+### `space_after_not_operator`
+
+Controls whether to add a space after the `!` operator.
+
+If enabled, the formatter will add a space after the `!` operator in logical negations.
+
+- Default: `true`
+- Type: `boolean`
+- Example:
+
+  ```toml
+  space_after_not_operator = false
+  ```

--- a/src/config/formatter.rs
+++ b/src/config/formatter.rs
@@ -149,6 +149,10 @@ pub struct FormatterConfiguration {
     /// making them resemble function calls.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parentheses_in_exit_and_die: Option<bool>,
+
+    /// Controls whether to include a space after the `!` operator.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub space_after_not_operator: Option<bool>,
 }
 
 impl FormatterConfiguration {
@@ -208,6 +212,7 @@ impl FormatterConfiguration {
             parentheses_in_exit_and_die: self
                 .parentheses_in_exit_and_die
                 .unwrap_or(default.parentheses_in_exit_and_die),
+            space_after_not_operator: self.space_after_not_operator.unwrap_or(default.space_after_not_operator),
         }
     }
 }


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR introduces a new `space_after_not_operator` option which when enabled will add a space between `!` and the expression.

## 🔍 Context & Motivation

This feature was requested in #99 

## 🛠️ Summary of Changes

- **Feature:** Added `space_after_not_operator` formatter option.
- **Docs:** Updated formatter settings docs to include the new `space_after_not_operator` option.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [x] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Closes #99 

## 📝 Notes for Reviewers

