### PR TITLE
feat(formatter): always breaking arguments list if it contains only named arguments

### DIFF
--- a/crates/formatter/src/internal/format/call_arguments.rs
+++ b/crates/formatter/src/internal/format/call_arguments.rs
@@ -113,10 +113,17 @@ pub(super) fn print_argument_list<'a>(f: &mut FormatterState<'a>, argument_list:
         ]));
 
         parts.push(Document::Line(Line::default()));
+        if let Some(leading_comments) = f.print_leading_comments(argument_list.right_parenthesis) {
+            parts.push(leading_comments);
+        }
         parts.push(Document::String(")"));
 
         Document::Group(Group::new(parts).with_break(true))
     };
+
+    if should_break_all_arguments(argument_list) {
+        return all_arguments_broken_out(f);
+    }
 
     if should_inline_single_breaking_argument(f, argument_list) {
         // we have a single argument that we can hug
@@ -226,6 +233,12 @@ pub(super) fn print_argument_list<'a>(f: &mut FormatterState<'a>, argument_list:
     Document::Group(Group::new(contents))
 }
 
+#[inline]
+fn should_break_all_arguments(argument_list: &ArgumentList) -> bool {
+    argument_list.arguments.len() >= 2 && argument_list.arguments.iter().all(|a| matches!(a, Argument::Named(_)))
+}
+
+#[inline]
 fn should_inline_single_breaking_argument<'a>(f: &FormatterState<'a>, argument_list: &'a ArgumentList) -> bool {
     if argument_list.arguments.len() != 1 {
         return false;

--- a/crates/formatter/tests/cases/breaking_named_arguments/after.php
+++ b/crates/formatter/tests/cases/breaking_named_arguments/after.php
@@ -1,0 +1,21 @@
+<?php
+
+$a = $this->viewCache->getCachedViewPath(
+    path: $view->path,
+    compiledView: fn() => $this->cleanupCompiled($this->compiler->compile($view->path)),
+);
+
+$p = new Point(
+    x: $actual + self::MARGIN_X + 1 + self::PADDING_X + 2,
+    y: self::MARGIN_TOP + $this->offsetY,
+);
+
+$t = new TailReader()->tail(
+    path: $debugLogPath,
+    format: fn(string $text) => $this->highlighter->parse($text, new VarExportLanguage()),
+);
+
+$this->console->keyValue(
+    key: $cacheClass,
+    value: "<style='bold fg-green'>CLEARED</style>",
+);

--- a/crates/formatter/tests/cases/breaking_named_arguments/before.php
+++ b/crates/formatter/tests/cases/breaking_named_arguments/before.php
@@ -1,0 +1,22 @@
+<?php
+
+$a = $this->viewCache->getCachedViewPath(
+    path: $view->path,
+    compiledView: fn () => $this->cleanupCompiled($this->compiler->compile($view->path)),
+);
+
+$p = new Point(
+    x: $actual + (self::MARGIN_X + 1 + self::PADDING_X) + 2,
+    y: self::MARGIN_TOP + $this->offsetY,
+);
+
+$t = new TailReader()->tail(
+    path: $debugLogPath,
+    format: fn (string $text) => $this->highlighter->parse(
+        $text,
+        new VarExportLanguage()),
+);
+
+$this->console->keyValue(
+    key: $cacheClass,     value: "<style='bold fg-green'>CLEARED</style>",
+);

--- a/crates/formatter/tests/cases/breaking_named_arguments/settings.inc
+++ b/crates/formatter/tests/cases/breaking_named_arguments/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings::default()

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -100,3 +100,4 @@ test_case!(nesting_wrap_super_narrow);
 test_case!(awaitable);
 test_case!(argument_list_comments);
 test_case!(space_after_not_operator);
+test_case!(breaking_named_arguments);


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR introduces changes to when the formatter breaks arguments list.

The logic remains the same as before, with an additional case where if the argument list contains 2 or more arguments, and all arguments are named arguments, the list will always be broken into multiple lines for readability.

## 🔍 Context & Motivation

See #100 

## 🛠️ Summary of Changes

- **Feature:** Introduce a new case in the formatter that causes argument lists to always break into multiple lines if they contain 2 or more arguments, all of which are named arguments.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Related to #100 

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
