### PR TITLE
feat(formatter): improve the member access chaining eligiblity logic

### DIFF
--- a/crates/formatter/src/internal/format/expression.rs
+++ b/crates/formatter/src/internal/format/expression.rs
@@ -62,7 +62,7 @@ impl<'a> Format<'a> for Expression {
                 Expression::Clone(c) => c.format(f),
                 Expression::Call(c) => {
                     if let Some(access_chain) = collect_member_access_chain(self) {
-                        if access_chain.is_eligible_for_chaining() {
+                        if access_chain.is_eligible_for_chaining(f) {
                             print_member_access_chain(&access_chain, f)
                         } else {
                             c.format(f)
@@ -73,7 +73,7 @@ impl<'a> Format<'a> for Expression {
                 }
                 Expression::Access(a) => {
                     if let Some(access_chain) = collect_member_access_chain(self) {
-                        if access_chain.is_eligible_for_chaining() {
+                        if access_chain.is_eligible_for_chaining(f) {
                             print_member_access_chain(&access_chain, f)
                         } else {
                             a.format(f)

--- a/crates/formatter/src/internal/format/misc.rs
+++ b/crates/formatter/src/internal/format/misc.rs
@@ -70,7 +70,7 @@ pub(super) fn should_hug_expression<'a>(f: &FormatterState<'a>, expression: &'a 
 
     if let Expression::Call(_) = expression {
         // Don't hug calls if they are part of a member access chain
-        return collect_member_access_chain(expression).is_none_or(|chain| !chain.is_eligible_for_chaining());
+        return collect_member_access_chain(expression).is_none_or(|chain| !chain.is_eligible_for_chaining(f));
     }
 
     if let Expression::Instantiation(instantiation) = expression {

--- a/crates/formatter/tests/cases/member_access_chain/after.php
+++ b/crates/formatter/tests/cases/member_access_chain/after.php
@@ -1,0 +1,84 @@
+<?php
+
+class Example
+{
+    public function something(): void
+    {
+        return $formattedArgumentName
+            ->wrap('<style="fg-gray dim">------------</style>', '<style="fg-gray dim">------------</style>')
+            ->toString();
+    }
+
+    public function something(): void
+    {
+        return $this->wrap(
+            '<style="fg-gray dim">------------</style>',
+            '<style="fg-gray dim">------------</style>',
+        )->toString();
+    }
+
+    public function something(): void
+    {
+        return $foo->wrap(
+            '<style="fg-gray dim">------------</style>',
+            '<style="fg-gray dim">------------</style>',
+        )->toString();
+    }
+
+    public function something(): void
+    {
+        return Foo->wrap(
+            '<style="fg-gray dim">------------</style>',
+            '<style="fg-gray dim">------------</style>',
+        )->toString();
+    }
+
+    public function something(): void
+    {
+        return Quz\Foo->wrap(
+            '<style="fg-gray dim">------------</style>',
+            '<style="fg-gray dim">------------</style>',
+        )->toString();
+    }
+
+    public function something(): void
+    {
+        return Quz\Foo->wrap(
+            '<style="fg-gray dim">------------------------------------</style>',
+            '<style="fg-gray dim">------------------------------------</style>',
+        )->toString();
+    }
+
+    public function something(): void
+    {
+        return new Bar()
+            ->wrap(
+                '<style="fg-gray dim">------------------------------------</style>',
+                '<style="fg-gray dim">------------------------------------</style>',
+            )
+            ->toString();
+    }
+
+    public function something(): void
+    {
+        $attribute = $this->matchedRoute
+            ->route
+            ->handler
+            ->getAttribute(Allow::class);
+    }
+
+    public function something(): void
+    {
+        EventLoop::getDriver()->run();
+    }
+
+    public function something(): void
+    {
+        $availableCommands = arr($this->repository->getPendingCommands())
+            ->filter(fn(object $command, string $uuid) => !array_key_exists($uuid, $processes));
+    }
+}
+
+return new CreateTableStatement('permissions')
+    ->primary()
+    ->varchar('name');

--- a/crates/formatter/tests/cases/member_access_chain/before.php
+++ b/crates/formatter/tests/cases/member_access_chain/before.php
@@ -1,0 +1,80 @@
+<?php
+
+class Example {
+    public function something(): void {
+        return $formattedArgumentName->wrap(
+        '<style="fg-gray dim">------------</style>',
+        '<style="fg-gray dim">------------</style>',
+
+        )->toString();
+    }
+
+    public function something(): void {
+        return $this->wrap(
+        '<style="fg-gray dim">------------</style>',
+        '<style="fg-gray dim">------------</style>',
+
+        )->toString();
+    }
+
+    public function something(): void {
+        return $foo->wrap(
+        '<style="fg-gray dim">------------</style>',
+        '<style="fg-gray dim">------------</style>',
+
+        )->toString();
+    }
+
+    public function something(): void {
+        return Foo->wrap(
+        '<style="fg-gray dim">------------</style>',
+        '<style="fg-gray dim">------------</style>',
+
+        )->toString();
+    }
+
+    public function something(): void {
+        return Quz\Foo->wrap(
+        '<style="fg-gray dim">------------</style>',
+        '<style="fg-gray dim">------------</style>',
+
+        )->toString();
+    }
+
+    public function something(): void {
+        return Quz\Foo->wrap(
+        '<style="fg-gray dim">------------------------------------</style>',
+        '<style="fg-gray dim">------------------------------------</style>',
+
+        )->toString();
+    }
+
+    public function something(): void {
+        return new Bar()
+        ->wrap(
+        '<style="fg-gray dim">------------------------------------</style>',
+        '<style="fg-gray dim">------------------------------------</style>',
+
+        )->toString();
+    }
+
+    public function something(): void {
+        $attribute = $this->matchedRoute
+            ->route
+            ->handler
+            ->getAttribute(Allow::class);
+    }
+
+    public function something(): void {
+        EventLoop::getDriver()->run();
+    }
+
+    public function something(): void {
+        $availableCommands = arr($this->repository->getPendingCommands())
+            ->filter(fn (object $command, string $uuid) => ! array_key_exists($uuid, $processes));
+    }
+}
+
+
+return new CreateTableStatement('permissions')
+    ->primary()    ->varchar('name');

--- a/crates/formatter/tests/cases/member_access_chain/settings.inc
+++ b/crates/formatter/tests/cases/member_access_chain/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings::default()

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -102,3 +102,4 @@ test_case!(argument_list_comments);
 test_case!(space_after_not_operator);
 test_case!(breaking_named_arguments);
 test_case!(break_fn_args);
+test_case!(member_access_chain);


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR improves the member access chain eligiblity logic, and adds a new condition of to when a chain will always break.

## 🔍 Context & Motivation

This improvement is implemented as part of a. series of fixes to the formatter to help improve the output as reported in issues #100 

## 🛠️ Summary of Changes

- **Feature:** Improved the formatter member access chain eligiblity logic.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Related to #100 

## 📝 Notes for Reviewers
