### PR TITLE
refactor(formatter): remove `keyword_case` option

### DIFF
--- a/crates/formatter/src/internal/format/expression.rs
+++ b/crates/formatter/src/internal/format/expression.rs
@@ -119,10 +119,7 @@ impl<'a> Format<'a> for UnaryPrefixOperator {
         wrap!(f, self, UnaryPrefixOperator, {
             let value = self.as_str(f.interner);
 
-            Document::String(match f.settings.keyword_case {
-                CasingStyle::Lowercase => f.as_str(value.to_lowercase()),
-                CasingStyle::Uppercase => f.as_str(value.to_uppercase()),
-            })
+            Document::String(f.as_str(value.to_lowercase()))
         })
     }
 }

--- a/crates/formatter/src/internal/format/mod.rs
+++ b/crates/formatter/src/internal/format/mod.rs
@@ -147,12 +147,7 @@ impl<'a> Format<'a> for OpeningTag {
 
 impl<'a> Format<'a> for FullOpeningTag {
     fn format(&'a self, f: &mut FormatterState<'a>) -> Document<'a> {
-        wrap!(f, self, FullOpeningTag, {
-            Document::String(match f.settings.keyword_case {
-                CasingStyle::Lowercase => "<?php",
-                CasingStyle::Uppercase => "<?PHP",
-            })
-        })
+        wrap!(f, self, FullOpeningTag, { Document::String("<?php") })
     }
 }
 
@@ -933,14 +928,9 @@ impl<'a> Format<'a> for MethodAbstractBody {
 impl<'a> Format<'a> for Keyword {
     fn format(&'a self, f: &mut FormatterState<'a>) -> Document<'a> {
         wrap!(f, self, Keyword, {
-            let mut value = f.lookup(&self.value);
+            let value = f.lookup(&self.value);
 
-            value = match f.settings.keyword_case {
-                CasingStyle::Lowercase => f.as_str(value.to_ascii_lowercase()),
-                CasingStyle::Uppercase => f.as_str(value.to_ascii_uppercase()),
-            };
-
-            Document::String(value)
+            Document::String(f.as_str(value.to_ascii_lowercase()))
         })
     }
 }
@@ -1266,10 +1256,7 @@ impl<'a> Format<'a> for Attribute {
 impl<'a> Format<'a> for Hint {
     fn format(&'a self, f: &mut FormatterState<'a>) -> Document<'a> {
         wrap!(f, self, Hint, {
-            let k = |v: &str| match f.settings.keyword_case {
-                CasingStyle::Lowercase => Document::String(f.as_str(v.to_ascii_lowercase())),
-                CasingStyle::Uppercase => Document::String(f.as_str(v.to_ascii_uppercase())),
-            };
+            let k = |v: &str| Document::String(f.as_str(v.to_ascii_lowercase()));
 
             match self {
                 Hint::Identifier(identifier) => identifier.format(f),

--- a/crates/formatter/src/settings.rs
+++ b/crates/formatter/src/settings.rs
@@ -68,36 +68,6 @@ pub struct FormatSettings {
     #[serde(default = "default_false")]
     pub space_around_declare_equals: bool,
 
-    /// Keyword casing (e.g., lowercase, uppercase).
-    ///
-    /// The formatter will convert keywords to the specified case.
-    ///
-    /// Example:
-    ///
-    /// ```php
-    /// // lowercase
-    /// if (true) {
-    ///    $foo = (string) $bar;
-    ///
-    ///    echo $foo;
-    ///
-    ///    return;
-    /// }
-    ///
-    /// // uppercase
-    /// IF (TRUE) {
-    ///   $foo = (STRING) $bar;
-    ///
-    ///   ECHO $foo;
-    ///
-    ///   RETURN;
-    /// }
-    /// ```
-    ///
-    /// Default: lowercase
-    #[serde(default)]
-    pub keyword_case: CasingStyle,
-
     /// In a control structure expression, is there a space after the opening parenthesis
     ///  and a space before the closing parenthesis?
     ///
@@ -630,7 +600,6 @@ impl Default for FormatSettings {
             single_quote: true,
             trailing_comma: true,
             space_around_declare_equals: false,
-            keyword_case: CasingStyle::default(),
             control_space_parens: false,
             closure_brace_style: BraceStyle::SameLine,
             function_brace_style: BraceStyle::NextLine,
@@ -672,16 +641,6 @@ pub enum EndOfLine {
     Crlf,
     #[serde(alias = "cr")]
     Cr,
-}
-
-/// Specifies the style of line endings.
-#[derive(Default, Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
-pub enum CasingStyle {
-    #[default]
-    #[serde(alias = "lowercase", alias = "lower")]
-    Lowercase,
-    #[serde(alias = "uppercase", alias = "upper")]
-    Uppercase,
 }
 
 /// Specifies the style of line endings.

--- a/docs/formatter/settings.md
+++ b/docs/formatter/settings.md
@@ -91,18 +91,6 @@ Controls whether spaces are added around the `=` sign in declare statements.
   space_around_declare_equals = false
   ```
 
-### `keyword_case`
-
-Specifies the case to use for keywords.
-
-- Default: `"lowercase"`
-- Type: `enum { "lowercase", "uppercase" }`
-- Example:
-
-  ```toml
-  keyword_case = "uppercase"
-  ```
-
 ### `control_space_parens`
 
 Controls whether spaces are added inside parentheses in control structures.

--- a/src/config/formatter.rs
+++ b/src/config/formatter.rs
@@ -47,10 +47,6 @@ pub struct FormatterConfiguration {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub space_around_declare_equals: Option<bool>,
 
-    /// Keyword casing (e.g., lowercase, uppercase, camelCase).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub keyword_case: Option<CasingStyle>,
-
     /// In a control structure expression, is there a space after the opening parenthesis
     ///  and a space before the closing parenthesis?
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -169,7 +165,6 @@ impl FormatterConfiguration {
             space_around_declare_equals: self
                 .space_around_declare_equals
                 .unwrap_or(default.space_around_declare_equals),
-            keyword_case: self.keyword_case.unwrap_or(default.keyword_case),
             control_space_parens: self.control_space_parens.unwrap_or(default.control_space_parens),
             closure_brace_style: self.closure_brace_style.unwrap_or(default.closure_brace_style),
             function_brace_style: self.function_brace_style.unwrap_or(default.function_brace_style),


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR removes the `keyword_case` option from the formatter configuration.

## 🔍 Context & Motivation

The `keyword_case` option allowed users to control the casing of keywords (e.g., `class`, `function`, `if`) in the formatted output. However, this option is rarely used, and changing the casing of keywords can lead to code that deviates from standard conventions.

This PR removes this option to simplify the formatter configuration and ensure that keywords are always formatted in lowercase, promoting consistency and adherence to common practices.

## 🛠️ Summary of Changes

- **Refactor:** Removed the keyword_case option from the formatter configuration.
- **Refactor:** Keywords are now always formatted in lowercase.
- **Test:** Updated tests to reflect the removal of the option and the consistent lowercase formatting of keywords.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [x] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [x] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs


## 📝 Notes for Reviewers
