### PR TITLE
feat(formatter): improve arrow function formatting.

### DIFF
--- a/crates/ast/src/ast/argument.rs
+++ b/crates/ast/src/ast/argument.rs
@@ -52,6 +52,11 @@ pub struct NamedArgument {
 }
 
 impl Argument {
+    #[inline]
+    pub const fn is_positional(&self) -> bool {
+        matches!(self, Argument::Positional(_))
+    }
+
     pub fn value(&self) -> &Expression {
         match self {
             Argument::Positional(arg) => &arg.value,

--- a/crates/ast/src/ast/call.rs
+++ b/crates/ast/src/ast/call.rs
@@ -53,6 +53,18 @@ pub struct StaticMethodCall {
     pub argument_list: ArgumentList,
 }
 
+impl Call {
+    #[inline]
+    pub fn get_argument_list(&self) -> &ArgumentList {
+        match self {
+            Call::Function(f) => &f.argument_list,
+            Call::Method(m) => &m.argument_list,
+            Call::NullSafeMethod(n) => &n.argument_list,
+            Call::StaticMethod(s) => &s.argument_list,
+        }
+    }
+}
+
 impl HasSpan for Call {
     fn span(&self) -> Span {
         match self {

--- a/crates/formatter/src/internal/format/expression.rs
+++ b/crates/formatter/src/internal/format/expression.rs
@@ -420,12 +420,6 @@ impl<'a> Format<'a> for DieConstruct {
     }
 }
 
-impl<'a> Format<'a> for ArgumentList {
-    fn format(&'a self, f: &mut FormatterState<'a>) -> Document<'a> {
-        wrap!(f, self, ArgumentList, { print_argument_list(f, self) })
-    }
-}
-
 impl<'a> Format<'a> for Argument {
     fn format(&'a self, f: &mut FormatterState<'a>) -> Document<'a> {
         wrap!(f, self, Argument, {
@@ -1159,8 +1153,8 @@ impl<'a> Format<'a> for AnonymousClass {
             }
 
             signature.push(self.class.format(f));
-            if let Some(arguments) = &self.arguments {
-                signature.push(arguments.format(f));
+            if let Some(argument_list) = &self.arguments {
+                signature.push(print_argument_list(f, argument_list));
             }
 
             if let Some(extends) = &self.extends {

--- a/crates/formatter/src/internal/format/expression.rs
+++ b/crates/formatter/src/internal/format/expression.rs
@@ -23,6 +23,7 @@ use crate::internal::format::misc;
 use crate::internal::format::misc::print_attribute_list_sequence;
 use crate::internal::format::misc::print_condition;
 use crate::internal::format::misc::print_modifiers;
+use crate::internal::format::return_value::format_return_value;
 use crate::internal::format::string::print_string;
 use crate::internal::utils;
 use crate::settings::*;
@@ -620,7 +621,7 @@ impl<'a> Format<'a> for ArrowFunction {
             }
 
             contents.push(Document::String(" => "));
-            contents.push(self.expression.format(f));
+            contents.push(format_return_value(f, self.expression.as_ref()));
 
             if let Some(attributes) = attributes {
                 Document::Group(Group::new(vec![attributes, Document::Group(Group::new(contents))]))

--- a/crates/formatter/src/internal/format/misc.rs
+++ b/crates/formatter/src/internal/format/misc.rs
@@ -147,17 +147,18 @@ pub(super) fn is_simple_expression(node: &Expression) -> bool {
     )
 }
 
-pub(super) fn is_string_word_type(node: &Expression) -> bool {
-    match node {
-        Expression::Static(_) | Expression::Parent(_) | Expression::Self_(_) => true,
-        Expression::MagicConstant(_) => true,
-        Expression::Identifier(identifier) => matches!(identifier, Identifier::Local(_)),
-        Expression::ConstantAccess(constant_access) => matches!(constant_access.name, Identifier::Local(_)),
-        Expression::Variable(variable) => {
-            matches!(variable, Variable::Direct(_))
-        }
-        _ => false,
-    }
+#[inline]
+pub(super) const fn is_string_word_type(node: &Expression) -> bool {
+    matches!(
+        node,
+        Expression::Static(_)
+            | Expression::Parent(_)
+            | Expression::Self_(_)
+            | Expression::MagicConstant(_)
+            | Expression::Identifier(Identifier::Local(_))
+            | Expression::ConstantAccess(ConstantAccess { name: Identifier::Local(_) })
+            | Expression::Variable(Variable::Direct(_))
+    )
 }
 
 pub(super) fn print_colon_delimited_body<'a>(

--- a/crates/formatter/src/internal/format/mod.rs
+++ b/crates/formatter/src/internal/format/mod.rs
@@ -1,7 +1,6 @@
 use mago_ast::*;
 use mago_span::HasSpan;
 use mago_span::Span;
-use return_value::format_return_value;
 
 use crate::document::*;
 use crate::internal::FormatterState;
@@ -16,6 +15,7 @@ use crate::internal::format::misc::print_attribute_list_sequence;
 use crate::internal::format::misc::print_colon_delimited_body;
 use crate::internal::format::misc::print_modifiers;
 use crate::internal::format::parameters::print_function_like_parameters;
+use crate::internal::format::return_value::format_return_value;
 use crate::internal::format::statement::print_statement_sequence;
 use crate::internal::utils;
 use crate::settings::*;

--- a/crates/formatter/src/internal/format/mod.rs
+++ b/crates/formatter/src/internal/format/mod.rs
@@ -1,7 +1,7 @@
 use mago_ast::*;
 use mago_span::HasSpan;
 use mago_span::Span;
-use misc::is_simple_expression;
+use return_value::format_return_value;
 
 use crate::document::*;
 use crate::internal::FormatterState;
@@ -12,15 +12,12 @@ use crate::internal::format::block::print_block_of_nodes;
 use crate::internal::format::call_node::CallLikeNode;
 use crate::internal::format::call_node::print_call_like_node;
 use crate::internal::format::class_like::print_class_like_body;
-use crate::internal::format::misc::has_new_line_in_range;
 use crate::internal::format::misc::print_attribute_list_sequence;
 use crate::internal::format::misc::print_colon_delimited_body;
 use crate::internal::format::misc::print_modifiers;
 use crate::internal::format::parameters::print_function_like_parameters;
 use crate::internal::format::statement::print_statement_sequence;
 use crate::internal::utils;
-use crate::internal::utils::get_left_side;
-use crate::internal::utils::has_naked_left_side;
 use crate::settings::*;
 use crate::wrap;
 
@@ -36,6 +33,7 @@ pub mod expression;
 pub mod member_access;
 pub mod misc;
 pub mod parameters;
+pub mod return_value;
 pub mod statement;
 pub mod string;
 
@@ -1171,70 +1169,17 @@ impl<'a> Format<'a> for Enum {
 
 impl<'a> Format<'a> for Return {
     fn format(&'a self, f: &mut FormatterState<'a>) -> Document<'a> {
-        fn return_argument_has_leading_comment<'a>(f: &mut FormatterState<'a>, argument: &'a Expression) -> bool {
-            if f.has_leading_own_line_comment(argument.span())
-                || f.has_comment_with_filter(argument.span(), CommentFlags::Leading, |comment| {
-                    has_new_line_in_range(f.source_text, comment.start, comment.end)
-                })
-            {
-                return true;
-            }
-
-            if has_naked_left_side(argument) {
-                let mut left_most = argument;
-                while let Some(new_left_most) = get_left_side(left_most) {
-                    left_most = new_left_most;
-
-                    if f.has_leading_own_line_comment(left_most.span()) {
-                        return true;
-                    }
-                }
-            }
-
-            false
-        }
-
         wrap!(f, self, Return, {
-            let mut parts = vec![];
+            let mut contents = vec![self.r#return.format(f)];
 
-            parts.push(self.r#return.format(f));
             if let Some(value) = &self.value {
-                parts.push(Document::space());
-
-                if return_argument_has_leading_comment(f, value) {
-                    parts.push(Document::String("("));
-                    parts.push(Document::Indent(vec![Document::Line(Line::hard()), value.format(f)]));
-                    parts.push(Document::Line(Line::hard()));
-                    parts.push(Document::String(")"));
-                } else {
-                    let mut expression = value;
-                    while let Expression::Parenthesized(parenthesized) = expression {
-                        expression = &parenthesized.expression;
-                    }
-
-                    if matches!(expression, Expression::Binary(binary) if !is_simple_expression(&binary.lhs) && !is_simple_expression(&binary.rhs))
-                        || matches!(expression, Expression::Conditional(conditional) if (
-                            conditional.then.is_none() || (
-                                matches!(conditional.then.as_ref().map(|e| e.as_ref()), Some(Expression::Conditional(_))) &&
-                                matches!(conditional.r#else.as_ref(), Expression::Conditional(_))
-                            )
-                        ))
-                    {
-                        parts.push(Document::Group(Group::new(vec![
-                            Document::IfBreak(IfBreak::then(Document::String("("))),
-                            Document::Indent(vec![Document::Line(Line::soft()), value.format(f)]),
-                            Document::Line(Line::soft()),
-                            Document::IfBreak(IfBreak::then(Document::String(")"))),
-                        ])));
-                    } else {
-                        parts.push(value.format(f));
-                    }
-                }
+                contents.push(Document::space());
+                contents.push(format_return_value(f, value));
             }
 
-            parts.push(self.terminator.format(f));
+            contents.push(self.terminator.format(f));
 
-            Document::Group(Group::new(parts))
+            Document::Group(Group::new(contents))
         })
     }
 }

--- a/crates/formatter/src/internal/format/return_value.rs
+++ b/crates/formatter/src/internal/format/return_value.rs
@@ -1,0 +1,73 @@
+use mago_ast::*;
+use mago_span::HasSpan;
+
+use crate::document::Document;
+use crate::document::Group;
+use crate::document::IfBreak;
+use crate::document::Line;
+use crate::internal::FormatterState;
+use crate::internal::comment::CommentFlags;
+use crate::internal::format::Format;
+use crate::internal::format::misc::has_new_line_in_range;
+use crate::internal::format::misc::is_simple_expression;
+use crate::internal::utils::get_left_side;
+use crate::internal::utils::has_naked_left_side;
+
+pub fn format_return_value<'a>(f: &mut FormatterState<'a>, value: &'a Expression) -> Document<'a> {
+    let mut contents = Vec::new();
+
+    if return_argument_has_leading_comment(f, value) {
+        contents.push(Document::String("("));
+        contents.push(Document::Indent(vec![Document::Line(Line::hard()), value.format(f)]));
+        contents.push(Document::Line(Line::hard()));
+        contents.push(Document::String(")"));
+    } else {
+        let mut expression = value;
+        while let Expression::Parenthesized(parenthesized) = expression {
+            expression = &parenthesized.expression;
+        }
+
+        if matches!(expression, Expression::Binary(binary) if !is_simple_expression(&binary.lhs) && !is_simple_expression(&binary.rhs))
+            || matches!(expression, Expression::Conditional(conditional) if (
+                conditional.then.is_none() || (
+                    matches!(conditional.then.as_ref().map(|e| e.as_ref()), Some(Expression::Conditional(_))) &&
+                    matches!(conditional.r#else.as_ref(), Expression::Conditional(_))
+                )
+            ))
+        {
+            contents.push(Document::Group(Group::new(vec![
+                Document::IfBreak(IfBreak::then(Document::String("("))),
+                Document::Indent(vec![Document::Line(Line::soft()), value.format(f)]),
+                Document::Line(Line::soft()),
+                Document::IfBreak(IfBreak::then(Document::String(")"))),
+            ])));
+        } else {
+            contents.push(value.format(f));
+        }
+    }
+
+    Document::Array(contents)
+}
+
+fn return_argument_has_leading_comment<'a>(f: &mut FormatterState<'a>, argument: &'a Expression) -> bool {
+    if f.has_leading_own_line_comment(argument.span())
+        || f.has_comment_with_filter(argument.span(), CommentFlags::Leading, |comment| {
+            has_new_line_in_range(f.source_text, comment.start, comment.end)
+        })
+    {
+        return true;
+    }
+
+    if has_naked_left_side(argument) {
+        let mut left_most = argument;
+        while let Some(new_left_most) = get_left_side(left_most) {
+            left_most = new_left_most;
+
+            if f.has_leading_own_line_comment(left_most.span()) {
+                return true;
+            }
+        }
+    }
+
+    false
+}

--- a/crates/formatter/tests/cases/arrow_return/after.php
+++ b/crates/formatter/tests/cases/arrow_return/after.php
@@ -1,0 +1,15 @@
+<?php
+
+class Example
+{
+    public function something(): void
+    {
+        $command = array_find(
+            array: $this->consoleConfig->commands,
+            callback: fn(ConsoleCommand $consoleCommand) => (
+                $consoleCommand->handler->getDeclaringClass()->getName() === $command[0] &&
+                $consoleCommand->handler->getName() === $command[1]
+            ),
+        );
+    }
+}

--- a/crates/formatter/tests/cases/arrow_return/after.php
+++ b/crates/formatter/tests/cases/arrow_return/after.php
@@ -11,5 +11,9 @@ class Example
                 $consoleCommand->handler->getName() === $command[1]
             ),
         );
+
+        $callable = new CommandBusMiddlewareCallable(
+            fn(object $command) => $this->container->get($middlewareClass)($command, $callable),
+        );
     }
 }

--- a/crates/formatter/tests/cases/arrow_return/before.php
+++ b/crates/formatter/tests/cases/arrow_return/before.php
@@ -8,5 +8,9 @@ class Example {
                 $consoleCommand->handler->getDeclaringClass()->getName() === $command[0]
                     && $consoleCommand->handler->getName() === $command[1],
         );
+
+        $callable = new CommandBusMiddlewareCallable(
+            fn (object $command) => $this->container->get($middlewareClass)($command, $callable),
+        );
     }
 }

--- a/crates/formatter/tests/cases/arrow_return/before.php
+++ b/crates/formatter/tests/cases/arrow_return/before.php
@@ -1,0 +1,12 @@
+<?php
+
+class Example {
+    public function something(): void {
+        $command = array_find(
+            array: $this->consoleConfig->commands,
+            callback: fn (ConsoleCommand $consoleCommand) =>
+                $consoleCommand->handler->getDeclaringClass()->getName() === $command[0]
+                    && $consoleCommand->handler->getName() === $command[1],
+        );
+    }
+}

--- a/crates/formatter/tests/cases/arrow_return/settings.inc
+++ b/crates/formatter/tests/cases/arrow_return/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings::default()

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -104,3 +104,4 @@ test_case!(breaking_named_arguments);
 test_case!(break_fn_args);
 test_case!(member_access_chain);
 test_case!(return_wrapping);
+test_case!(arrow_return);


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR improves the formatting of arrow functions in two main ways:

- Consistent formatting with return statements: The expression on the right-hand side of an arrow function is now formatted using the same logic as return statement values. This means that in some cases, the expression might be wrapped in parentheses for better readability, especially when it spans multiple lines.

- Improved argument list breaking: When an arrow function is the only argument in a function call, and that arrow function has a simple expression or a function-call-like expression with simple arguments, the formatter will now break the argument list into multiple lines before breaking the arrow function's expression. This makes the code easier to read and understand.

## 🔍 Context & Motivation

This PR addresses issues raised in #100 where a user reported that the formatting of arrow functions could be difficult to read in certain cases. The changes in this PR aim to improve the readability and consistency of arrow function formatting.

## 🛠️ Summary of Changes

- **Feature:** Format arrow function expressions using the same logic as return statement values.
- **Feature:** Improve the breaking behavior of argument lists containing single arrow function arguments.
- **Tests:** Added new tests to cover the updated arrow function formatting behavior.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Related to #100 

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
