### PR TITLE
fix(formatter): correct formatting of default arm in match expressions

### DIFF
--- a/crates/formatter/src/internal/format/expression.rs
+++ b/crates/formatter/src/internal/format/expression.rs
@@ -763,10 +763,7 @@ impl<'a> Format<'a> for MatchDefaultArm {
         wrap!(f, self, MatchDefaultArm, {
             Document::Group(Group::new(vec![
                 self.default.format(f),
-                Document::IndentIfBreak(IndentIfBreak::new(vec![
-                    Document::IfBreak(IfBreak::new(Document::Line(Line::default()), Document::space())),
-                    Document::String("=> "),
-                ])),
+                Document::String(" => "),
                 self.expression.format(f),
             ]))
         })
@@ -782,14 +779,14 @@ impl<'a> Format<'a> for MatchExpressionArm {
                 contents.push(condition.format(f));
                 if i != (len - 1) {
                     contents.push(Document::String(","));
-                    contents.push(Document::IfBreak(IfBreak::new(Document::Line(Line::default()), Document::space())));
+                    contents.push(Document::Line(Line::default()));
                 } else if f.settings.trailing_comma {
                     contents.push(Document::IfBreak(IfBreak::then(Document::String(","))));
                 }
             }
 
             contents.push(Document::IndentIfBreak(IndentIfBreak::new(vec![
-                Document::IfBreak(IfBreak::new(Document::Line(Line::default()), Document::space())),
+                Document::Line(Line::default()),
                 Document::String("=> "),
             ])));
 

--- a/crates/formatter/tests/cases/match_breaking/after.php
+++ b/crates/formatter/tests/cases/match_breaking/after.php
@@ -1,0 +1,36 @@
+<?php
+
+final readonly class TestCase
+{
+    private function getStubFileFromConfigType(ConfigType $configType): StubFile
+    {
+        try {
+            $stubPath = dirname(__DIR__) . '/Stubs';
+
+            return match ($configType) {
+                ConfigType::CONSOLE => StubFile::from($stubPath . '/console.config.stub.php'),
+                ConfigType::CACHE => StubFile::from($stubPath . '/cache.config.stub.php'),
+                ConfigType::LOG => StubFile::from($stubPath . '/log.config.stub.php'),
+                ConfigType::COMMAND_BUS => StubFile::from($stubPath . '/command-bus.config.stub.php'),
+                ConfigType::EVENT_BUS => StubFile::from($stubPath . '/event-bus.config.stub.php'),
+                ConfigType::VIEW => StubFile::from($stubPath . '/view.config.stub.php'),
+                ConfigType::BLADE => StubFile::from($stubPath . '/blade.config.stub.php'),
+                ConfigType::TWIG => StubFile::from($stubPath . '/twig.config.stub.php'),
+                ConfigType::DATABASE => StubFile::from($stubPath . '/database.config.stub.php'), // @phpstan-ignore match.alwaysTrue (Because this is a guardrail for the future implementations)
+                ConfigType::COMMAND => throw new InvalidArgumentException(sprintf(
+                    'The "%s" config type is no longer supported, use ConfigType::COMMAND_BUS instead.',
+                    $configType->value,
+                )),
+                default => throw new InvalidArgumentException(sprintf(
+                    'The "%s" config type has no supported stub file.',
+                    $configType->value,
+                )),
+            };
+        } catch (InvalidArgumentException $invalidArgumentException) {
+            throw new FileGenerationFailedException(sprintf(
+                'Cannot retrieve stub file: %s',
+                $invalidArgumentException->getMessage(),
+            ));
+        }
+    }
+}

--- a/crates/formatter/tests/cases/match_breaking/before.php
+++ b/crates/formatter/tests/cases/match_breaking/before.php
@@ -1,0 +1,30 @@
+<?php
+
+
+final readonly class TestCase {
+    private function getStubFileFromConfigType(ConfigType $configType): StubFile
+        {
+            try {
+                $stubPath = dirname(__DIR__) . '/Stubs';
+    
+                return match ($configType) {
+                    ConfigType::CONSOLE => StubFile::from($stubPath . '/console.config.stub.php'),
+                    ConfigType::CACHE => StubFile::from($stubPath . '/cache.config.stub.php'),
+                    ConfigType::LOG => StubFile::from($stubPath . '/log.config.stub.php'),
+                    ConfigType::COMMAND_BUS => StubFile::from($stubPath . '/command-bus.config.stub.php'),
+                    ConfigType::EVENT_BUS => StubFile::from($stubPath . '/event-bus.config.stub.php'),
+                    ConfigType::VIEW => StubFile::from($stubPath . '/view.config.stub.php'),
+                    ConfigType::BLADE => StubFile::from($stubPath . '/blade.config.stub.php'),
+                    ConfigType::TWIG => StubFile::from($stubPath . '/twig.config.stub.php'),
+                    ConfigType::DATABASE => StubFile::from($stubPath . '/database.config.stub.php'), // @phpstan-ignore match.alwaysTrue (Because this is a guardrail for the future implementations)
+                    ConfigType::COMMAND => throw new InvalidArgumentException(sprintf(
+                        'The "%s" config type is no longer supported, use ConfigType::COMMAND_BUS instead.',
+                        $configType->value,
+                    )),
+                    default => throw new InvalidArgumentException(sprintf('The "%s" config type has no supported stub file.', $configType->value)),
+                };
+            } catch (InvalidArgumentException $invalidArgumentException) {
+                throw new FileGenerationFailedException(sprintf('Cannot retrieve stub file: %s', $invalidArgumentException->getMessage()));
+            }
+        }
+}

--- a/crates/formatter/tests/cases/match_breaking/settings.inc
+++ b/crates/formatter/tests/cases/match_breaking/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings::default()

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -105,3 +105,4 @@ test_case!(break_fn_args);
 test_case!(member_access_chain);
 test_case!(return_wrapping);
 test_case!(arrow_return);
+test_case!(match_breaking);


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR fixes a bug in the formatter that caused incorrect formatting of the `default` arm in `match` expressions.

## 🔍 Context & Motivation

The formatter was not handling the `default` arm in `match` expressions correctly, leading to inconsistent and sometimes confusing indentation and spacing. This PR addresses this issue by correcting the formatting logic for default arms.

## 🛠️ Summary of Changes

- **Bug Fix**: Corrected the formatting of the default arm in match expressions.
- **Tests**: Added new test cases to verify the correct formatting of default arms.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Related to #100 

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
