### PR TITLE
fix(formatter): never break parameter list that is empty, unless comments break it

### DIFF
--- a/crates/formatter/src/document/group.rs
+++ b/crates/formatter/src/document/group.rs
@@ -40,6 +40,6 @@ impl AddAssign<usize> for GroupIdentifier {
 
 impl Display for GroupIdentifier {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        write!(f, "group-identifier({})", self.0)
+        write!(f, "{}", self.0)
     }
 }

--- a/crates/formatter/src/document/mod.rs
+++ b/crates/formatter/src/document/mod.rs
@@ -259,7 +259,7 @@ impl fmt::Display for Document<'_> {
             Document::IndentIfBreak(IndentIfBreak { contents, group_id }) => {
                 let mut options = vec![];
                 if let Some(id) = group_id {
-                    options.push(format!("groupId: {:?}", id));
+                    options.push(format!("groupId: {}", id));
                 }
                 let options_str =
                     if options.is_empty() { String::new() } else { format!(", {{ {} }}", options.join(", ")) };
@@ -271,7 +271,7 @@ impl fmt::Display for Document<'_> {
                     options.push("shouldBreak: true".to_string());
                 }
                 if let Some(id) = id {
-                    options.push(format!("id: {:?}", id));
+                    options.push(format!("id: {}", id));
                 }
                 let expanded_states_str = if let Some(states) = expanded_states {
                     format!(
@@ -308,7 +308,7 @@ impl fmt::Display for Document<'_> {
             Document::IfBreak(IfBreak { break_contents, flat_content, group_id }) => {
                 let mut options = vec![];
                 if let Some(id) = group_id {
-                    options.push(format!("groupId: {:?}", id));
+                    options.push(format!("groupId: {}", id));
                 }
                 let options_str =
                     if options.is_empty() { String::new() } else { format!(", {{ {} }}", options.join(", ")) };

--- a/crates/formatter/src/internal/format/block.rs
+++ b/crates/formatter/src/internal/format/block.rs
@@ -70,13 +70,14 @@ pub(super) fn print_block<'a>(
         }
 
         contents.push(Document::Indent(statements));
+
         true
     } else {
         let parent = f.parent_node();
         // in case the block is empty, we still want to add a new line
         // in some cases.
         match &parent {
-            // functions, closures, and methods
+            // functions, and methods
             Node::Function(_) | Node::MethodBody(_) | Node::PropertyHookConcreteBody(_) => true,
             // try, catch, finally
             Node::Try(_) | Node::TryCatchClause(_) | Node::TryFinallyClause(_) => true,
@@ -106,7 +107,7 @@ pub(super) fn print_block<'a>(
         contents.push(comments);
     } else if has_inline_body {
         contents.push(Document::space());
-    } else {
+    } else if should_break {
         contents.push(Document::Line(Line::soft()));
     }
 

--- a/crates/formatter/src/internal/format/mod.rs
+++ b/crates/formatter/src/internal/format/mod.rs
@@ -876,6 +876,9 @@ impl<'a> Format<'a> for Method {
             }
 
             signature.push(self.name.format(f));
+            let has_parameters_or_inner_parameter_comments =
+                !self.parameter_list.parameters.is_empty() || f.has_inner_comment(self.parameter_list.span());
+
             signature.push(self.parameter_list.format(f));
             if let Some(return_type) = &self.return_type_hint {
                 signature.push(return_type.format(f));
@@ -888,9 +891,15 @@ impl<'a> Format<'a> for Method {
             if let MethodBody::Concrete(_) = self.body {
                 body.push(match f.settings.method_brace_style {
                     BraceStyle::SameLine => Document::space(),
-                    BraceStyle::NextLine => Document::IfBreak(
-                        IfBreak::new(Document::space(), Document::Line(Line::hard())).with_id(signature_id),
-                    ),
+                    BraceStyle::NextLine => {
+                        if !has_parameters_or_inner_parameter_comments {
+                            Document::Line(Line::hard())
+                        } else {
+                            Document::IfBreak(
+                                IfBreak::new(Document::space(), Document::Line(Line::hard())).with_id(signature_id),
+                            )
+                        }
+                    }
                 });
             }
 
@@ -1730,6 +1739,9 @@ impl<'a> Format<'a> for Function {
             }
 
             signature.push(self.name.format(f));
+            let has_parameters_or_inner_parameter_comments =
+                !self.parameter_list.parameters.is_empty() || f.has_inner_comment(self.parameter_list.span());
+
             signature.push(self.parameter_list.format(f));
             if let Some(return_type) = &self.return_type_hint {
                 signature.push(return_type.format(f));
@@ -1744,13 +1756,19 @@ impl<'a> Format<'a> for Function {
                 Document::Group(Group::new(vec![
                     match f.settings.function_brace_style {
                         BraceStyle::SameLine => Document::space(),
-                        BraceStyle::NextLine => Document::IfBreak(
-                            IfBreak::new(
-                                Document::space(),
-                                Document::Array(vec![Document::Line(Line::hard()), Document::BreakParent]),
-                            )
-                            .with_id(signature_id),
-                        ),
+                        BraceStyle::NextLine => {
+                            if !has_parameters_or_inner_parameter_comments {
+                                Document::Line(Line::hard())
+                            } else {
+                                Document::IfBreak(
+                                    IfBreak::new(
+                                        Document::space(),
+                                        Document::Array(vec![Document::Line(Line::hard()), Document::BreakParent]),
+                                    )
+                                    .with_id(signature_id),
+                                )
+                            }
+                        }
                     },
                     self.body.format(f),
                 ])),

--- a/crates/formatter/src/internal/format/parameters.rs
+++ b/crates/formatter/src/internal/format/parameters.rs
@@ -42,6 +42,17 @@ pub(super) fn print_function_like_parameters<'a>(
     f: &mut FormatterState<'a>,
     parameter_list: &'a FunctionLikeParameterList,
 ) -> Document<'a> {
+    if parameter_list.parameters.is_empty() {
+        let mut contents = vec![Document::String("(")];
+        if let Some(comments) = f.print_inner_comment(parameter_list.span(), true) {
+            contents.push(comments);
+        }
+
+        contents.push(Document::String(")"));
+
+        return Document::Array(contents);
+    }
+
     let should_hug_the_parameters = should_hug_the_only_parameter(f, parameter_list);
     let should_break = !should_hug_the_parameters
         && f.settings.break_promoted_properties_list
@@ -57,15 +68,11 @@ pub(super) fn print_function_like_parameters<'a>(
         }
 
         printed.push(Document::String(","));
-        if should_hug_the_parameters {
-            printed.push(Document::space());
-        } else {
-            printed.push(Document::Line(Line::default()));
+        printed.push(Document::Line(Line::default()));
 
-            if f.is_next_line_empty(parameter.span()) {
-                printed.push(Document::BreakParent);
-                printed.push(Document::Line(Line::hard()));
-            }
+        if f.is_next_line_empty(parameter.span()) {
+            printed.push(Document::BreakParent);
+            printed.push(Document::Line(Line::hard()));
         }
     }
 

--- a/crates/formatter/tests/cases/break_fn_args/after.php
+++ b/crates/formatter/tests/cases/break_fn_args/after.php
@@ -1,0 +1,98 @@
+<?php
+
+$path = $this->viewCache->getCachedViewPath(
+    $view->path,
+    compiledView: fn() => $this->cleanupCompiled($this->compiler->compile($view->path)),
+);
+
+$path = $this->viewCache->getCachedViewPath(
+    $superLonnnnnnnngVariableNameeeeeeeeeeeee->path,
+    compiledView: function () {},
+);
+$path = $this->viewCache->getCachedViewPath(
+    $superLonnnnnnnnnnnnnnnnnnnngVariableNameeeeeeeeeeeee->path,
+    compiledView: function ( /* Hehe */ ) {},
+);
+$path = $this->viewCache->getCachedViewPath($superLonnnnnnnngVariableNameeeeeeeeeeeee->path, compiledView: function (
+    /* Hehe */
+) {});
+
+function shortFunName(): void
+{
+    echo 'Hello';
+}
+
+function shortFunName(
+    // No parameters
+): void {
+    echo 'Hello';
+}
+
+function shortFunName(
+    // No parameters
+): void {
+    echo 'Hello';
+}
+
+function shortFunName( /* No parameters */ ): void
+{
+    echo 'Hello';
+}
+
+function superLoooooooooooooooooooooooooooooooooooooooooooooooooooooongFuuuuuuuuuuuuuuuctioooooooooooooonNameeeeeeeeeeee(
+    /**
+     * No parameters
+     */
+): void {
+    echo 'Hello';
+}
+
+function superLoooooooooooooooooooooooooooooooooooooooooooooooooooooongFuuuuuuuuuuuuuuuctioooooooooooooonNameeeeeeeeeeee(
+    /* No parameters */
+): void {
+    echo 'Hello';
+}
+
+function superLoooooooooooooooooooooooooooooooooooooooooooooooooooooongFuuuuuuuuuuuuuuuctioooooooooooooonNameeeeeeeeeeee(
+    /// No parameters
+): void {
+    echo 'Hello';
+}
+
+function superLoooooooooooooooooooooooooooooooooooooooooooooooooooooongFuuuuuuuuuuuuuuuctioooooooooooooonNameeeeeeeeeeee(): void
+{
+    echo 'Hello';
+}
+
+class Example
+{
+    public function before(): void
+    {
+        echo 'Hello';
+    }
+
+    public function superLoooooooooooooooooooooooooooooooooooooooooooooooooooooongFuuuuuuuuuuuuuuuctioooooooooooooonNameeeeeeeeeeee(
+        /**
+         * No parameters
+         */
+    ): void {
+        echo 'Hello';
+    }
+
+    public function superLoooooooooooooooooooooooooooooooooooooooooooooooooooooongFuuuuuuuuuuuuuuuctioooooooooooooonNameeeeeeeeeeee(
+        /* No parameters */
+    ): void {
+        echo 'Hello';
+    }
+
+    public function superLoooooooooooooooooooooooooooooooooooooooooooooooooooooongFuuuuuuuuuuuuuuuctioooooooooooooonNameeeeeeeeeeee(
+        /// No parameters
+    ): void {
+        echo 'Hello';
+    }
+
+    public function superLoooooooooooooooooooooooooooooooooooooooooooooooooooooongFuuuuuuuuuuuuuuuctioooooooooooooonNameeeeeeeeeeee(): void
+    {
+        echo 'Hello';
+    }
+}

--- a/crates/formatter/tests/cases/break_fn_args/before.php
+++ b/crates/formatter/tests/cases/break_fn_args/before.php
@@ -1,0 +1,95 @@
+<?php
+
+$path = $this->viewCache->getCachedViewPath(
+   $view->path,
+    compiledView: fn () => $this->cleanupCompiled($this->compiler->compile($view->path)),
+);
+
+$path = $this->viewCache->getCachedViewPath($superLonnnnnnnngVariableNameeeeeeeeeeeee->path, compiledView: function() {});
+$path = $this->viewCache->getCachedViewPath($superLonnnnnnnnnnnnnnnnnnnngVariableNameeeeeeeeeeeee->path, compiledView: function ( /* Hehe */ ) {});
+$path = $this->viewCache->getCachedViewPath($superLonnnnnnnngVariableNameeeeeeeeeeeee->path, compiledView: function ( /* Hehe */ ) {});
+
+function shortFunName(): void
+{
+    echo 'Hello';
+}
+
+function shortFunName(
+// No parameters
+): void
+{
+    echo 'Hello';
+}
+
+function shortFunName( // No parameters
+): void
+{
+    echo 'Hello';
+}
+
+function shortFunName( /* No parameters */
+): void
+{
+    echo 'Hello';
+}
+
+function superLoooooooooooooooooooooooooooooooooooooooooooooooooooooongFuuuuuuuuuuuuuuuctioooooooooooooonNameeeeeeeeeeee(
+    /**
+     * No parameters
+     */
+): void {
+    echo 'Hello';
+}
+
+function superLoooooooooooooooooooooooooooooooooooooooooooooooooooooongFuuuuuuuuuuuuuuuctioooooooooooooonNameeeeeeeeeeee( /* No parameters */ ): void {
+    echo 'Hello';
+}
+
+function superLoooooooooooooooooooooooooooooooooooooooooooooooooooooongFuuuuuuuuuuuuuuuctioooooooooooooonNameeeeeeeeeeee( /// No parameters
+): void {
+    echo 'Hello';
+}
+
+function superLoooooooooooooooooooooooooooooooooooooooooooooooooooooongFuuuuuuuuuuuuuuuctioooooooooooooonNameeeeeeeeeeee(
+): void {
+    echo 'Hello';
+}
+
+
+class Example {
+    public
+    function before(): void
+    {
+        echo 'Hello';
+    }
+    
+    public
+    function superLoooooooooooooooooooooooooooooooooooooooooooooooooooooongFuuuuuuuuuuuuuuuctioooooooooooooonNameeeeeeeeeeee(
+        /**
+         * No parameters
+         */
+    ): void {
+        echo 'Hello';
+    }
+    
+    public
+    function superLoooooooooooooooooooooooooooooooooooooooooooooooooooooongFuuuuuuuuuuuuuuuctioooooooooooooonNameeeeeeeeeeee(
+        /* No parameters */
+    ): void {
+        echo 'Hello';
+    }
+    
+    public
+    function superLoooooooooooooooooooooooooooooooooooooooooooooooooooooongFuuuuuuuuuuuuuuuctioooooooooooooonNameeeeeeeeeeee(
+        /// No parameters
+    ): void {
+        echo 'Hello';
+    }
+    
+    public
+    function superLoooooooooooooooooooooooooooooooooooooooooooooooooooooongFuuuuuuuuuuuuuuuctioooooooooooooonNameeeeeeeeeeee(): void
+    {
+        echo 'Hello';
+    }
+}
+

--- a/crates/formatter/tests/cases/break_fn_args/settings.inc
+++ b/crates/formatter/tests/cases/break_fn_args/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings::default()

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -101,3 +101,4 @@ test_case!(awaitable);
 test_case!(argument_list_comments);
 test_case!(space_after_not_operator);
 test_case!(breaking_named_arguments);
+test_case!(break_fn_args);


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR fixes a bug in the formatter which resulted in the parameter list of any function-like node to be broken into multiple lines when it had no parameters, and also fixes an issue with parameter lists missing inner comments in some cases.

This PR also fixes a bug in the formatting of argument lists where in some cases arguments will lose their comments due to being formatted more than once.

## 🔍 Context & Motivation

The bug was reported by a user in #100 

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed incorrect handling of parameter lists in the formatter.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Related to #100 

## 📝 Notes for Reviewers

