### PR TITLE
feat(formatter): do not wrap return value if its a binary and either sides is a simple expression

### DIFF
--- a/composer/InstallMagoBinaryCommand.php
+++ b/composer/InstallMagoBinaryCommand.php
@@ -79,25 +79,24 @@ final class InstallMagoBinaryCommand extends BaseCommand
         $io->write(" - {$download['file']}");
 
         $downloaded_file = $release_dir . '/' . $download['file'];
-        $promise = $downloader->addCopy(
-            $download['url'],
-            $downloaded_file,
-        )->then(static function (Response $response) use (
-            $filesystem,
-            $release_dir,
-            $downloaded_file,
-            $executable_platform_file,
-            $executable_platform_content,
-        ): Response {
-            $phar = new \PharData($downloaded_file);
-            $phar->extractTo($release_dir);
+        $promise = $downloader
+            ->addCopy($download['url'], $downloaded_file)
+            ->then(static function (Response $response) use (
+                $filesystem,
+                $release_dir,
+                $downloaded_file,
+                $executable_platform_file,
+                $executable_platform_content,
+            ): Response {
+                $phar = new \PharData($downloaded_file);
+                $phar->extractTo($release_dir);
 
-            $filesystem->remove($downloaded_file);
+                $filesystem->remove($downloaded_file);
 
-            file_put_contents($executable_platform_file, $executable_platform_content);
+                file_put_contents($executable_platform_file, $executable_platform_content);
 
-            return $response;
-        });
+                return $response;
+            });
 
         $io->write('');
         $progress_bar = ($io instanceof ConsoleIO) ? $io->getProgressBar() : null;

--- a/crates/formatter/src/internal/format/mod.rs
+++ b/crates/formatter/src/internal/format/mod.rs
@@ -1,6 +1,7 @@
 use mago_ast::*;
 use mago_span::HasSpan;
 use mago_span::Span;
+use misc::is_simple_expression;
 
 use crate::document::*;
 use crate::internal::FormatterState;
@@ -1211,7 +1212,7 @@ impl<'a> Format<'a> for Return {
                         expression = &parenthesized.expression;
                     }
 
-                    if expression.is_binary()
+                    if matches!(expression, Expression::Binary(binary) if !is_simple_expression(&binary.lhs) && !is_simple_expression(&binary.rhs))
                         || matches!(expression, Expression::Conditional(conditional) if (
                             conditional.then.is_none() || (
                                 matches!(conditional.then.as_ref().map(|e| e.as_ref()), Some(Expression::Conditional(_))) &&

--- a/crates/formatter/tests/cases/return_wrapping/after.php
+++ b/crates/formatter/tests/cases/return_wrapping/after.php
@@ -1,0 +1,19 @@
+<?php
+
+class Example
+{
+    public function something(): void
+    {
+        return $handler->run(function (string $output, string $buffer) use ($log): bool {
+            if ($output === Process::ERR) {
+                return true;
+            }
+
+            if ($line = trim($buffer)) {
+                $log($line);
+            }
+
+            return true;
+        }) === 0;
+    }
+}

--- a/crates/formatter/tests/cases/return_wrapping/before.php
+++ b/crates/formatter/tests/cases/return_wrapping/before.php
@@ -1,0 +1,18 @@
+<?php
+
+class Example {
+    public function something(): void {
+        return $handler->run(function (string $output, string $buffer) use ($log): bool {
+            if ($output === Process::ERR) {
+                return true;
+            }
+        
+            if ($line = trim($buffer)) {
+                $log($line);
+            }
+        
+            return true;
+        }) === 0;
+    }
+
+}

--- a/crates/formatter/tests/cases/return_wrapping/settings.inc
+++ b/crates/formatter/tests/cases/return_wrapping/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings::default()

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -103,3 +103,4 @@ test_case!(space_after_not_operator);
 test_case!(breaking_named_arguments);
 test_case!(break_fn_args);
 test_case!(member_access_chain);
+test_case!(return_wrapping);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Previously, if the expression on the right side of a return statement is a binary operation, it will always be wrapped within parenthesis if it breaks into multiple lines, this has now been adjusted to not wrap binary operations if either sides is a simple expression ( e.g literal, simple word ).

## 🔍 Context & Motivation

This change was requested in issue #100 to provide better readability.

## 🛠️ Summary of Changes

- **Feature:** Avoid wrapping return valie in parenthesis if its a binary operation, and either sides is a simple expression.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Related to #100 

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
