### PR TITLE
feat(formatter): add support for formatting table-style arrays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,6 +1639,7 @@ dependencies = [
  "mago-token",
  "pretty_assertions",
  "serde",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ blake3 = "1.5.5"
 memchr = "2.7.4"
 parking_lot = "0.12.3"
 dialoguer = "0.11.0"
+unicode-width = { version = "0.2.0", default-features = false }
 
 [lints]
 workspace = true

--- a/crates/formatter/Cargo.toml
+++ b/crates/formatter/Cargo.toml
@@ -23,6 +23,7 @@ mago-php-version = { workspace = true }
 ahash = { workspace = true }
 serde = { workspace = true }
 bitflags = { workspace = true }
+unicode-width = { workspace = true }
 
 [dev-dependencies]
 indoc = { workspace = true }

--- a/crates/formatter/src/internal/comment/format.rs
+++ b/crates/formatter/src/internal/comment/format.rs
@@ -201,10 +201,7 @@ impl<'a> FormatterState<'a> {
         }
 
         if !comment.is_block || previous.is_some_and(|c| c.has_line_suffix) {
-            parts.push(Document::Array(vec![
-                Document::LineSuffix(vec![Document::space(), printed]),
-                Document::BreakParent,
-            ]));
+            parts.push(Document::LineSuffix(vec![Document::space(), printed]));
 
             return comment.with_line_suffix(true);
         }

--- a/crates/formatter/src/internal/format/array.rs
+++ b/crates/formatter/src/internal/format/array.rs
@@ -1,3 +1,5 @@
+use unicode_width::UnicodeWidthStr;
+
 use mago_ast::*;
 use mago_span::*;
 
@@ -48,8 +50,31 @@ impl<'a> ArrayLike<'a> {
     }
 
     #[inline]
-    const fn uses_parenthesis(&self) -> bool {
-        matches!(self, Self::List(_) | Self::LegacyArray(_))
+    pub fn get_left_delimiter_span(&self) -> Span {
+        match self {
+            Self::Array(array) => array.left_bracket.span(),
+            Self::List(list) => list.left_parenthesis.span(),
+            Self::LegacyArray(array) => array.left_parenthesis.span(),
+        }
+    }
+
+    #[inline]
+    pub const fn get_left_delimiter(&self) -> &'static str {
+        if matches!(self, Self::List(_) | Self::LegacyArray(_)) { "(" } else { "[" }
+    }
+
+    #[inline]
+    pub fn get_right_delimiter_span(&self) -> Span {
+        match self {
+            Self::Array(array) => array.right_bracket.span(),
+            Self::List(list) => list.right_parenthesis.span(),
+            Self::LegacyArray(array) => array.right_parenthesis.span(),
+        }
+    }
+
+    #[inline]
+    pub const fn get_right_delimiter(&self) -> &'static str {
+        if matches!(self, Self::List(_) | Self::LegacyArray(_)) { ")" } else { "]" }
     }
 
     fn prefix(&self, f: &mut FormatterState<'a>) -> Option<Document<'a>> {
@@ -57,14 +82,6 @@ impl<'a> ArrayLike<'a> {
             Self::List(list) => Some(list.list.format(f)),
             Self::LegacyArray(array) => Some(array.array.format(f)),
             _ => None,
-        }
-    }
-
-    fn iter<'b>(&'b self, p: &'b mut FormatterState<'a>) -> Box<dyn Iterator<Item = Document<'a>> + 'b> {
-        match self {
-            Self::Array(array) => Box::new(array.elements.iter().map(|element| element.format(p))),
-            Self::List(list) => Box::new(list.elements.iter().map(|element| element.format(p))),
-            Self::LegacyArray(array) => Box::new(array.elements.iter().map(|element| element.format(p))),
         }
     }
 }
@@ -80,13 +97,29 @@ impl HasSpan for ArrayLike<'_> {
 }
 
 pub(super) fn print_array_like<'a>(f: &mut FormatterState<'a>, array_like: ArrayLike<'a>) -> Document<'a> {
-    let left_delimiter = if let Some(prefix) = array_like.prefix(f) {
-        Document::Array(vec![prefix, Document::String(if array_like.uses_parenthesis() { "(" } else { "[" })])
-    } else {
-        Document::String(if array_like.uses_parenthesis() { "(" } else { "[" })
+    let left_delimiter = {
+        let mut left_delimiter_content = vec![];
+        if let Some(prefix) = array_like.prefix(f) {
+            left_delimiter_content.push(prefix);
+        }
+
+        left_delimiter_content.push(Document::String(array_like.get_left_delimiter()));
+        if let Some(s) = f.print_trailing_comments(array_like.get_left_delimiter_span()) {
+            left_delimiter_content.push(s);
+        }
+
+        Document::Array(left_delimiter_content)
     };
 
-    let right_delimiter = Document::String(if array_like.uses_parenthesis() { ")" } else { "]" });
+    let get_right_delimiter = |f: &mut FormatterState<'a>, array_like: &ArrayLike<'a>| {
+        let mut right_delimiter_content = vec![];
+        right_delimiter_content.push(Document::String(array_like.get_right_delimiter()));
+        if let Some(s) = f.print_trailing_comments(array_like.get_right_delimiter_span()) {
+            right_delimiter_content.push(s);
+        }
+
+        Document::Array(right_delimiter_content)
+    };
 
     if array_like.is_empty() {
         return Document::Group(Group::new(vec![
@@ -96,7 +129,7 @@ pub(super) fn print_array_like<'a>(f: &mut FormatterState<'a>, array_like: Array
             } else {
                 Document::empty()
             },
-            right_delimiter,
+            get_right_delimiter(f, &array_like),
         ]));
     }
 
@@ -104,23 +137,43 @@ pub(super) fn print_array_like<'a>(f: &mut FormatterState<'a>, array_like: Array
 
     if let Some(element) = inline_single_element(f, &array_like) {
         parts.push(element);
-        parts.push(right_delimiter);
+        parts.push(get_right_delimiter(f, &array_like));
 
         return Document::Group(Group::new(parts));
     }
+
+    // Check if we should use table-style formatting
+    let use_table_style = is_table_style(f, &array_like);
+    let column_widths = if use_table_style { calculate_column_widths(f, &array_like) } else { None };
 
     parts.push(Document::Indent({
         let len = array_like.len();
         let mut indent_parts = vec![];
         indent_parts.push(Document::Line(Line::soft()));
-        for (i, doc) in array_like.iter(f).enumerate() {
-            indent_parts.push(doc);
-            if i == len - 1 {
-                break;
-            }
 
-            indent_parts.push(Document::String(","));
-            indent_parts.push(Document::Line(Line::default()));
+        if let Some(widths) = column_widths {
+            for (i, element) in array_like.elements().iter().enumerate() {
+                let formatted_element = element.format(f);
+                if i == len - 1 {
+                    indent_parts.push(format_row_with_alignment(f, formatted_element, &widths));
+                    break;
+                }
+
+                indent_parts.push(format_row_with_alignment(f, formatted_element, &widths));
+                indent_parts.push(Document::String(","));
+                indent_parts.push(Document::Line(Line::hard()));
+            }
+        } else {
+            // Standard formatting without alignment
+            for (i, element) in array_like.elements().iter().enumerate() {
+                indent_parts.push(element.format(f));
+                if i == len - 1 {
+                    break;
+                }
+
+                indent_parts.push(Document::String(","));
+                indent_parts.push(Document::Line(Line::default()));
+            }
         }
 
         indent_parts
@@ -136,14 +189,15 @@ pub(super) fn print_array_like<'a>(f: &mut FormatterState<'a>, array_like: Array
         parts.push(Document::Line(Line::soft()));
     }
 
-    parts.push(right_delimiter);
+    parts.push(get_right_delimiter(f, &array_like));
 
-    // preserve new lines between the opening delimiter ( e.g. `[` or `(` ) and the first element
-    let should_break = misc::has_new_line_in_range(
-        f.source_text,
-        array_like.span().start.offset,
-        array_like.elements()[0].span().start.offset,
-    );
+    // preserve new lines between the opening delimiter and the first element
+    let should_break = use_table_style
+        || misc::has_new_line_in_range(
+            f.source_text,
+            array_like.span().start.offset,
+            array_like.elements()[0].span().start.offset,
+        );
 
     Document::Group(Group::new(parts).with_break(should_break))
 }
@@ -181,5 +235,306 @@ fn inline_single_element<'a>(f: &mut FormatterState<'a>, array_like: &ArrayLike<
             }
         }
         ArrayElement::Missing(_) => None,
+    }
+}
+
+fn format_row_with_alignment<'a>(
+    f: &mut FormatterState<'a>,
+    document: Document<'a>,
+    column_widths: &[usize],
+) -> Document<'a> {
+    match document {
+        Document::Array(mut elements) => {
+            let Some(last_element) = elements.pop() else {
+                return Document::Array(elements);
+            };
+
+            let formatted_row = format_row_with_alignment(f, last_element, column_widths);
+            if elements.is_empty() {
+                formatted_row
+            } else {
+                elements.push(formatted_row);
+
+                Document::Array(elements)
+            }
+        }
+        Document::Group(group) => {
+            if let Some((opening_delimiter, elements, closing_delimiter)) = extract_array_elements(&group.contents) {
+                let formatted_elements = format_elements_with_alignment(f, elements, column_widths);
+
+                Document::Group(Group::new(vec![
+                    opening_delimiter,
+                    Document::Array(formatted_elements),
+                    closing_delimiter,
+                ]))
+            } else {
+                Document::Group(group)
+            }
+        }
+        document => document,
+    }
+}
+
+fn extract_array_elements<'a>(contents: &[Document<'a>]) -> Option<(Document<'a>, Vec<Document<'a>>, Document<'a>)> {
+    let mut opening_delimiter = None;
+    let mut closing_delimiter = None;
+    let mut elements = Vec::new();
+    let mut in_elements = false;
+
+    for doc in contents {
+        match doc {
+            delimiter @ Document::Array(arr) => {
+                // Check if this array contains the left delimiter
+                for item in arr {
+                    if let Document::String(s) = item {
+                        if *s == "[" || *s == "(" {
+                            opening_delimiter = Some(delimiter.clone());
+                            in_elements = true;
+                            break;
+                        } else if !in_elements && *s == "]" || *s == ")" {
+                            closing_delimiter = Some(delimiter.clone());
+                            break;
+                        }
+                    }
+                }
+            }
+            Document::Indent(indent_docs) if in_elements => {
+                // Extract elements from the indented content
+                let mut element_start = 1;
+                for (i, item) in indent_docs.iter().enumerate() {
+                    match item {
+                        Document::String(s) if *s == "," => {
+                            if i > element_start {
+                                elements.push(indent_docs[element_start].clone());
+                            }
+                            element_start = i + 2; // Skip comma and Line
+                        }
+                        _ => {}
+                    }
+                }
+                // Add last element
+                if element_start < indent_docs.len() {
+                    elements.push(indent_docs[element_start].clone());
+                }
+
+                in_elements = false;
+            }
+            _ => {}
+        }
+    }
+
+    match (opening_delimiter, closing_delimiter) {
+        (Some(opening_delimiter), Some(closing_delimiter)) => {
+            if elements.is_empty() {
+                None
+            } else {
+                Some((opening_delimiter, elements, closing_delimiter))
+            }
+        }
+        _ => None,
+    }
+}
+
+fn format_elements_with_alignment<'a>(
+    f: &mut FormatterState<'a>,
+    elements: Vec<Document<'a>>,
+    column_widths: &[usize],
+) -> Vec<Document<'a>> {
+    let mut formatted_elements = Vec::new();
+
+    let len = elements.len();
+    for (i, element) in elements.into_iter().enumerate() {
+        let formatted = if i < len - 1 {
+            // For all elements except the last one, add padding
+            let element_width = get_document_width(&element);
+            let padding = column_widths[i].saturating_sub(element_width);
+
+            if padding > 0 {
+                // Create a padded document
+                Document::Array(vec![
+                    element,
+                    Document::String(","),
+                    Document::String(f.as_str(" ".repeat(padding + 1))), // +1 for standard space after comma
+                ])
+            } else {
+                // No padding needed
+                Document::Array(vec![element, Document::String(","), Document::space()])
+            }
+        } else {
+            // Last element, no padding
+            element
+        };
+
+        formatted_elements.push(formatted);
+    }
+
+    formatted_elements
+}
+
+fn is_table_style<'a>(f: &mut FormatterState<'a>, array_like: &ArrayLike<'a>) -> bool {
+    let elements = array_like.elements();
+    if elements.len() < 2 {
+        return false; // Need at least two rows for table style to make sense
+    }
+
+    let mut row_size = None;
+    let mut maximum_width = 0;
+
+    // Check if all elements are nested arrays with consistent row sizes
+    for element in elements {
+        if f.has_inner_comment(element.span()) {
+            return false; // Do not format if there are inner comments
+        }
+
+        match element {
+            ArrayElement::Value(element) => {
+                if let Expression::Array(Array { elements, .. })
+                | Expression::LegacyArray(LegacyArray { elements, .. }) = element.value.as_ref()
+                {
+                    let size = elements.len();
+
+                    // Check if row size is consistent
+                    if let Some(existing_size) = row_size {
+                        if existing_size != size {
+                            return false;
+                        }
+                    } else {
+                        if size < 2 {
+                            return false; // Need at least two columns
+                        }
+
+                        row_size = Some(size);
+                    }
+
+                    // Check if all inner elements are simple (strings, numbers, etc.)
+                    let mut elements_width = 0;
+                    for inner_element in elements.iter() {
+                        match inner_element {
+                            ArrayElement::Value(inner_value) => {
+                                match get_element_width(f, &inner_value.value) {
+                                    Some(width) => elements_width += width,
+                                    None => {
+                                        return false; // Only support simple elements
+                                    }
+                                }
+                            }
+                            _ => {
+                                return false; // Only support Value elements
+                            }
+                        }
+                    }
+
+                    let total_width = elements_width + ((size - 1) * 2);
+                    // `20` is an arbitrary limit to prevent excessive column width
+                    if total_width > (f.settings.print_width - 20) {
+                        return false; // Exceeds column width limit
+                    }
+
+                    maximum_width = maximum_width.max(total_width);
+                } else {
+                    return false; // Not a nested array
+                }
+            }
+            _ => return false, // Only support Value elements
+        }
+    }
+
+    if maximum_width < 20 {
+        return false; // Too narrow to be a table
+    }
+
+    // Check if row size is within reasonable bounds (2-10 columns)
+    match row_size {
+        Some(size) => (3..=12).contains(&size),
+        None => false,
+    }
+}
+
+fn calculate_column_widths<'a>(f: &mut FormatterState<'a>, array_like: &ArrayLike<'a>) -> Option<Vec<usize>> {
+    let elements = array_like.elements();
+    let mut row_size = None;
+    let mut column_maximum_widths = Vec::new();
+
+    // First pass: determine consistent row size and initialize column widths
+    for element in elements {
+        match element {
+            ArrayElement::Value(element) => {
+                if let Expression::Array(Array { elements, .. })
+                | Expression::LegacyArray(LegacyArray { elements, .. }) = element.value.as_ref()
+                {
+                    let size = elements.len();
+
+                    if let Some(existing_size) = row_size {
+                        if existing_size != size {
+                            return None; // Inconsistent row sizes
+                        }
+                    } else {
+                        row_size = Some(size);
+                        column_maximum_widths = vec![0; size];
+                    }
+                } else {
+                    return None; // Not a nested array
+                }
+            }
+            _ => return None, // Only support Value elements
+        }
+    }
+
+    // Second pass: calculate maximum width for each column
+    for element in elements {
+        if let ArrayElement::Value(element) = element {
+            if let Expression::Array(Array { elements, .. }) | Expression::LegacyArray(LegacyArray { elements, .. }) =
+                element.value.as_ref()
+            {
+                for (col_idx, col_element) in elements.iter().enumerate() {
+                    if let ArrayElement::Value(value_element) = col_element {
+                        if let Some(width) = get_element_width(f, &value_element.value) {
+                            column_maximum_widths[col_idx] = column_maximum_widths[col_idx].max(width);
+                        } else {
+                            return None; // Cannot determine element width
+                        }
+                    } else {
+                        return None; // Only support Value elements in inner arrays
+                    }
+                }
+            }
+        }
+    }
+
+    Some(column_maximum_widths)
+}
+
+fn get_element_width<'a>(f: &mut FormatterState<'a>, element: &'a Expression) -> Option<usize> {
+    Some(match element {
+        Expression::Literal(literal) => match literal {
+            Literal::String(literal_string) => f.interner.lookup(&literal_string.value).width(),
+            Literal::Integer(literal_integer) => f.interner.lookup(&literal_integer.raw).width(),
+            Literal::Float(literal_float) => f.interner.lookup(&literal_float.raw).width(),
+            Literal::True(_) => 4,
+            Literal::False(_) => 5,
+            Literal::Null(_) => 4,
+        },
+        Expression::MagicConstant(magic_constant) => f.interner.lookup(&magic_constant.value().value).width(),
+        Expression::ConstantAccess(ConstantAccess { name: Identifier::Local(local) })
+        | Expression::Identifier(Identifier::Local(local)) => f.interner.lookup(&local.value).width(),
+        Expression::Variable(Variable::Direct(variable)) => f.interner.lookup(&variable.name).width(),
+        _ => {
+            return None;
+        }
+    })
+}
+
+fn get_document_width(doc: &Document<'_>) -> usize {
+    match doc {
+        Document::String(s) => s.width(),
+        Document::Array(docs) => docs.iter().map(get_document_width).sum(),
+        Document::Group(group) => group.contents.iter().map(get_document_width).sum(),
+        Document::Indent(docs) => docs.iter().map(get_document_width).sum(),
+        // For other document types, provide reasonable estimates
+        Document::Line(_) => 1,
+        Document::IfBreak(if_break) => {
+            get_document_width(&if_break.break_contents).max(get_document_width(&if_break.flat_content))
+        }
+        _ => 0,
     }
 }

--- a/crates/formatter/tests/cases/array_alignment/after.php
+++ b/crates/formatter/tests/cases/array_alignment/after.php
@@ -1,0 +1,219 @@
+<?php
+
+show_table([ // This is a comment
+    ['Month',     'Premium', 'Revenue'], // This is a comment
+    ['January',   '$0.00',   '$0.00'],
+    ['February',  '$0.00',   '$0.00'],
+    ['March',     '$0.00',   '$0.00'],
+    ['April',     '$0.00',   '$0.00'],
+    ['May',       '$0.00',   '$0.00'],
+    ['June',      '$0.00',   '$0.00'],
+    ['July',      '$0.00',   '$0.00'],
+    ['August',    '$0.00',   '$0.00'],
+    // September ..
+    ['September', '$0.00',   '$0.00'],
+    /// Weeeee!
+    /// Weee!!!!
+    /* Weeeee! */
+    ['October',   '$0.00',   '$0.00'],
+    ['November',  '$0.00',   '$0.00'],
+    ['December',  '$0.00',   '$0.00'], // This is a comment
+]); // This is a comment
+
+show_table([ // This is a comment
+    ['Hello', 11212, 112.1, true,  $bar,  PHP_VERSION],
+    ['World', 125.1, 12,    false, $quux, PHP_VERSION_ID],
+]);
+
+show_table([[[ // This is a comment
+    ['Hello', 11212, 112.1, true,  $bar,  PHP_VERSION],
+    ['World', 125.1, 12,    false, $quux, PHP_VERSION_ID],
+]]]);
+
+show_table(array( // This is a comment
+    array('Month',     'Premium', 'Revenue'), // This is a comment
+    array('January',   '$0.00',   '$0.00'),
+    array('February',  '$0.00',   '$0.00'),
+    array('March',     '$0.00',   '$0.00'),
+    array('April',     '$0.00',   '$0.00'),
+    array('May',       '$0.00',   '$0.00'),
+    array('June',      '$0.00',   '$0.00'),
+    array('July',      '$0.00',   '$0.00'),
+    array('August',    '$0.00',   '$0.00'),
+    array('September', '$0.00',   '$0.00'),
+    array('October',   '$0.00',   '$0.00'),
+    array('November',  '$0.00',   '$0.00'),
+    array('December',  '$0.00',   '$0.00'), // This is a comment
+)); // This is a comment
+
+show_table([ // This is a comment
+    array('Hello', 11212, 112.1,  true,  $bar,  PHP_VERSION),
+    array('World', 125.1, 12,     false, $quux, PHP_VERSION_ID),
+    array('!!',    125.1, 123512, false, $bar,  PHP_VERSION_ID),
+]);
+
+// This table contains a very long string so it won't be formatted as a table
+show_table([ // This is a comment
+    array(
+        'HelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHello',
+        11212,
+        112.1,
+        true,
+        $bar,
+        PHP_VERSION,
+    ),
+    array('World', 125.1, 12, false, $quux, PHP_VERSION_ID),
+    array('!!', 125.1, 123512, false, $bar, PHP_VERSION_ID),
+]);
+
+// too small for table.
+$a = [[1, 2], [3, 4], [5, 6]];
+
+$arr = [
+    ['الاسم',    'العمر', 'المدينة', 'المهنة'],
+    ['أحمد',    '30',    'الرياض',  'مهندس'],
+    ['فاطمة',   '25',    'جدة',     'طبيبة'],
+    ['علي',     '35',    'الدمام',  'محاسب'],
+    ['ليلى',    '28',    'مكة',     'معلمة'],
+    ['خالد',    '40',    'المدينة', 'مدير'],
+    ['سارة',    '22',    'تبوك',    'طالبة'],
+    ['يوسف',    '32',    'حائل',    'مبرمج'],
+    ['نورة',    '29',    'أبها',    'مصممة'],
+    ['عبدالله', '38',    'جازان',   'محامٍ'],
+];
+
+$arr = [
+    ['Name',    'Age', 'City',     'Occupation'],
+    ['John',    '30',  'New York', 'Engineer'],
+    ['Jane',    '25',  'London',   'Doctor'],
+    ['Mike',    '35',  'Paris',    'Accountant'],
+    ['Emily',   '28',  'Tokyo',    'Teacher'],
+    ['David',   '40',  'Sydney',   'Manager'],
+    ['Sarah',   '22',  'Toronto',  'Student'],
+    ['Robert',  '32',  'Berlin',   'Programmer'],
+    ['Jessica', '29',  'Rome',     'Designer'],
+    ['William', '38',  'Madrid',   'Lawyer'],
+];
+
+$arr = [
+    ['姓名', '年龄', '城市', '职业'],
+    ['李明', '30',   '北京', '工程师'],
+    ['王芳', '25',   '上海', '医生'],
+    ['张伟', '35',   '广州', '会计'],
+    ['刘丽', '28',   '深圳', '教师'],
+    ['陈刚', '40',   '杭州', '经理'],
+    ['杨梅', '22',   '成都', '学生'],
+    ['赵强', '32',   '南京', '程序员'],
+    ['周红', '29',   '武汉', '设计师'],
+    ['孙军', '38',   '西安', '律师'],
+];
+
+$arr = [
+    ['名前', '年齢', '都市',   '職業'],
+    ['田中', '30',   '東京',   'エンジニア'],
+    ['佐藤', '25',   '大阪',   '医者'],
+    ['鈴木', '35',   '名古屋', '会計士'],
+    ['高橋', '28',   '福岡',   '教師'],
+    ['伊藤', '40',   '札幌',   'マネージャー'],
+    ['渡辺', '22',   '仙台',   '学生'],
+    ['加藤', '32',   '広島',   'プログラマー'],
+    ['山本', '29',   '京都',   'デザイナー'],
+    ['中村', '38',   '横浜',   '弁護士'],
+];
+
+$arr = [
+    ['이름',   '나이', '도시', '직업'],
+    ['김민수', '30',   '서울', '엔지니어'],
+    ['박지영', '25',   '부산', '의사'],
+    ['최성훈', '35',   '대구', '회계사'],
+    ['정수진', '28',   '인천', '교사'],
+    ['강동현', '40',   '광주', '매니저'],
+    ['송하늘', '22',   '대전', '학생'],
+    ['윤재혁', '32',   '울산', '프로그래머'],
+    ['신혜리', '29',   '수원', '디자이너'],
+    ['한정우', '38',   '창원', '변호사'],
+];
+
+$arr = [
+    ['Имя',       'Возраст', 'Город',           'Профессия'],
+    ['Иван',      '30',      'Москва',          'Инженер'],
+    ['Елена',     '25',      'Санкт-Петербург', 'Врач'],
+    ['Сергей',    '35',      'Новосибирск',     'Бухгалтер'],
+    ['Ольга',     '28',      'Екатеринбург',    'Учитель'],
+    ['Дмитрий',   '40',      'Нижний Новгород', 'Менеджер'],
+    ['Анастасия', '22',      'Казань',          'Студент'],
+    ['Алексей',   '32',      'Челябинск',       'Программист'],
+    ['Юлия',      '29',      'Самара',          'Дизайнер'],
+    ['Андрей',    '38',      'Омск',            'Юрист'],
+];
+
+$arr = [
+    ['Nom',    'Âge', 'Ville',       'Profession'],
+    ['Jean',   '30',  'Paris',       'Ingénieur'],
+    ['Marie',  '25',  'Lyon',        'Médecin'],
+    ['Pierre', '35',  'Marseille',   'Comptable'],
+    ['Sophie', '28',  'Toulouse',    'Professeur'],
+    ['Luc',    '40',  'Nice',        'Directeur'],
+    ['Claire', '22',  'Nantes',      'Étudiante'],
+    ['Paul',   '32',  'Strasbourg',  'Programmeur'],
+    ['Alice',  '29',  'Montpellier', 'Designer'],
+    ['Michel', '38',  'Bordeaux',    'Avocat'],
+];
+
+$arr = [
+    ['Nombre', 'Edad', 'Ciudad',    'Profesión'],
+    ['Juan',   '30',   'Madrid',    'Ingeniero'],
+    ['María',  '25',   'Barcelona', 'Médico'],
+    ['Pedro',  '35',   'Valencia',  'Contable'],
+    ['Laura',  '28',   'Sevilla',   'Profesor'],
+    ['Carlos', '40',   'Bilbao',    'Gerente'],
+    ['Ana',    '22',   'Zaragoza',  'Estudiante'],
+    ['Luis',   '32',   'Málaga',    'Programador'],
+    ['Elena',  '29',   'Murcia',    'Diseñador'],
+    ['Javier', '38',   'Palma',     'Abogado'],
+];
+
+$arr = [
+    ['ชื่อ',     'อายุ', 'เมือง',      'อาชีพ'],
+    ['สมชาย',  '30',  'กรุงเทพ',    'วิศวกร'],
+    ['สมหญิง',  '25',  'เชียงใหม่',   'แพทย์'],
+    ['สมศักดิ์',  '35',  'ภูเก็ต',      'นักบัญชี'],
+    ['สมศรี',   '28',  'ขอนแก่น',    'ครู'],
+    ['สมบูรณ์',  '40',  'ชลบุรี',      'ผู้จัดการ'],
+    ['สมใจ',   '22',  'นครราชสีมา', 'นักเรียน'],
+    ['สมหวัง',  '32',  'สุราษฎร์ธานี', 'โปรแกรมเมอร์'],
+    ['สมนึก',   '29',  'อุบลราชธานี', 'นักออกแบบ'],
+    ['สมหมาย', '38',  'หาดใหญ่',    'ทนายความ'],
+];
+
+$arr = [
+    ['Tên',  'Tuổi', 'Thành phố',   'Nghề nghiệp'],
+    ['Tuấn', '30',   'Hà Nội',      'Kỹ sư'],
+    ['Lan',  '25',   'Hồ Chí Minh', 'Bác sĩ'],
+    ['Hùng', '35',   'Đà Nẵng',     'Kế toán'],
+    ['Mai',  '28',   'Hải Phòng',   'Giáo viên'],
+    ['Nam',  '40',   'Cần Thơ',     'Quản lý'],
+    ['Hoa',  '22',   'Biên Hòa',    'Sinh viên'],
+    ['Dũng', '32',   'Huế',         'Lập trình viên'],
+    ['Thảo', '29',   'Nha Trang',   'Nhà thiết kế'],
+    ['Long', '38',   'Vũng Tàu',    'Luật sư'],
+];
+
+function _trailing_comments(): iterable
+{
+    yield [(object) [
+        'name' => 'saif',
+        'articles' => [
+            ['title' => 'biz', 'content' => 'foo', 'upvotes' => 4], // 'likes' replaced by 'upvotes'
+            ['title' => 'biz', 'content' => 'foo', 'upvotes' => 4], // 'likes' replaced by 'upvotes'
+        ],
+    ]];
+
+    yield [(object) [
+        'name' => 'saif',
+        'articles' => [
+            ['title' => 'biz', 'content' => 'foo', 'upvotes' => 4], // 'likes' replaced by 'upvotes'
+            ['title' => 'biz', 'content' => 'foo', 'upvotes' => 4], // 'likes' replaced by 'upvotes'
+        ],
+    ]];
+}

--- a/crates/formatter/tests/cases/array_alignment/before.php
+++ b/crates/formatter/tests/cases/array_alignment/before.php
@@ -1,0 +1,210 @@
+<?php
+
+show_table([ // This is a comment
+    ["Month", "Premium", "Revenue"], // This is a comment
+    ["January", '$0.00', '$0.00'],
+    ["February", '$0.00', '$0.00'],
+    ["March", '$0.00', '$0.00'],
+    ["April", '$0.00', '$0.00'],
+    ["May", '$0.00', '$0.00'],
+    ["June", '$0.00', '$0.00'],
+    ["July", '$0.00', '$0.00'],
+    ["August", '$0.00', '$0.00'],
+    // September ..
+    ["September", '$0.00', '$0.00'],
+    /// Weeeee!
+    /// Weee!!!!
+    /* Weeeee! */
+    ["October", '$0.00', '$0.00'],
+    ["November", '$0.00', '$0.00'],
+    ["December", '$0.00', '$0.00'], // This is a comment
+]); // This is a comment
+
+show_table([ // This is a comment
+    ["Hello", 11212, 112.1, true, $bar, PHP_VERSION],
+    ["World", 125.1, 12, false, $quux, PHP_VERSION_ID],
+]);
+
+show_table([[[ // This is a comment
+    ["Hello", 11212, 112.1, true, $bar, PHP_VERSION],
+    ["World", 125.1, 12, false, $quux, PHP_VERSION_ID],
+]]]);
+
+show_table(array( // This is a comment
+    array("Month", "Premium", "Revenue"), // This is a comment
+    array("January", '$0.00', '$0.00'),
+    array("February", '$0.00', '$0.00'),
+    array("March", '$0.00', '$0.00'),
+    array("April", '$0.00', '$0.00'), array("May", '$0.00', '$0.00'), array("June", '$0.00', '$0.00'),
+    array("July", '$0.00', '$0.00'),
+    array("August", '$0.00', '$0.00'),
+    array("September", '$0.00', '$0.00'),
+    array("October", '$0.00', '$0.00'),
+    array("November", '$0.00', '$0.00'),
+    array("December", '$0.00', '$0.00'), // This is a comment
+)); // This is a comment
+
+show_table([ // This is a comment
+    array("Hello", 11212, 112.1, true, $bar, PHP_VERSION),
+    array("World", 125.1, 12, false, $quux, PHP_VERSION_ID),
+    array('!!', 125.1, 123512, false, $bar, PHP_VERSION_ID),
+]);
+
+// This table contains a very long string so it won't be formatted as a table
+show_table([ // This is a comment
+    array('HelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHelloHello', 11212, 112.1, true,  $bar,  PHP_VERSION),
+    array('World', 125.1, 12,    false, $quux, PHP_VERSION_ID),
+    array('!!', 125.1, 123512, false, $bar, PHP_VERSION_ID),
+]);
+
+// too small for table.
+$a = [[1, 2], [3, 4], [5, 6]];
+
+$arr =  [
+   ["الاسم", "العمر", "المدينة", "المهنة"],
+   ["أحمد", "30", "الرياض", "مهندس"],
+   ["فاطمة", "25", "جدة", "طبيبة"],
+   ["علي", "35", "الدمام", "محاسب"],
+   ["ليلى", "28", "مكة", "معلمة"],
+   ["خالد", "40", "المدينة", "مدير"],
+   ["سارة", "22", "تبوك", "طالبة"],
+   ["يوسف", "32", "حائل", "مبرمج"],
+   ["نورة", "29", "أبها", "مصممة"],
+   ["عبدالله", "38", "جازان", "محامٍ"],
+];
+
+$arr = [
+    ["Name", "Age", "City", "Occupation"],
+    ["John", "30", "New York", "Engineer"],
+    ["Jane", "25", "London", "Doctor"],
+    ["Mike", "35", "Paris", "Accountant"],
+    ["Emily", "28", "Tokyo", "Teacher"],
+    ["David", "40", "Sydney", "Manager"],
+    ["Sarah", "22", "Toronto", "Student"],
+    ["Robert", "32", "Berlin", "Programmer"],
+    ["Jessica", "29", "Rome", "Designer"],
+    ["William", "38", "Madrid", "Lawyer"],
+];
+
+$arr = [
+    ["姓名", "年龄", "城市", "职业"],
+    ["李明", "30", "北京", "工程师"],
+    ["王芳", "25", "上海", "医生"],
+    ["张伟", "35", "广州", "会计"],
+    ["刘丽", "28", "深圳", "教师"],
+    ["陈刚", "40", "杭州", "经理"],
+    ["杨梅", "22", "成都", "学生"],
+    ["赵强", "32", "南京", "程序员"],
+    ["周红", "29", "武汉", "设计师"],
+    ["孙军", "38", "西安", "律师"],
+];
+
+$arr = [
+    ["名前", "年齢", "都市", "職業"],
+    ["田中", "30", "東京", "エンジニア"],
+    ["佐藤", "25", "大阪", "医者"],
+    ["鈴木", "35", "名古屋", "会計士"],
+    ["高橋", "28", "福岡", "教師"],
+    ["伊藤", "40", "札幌", "マネージャー"],
+    ["渡辺", "22", "仙台", "学生"],
+    ["加藤", "32", "広島", "プログラマー"],
+    ["山本", "29", "京都", "デザイナー"],
+    ["中村", "38", "横浜", "弁護士"],
+];
+
+$arr = [
+    ["이름", "나이", "도시", "직업"],
+    ["김민수", "30", "서울", "엔지니어"],
+    ["박지영", "25", "부산", "의사"],
+    ["최성훈", "35", "대구", "회계사"],
+    ["정수진", "28", "인천", "교사"],
+    ["강동현", "40", "광주", "매니저"],
+    ["송하늘", "22", "대전", "학생"],
+    ["윤재혁", "32", "울산", "프로그래머"],
+    ["신혜리", "29", "수원", "디자이너"],
+    ["한정우", "38", "창원", "변호사"],
+];
+
+$arr = [
+    ["Имя", "Возраст", "Город", "Профессия"],
+    ["Иван", "30", "Москва", "Инженер"],
+    ["Елена", "25", "Санкт-Петербург", "Врач"],
+    ["Сергей", "35", "Новосибирск", "Бухгалтер"],
+    ["Ольга", "28", "Екатеринбург", "Учитель"],
+    ["Дмитрий", "40", "Нижний Новгород", "Менеджер"],
+    ["Анастасия", "22", "Казань", "Студент"],
+    ["Алексей", "32", "Челябинск", "Программист"],
+    ["Юлия", "29", "Самара", "Дизайнер"],
+    ["Андрей", "38", "Омск", "Юрист"],
+];
+
+$arr = [
+    ["Nom", "Âge", "Ville", "Profession"],
+    ["Jean", "30", "Paris", "Ingénieur"],
+    ["Marie", "25", "Lyon", "Médecin"],
+    ["Pierre", "35", "Marseille", "Comptable"],
+    ["Sophie", "28", "Toulouse", "Professeur"],
+    ["Luc", "40", "Nice", "Directeur"],
+    ["Claire", "22", "Nantes", "Étudiante"],
+    ["Paul", "32", "Strasbourg", "Programmeur"],
+    ["Alice", "29", "Montpellier", "Designer"],
+    ["Michel", "38", "Bordeaux", "Avocat"],
+];
+
+$arr = [
+    ["Nombre", "Edad", "Ciudad", "Profesión"],
+    ["Juan", "30", "Madrid", "Ingeniero"],
+    ["María", "25", "Barcelona", "Médico"],
+    ["Pedro", "35", "Valencia", "Contable"],
+    ["Laura", "28", "Sevilla", "Profesor"],
+    ["Carlos", "40", "Bilbao", "Gerente"],
+    ["Ana", "22", "Zaragoza", "Estudiante"],
+    ["Luis", "32", "Málaga", "Programador"],
+    ["Elena", "29", "Murcia", "Diseñador"],
+    ["Javier", "38", "Palma", "Abogado"],
+];
+
+$arr = [
+    ["ชื่อ", "อายุ", "เมือง", "อาชีพ"],
+    ["สมชาย", "30", "กรุงเทพ", "วิศวกร"],
+    ["สมหญิง", "25", "เชียงใหม่", "แพทย์"],
+    ["สมศักดิ์", "35", "ภูเก็ต", "นักบัญชี"],
+    ["สมศรี", "28", "ขอนแก่น", "ครู"],
+    ["สมบูรณ์", "40", "ชลบุรี", "ผู้จัดการ"],
+    ["สมใจ", "22", "นครราชสีมา", "นักเรียน"],
+    ["สมหวัง", "32", "สุราษฎร์ธานี", "โปรแกรมเมอร์"],
+    ["สมนึก", "29", "อุบลราชธานี", "นักออกแบบ"],
+    ["สมหมาย", "38", "หาดใหญ่", "ทนายความ"],
+];
+
+$arr = [
+    ["Tên", "Tuổi", "Thành phố", "Nghề nghiệp"],
+    ["Tuấn", "30", "Hà Nội", "Kỹ sư"],
+    ["Lan", "25", "Hồ Chí Minh", "Bác sĩ"],
+    ["Hùng", "35", "Đà Nẵng", "Kế toán"],
+    ["Mai", "28", "Hải Phòng", "Giáo viên"],
+    ["Nam", "40", "Cần Thơ", "Quản lý"],
+    ["Hoa", "22", "Biên Hòa", "Sinh viên"],
+    ["Dũng", "32", "Huế", "Lập trình viên"],
+    ["Thảo", "29", "Nha Trang", "Nhà thiết kế"],
+    ["Long", "38", "Vũng Tàu", "Luật sư"],
+];
+
+function _trailing_comments(): iterable
+{
+    yield [(object) [
+        'name' => 'saif',
+        'articles' => [
+            ['title' => 'biz', 'content' => 'foo', 'upvotes' => 4], // 'likes' replaced by 'upvotes'
+            ['title' => 'biz', 'content' => 'foo', 'upvotes' => 4], // 'likes' replaced by 'upvotes'
+        ],
+    ]];
+
+    yield [(object) [
+        'name' => 'saif',
+        'articles' => [
+            ['title' => 'biz', 'content' => 'foo', 'upvotes' => 4], // 'likes' replaced by 'upvotes'
+            ['title' => 'biz', 'content' => 'foo', 'upvotes' => 4], // 'likes' replaced by 'upvotes'
+        ],
+    ]];
+}

--- a/crates/formatter/tests/cases/array_alignment/settings.inc
+++ b/crates/formatter/tests/cases/array_alignment/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings::default()

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -106,3 +106,4 @@ test_case!(member_access_chain);
 test_case!(return_wrapping);
 test_case!(arrow_return);
 test_case!(match_breaking);
+test_case!(array_alignment);


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR introduces a new table-style formatting feature for arrays, enhancing the readability of arrays with consistent, simple elements. It also includes checks to prevent table-style formatting for overly wide arrays and refines the detection of suitable arrays for this formatting style.

## 🔍 Context & Motivation

This PR aims to improve the readability of arrays by introducing a new formatting style that aligns elements in a table-like format. This is particularly beneficial for arrays with consistent elements, such as those used for data structures or configuration. The checks for maximum row width and the refined detection logic ensure that this formatting style is applied appropriately and effectively.

## 🛠️ Summary of Changes

- **Feature:** Introduced table-style formatting for arrays, aligning elements in a table-like format.
- **Tests:** Added new test cases to verify the behavior of the table-style formatting logic.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Related ( but does not solve ) #63 

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
