### PR TITLE
fix(formatter): indent binary operations when split into multple lines inside parenthesis

### DIFF
--- a/crates/formatter/src/internal/format/binaryish.rs
+++ b/crates/formatter/src/internal/format/binaryish.rs
@@ -51,7 +51,7 @@ pub(super) fn print_binaryish_expression<'a>(
     //     $this->lookahead()->type === $tt->parenLeft
     //   ) {
     if is_inside_parenthesis {
-        return Document::Array(parts);
+        return Document::Indent(parts);
     }
 
     // Break between the parens in

--- a/crates/formatter/tests/cases/binary_alignment/after.php
+++ b/crates/formatter/tests/cases/binary_alignment/after.php
@@ -1,0 +1,33 @@
+<?php
+
+final class EntityRepository implements EntityRepositoryInterface
+{
+    // ...
+
+    private function addSearchClause(
+        QueryBuilder $queryBuilder,
+        SearchDto $searchDto,
+        EntityDto $entityDto,
+        string $databasePlatformFqcn,
+    ): void {
+        // ...
+
+        foreach ($queryTerms as $queryTerm) {
+            // ...
+
+            $queryTermConditions = new Orx();
+            foreach ($searchablePropertiesConfig as $propertyConfig) {
+                $entityName = $propertyConfig['entity_name'];
+
+                // this complex condition is needed to avoid issues on PostgreSQL databases
+                if (
+                    $propertyConfig['is_small_integer'] && $isSmallIntegerQueryTerm ||
+                        $propertyConfig['is_integer'] && $isIntegerQueryTerm ||
+                        $propertyConfig['is_numeric'] && $isNumericQueryTerm
+                ) {
+                    // ...
+                }
+            }
+        }
+    }
+}

--- a/crates/formatter/tests/cases/binary_alignment/before.php
+++ b/crates/formatter/tests/cases/binary_alignment/before.php
@@ -1,0 +1,24 @@
+<?php
+
+final class EntityRepository implements EntityRepositoryInterface {
+    // ...
+
+    private function addSearchClause(QueryBuilder $queryBuilder, SearchDto $searchDto, EntityDto $entityDto, string $databasePlatformFqcn): void {
+        // ...
+
+        foreach ($queryTerms as $queryTerm) {
+            // ...
+
+            $queryTermConditions = (((((new Orx())))));
+            foreach ($searchablePropertiesConfig as $propertyConfig) {
+                $entityName =
+                $propertyConfig['entity_name'];
+
+                // this complex condition is needed to avoid issues on PostgreSQL databases
+                if ($propertyConfig['is_small_integer'] && $isSmallIntegerQueryTerm || $propertyConfig['is_integer'] && $isIntegerQueryTerm || $propertyConfig['is_numeric'] && $isNumericQueryTerm) {
+                    // ...
+                }
+            }
+        }
+    }
+}

--- a/crates/formatter/tests/cases/binary_alignment/settings.inc
+++ b/crates/formatter/tests/cases/binary_alignment/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings::default()

--- a/crates/formatter/tests/cases/binary_alignment_before_op/after.php
+++ b/crates/formatter/tests/cases/binary_alignment_before_op/after.php
@@ -1,0 +1,33 @@
+<?php
+
+final class EntityRepository implements EntityRepositoryInterface
+{
+    // ...
+
+    private function addSearchClause(
+        QueryBuilder $queryBuilder,
+        SearchDto $searchDto,
+        EntityDto $entityDto,
+        string $databasePlatformFqcn,
+    ): void {
+        // ...
+
+        foreach ($queryTerms as $queryTerm) {
+            // ...
+
+            $queryTermConditions = new Orx();
+            foreach ($searchablePropertiesConfig as $propertyConfig) {
+                $entityName = $propertyConfig['entity_name'];
+
+                // this complex condition is needed to avoid issues on PostgreSQL databases
+                if (
+                    $propertyConfig['is_small_integer'] && $isSmallIntegerQueryTerm
+                        || $propertyConfig['is_integer'] && $isIntegerQueryTerm
+                        || $propertyConfig['is_numeric'] && $isNumericQueryTerm
+                ) {
+                    // ...
+                }
+            }
+        }
+    }
+}

--- a/crates/formatter/tests/cases/binary_alignment_before_op/before.php
+++ b/crates/formatter/tests/cases/binary_alignment_before_op/before.php
@@ -1,0 +1,24 @@
+<?php
+
+final class EntityRepository implements EntityRepositoryInterface {
+    // ...
+
+    private function addSearchClause(QueryBuilder $queryBuilder, SearchDto $searchDto, EntityDto $entityDto, string $databasePlatformFqcn): void {
+        // ...
+
+        foreach ($queryTerms as $queryTerm) {
+            // ...
+
+            $queryTermConditions = (((((new Orx())))));
+            foreach ($searchablePropertiesConfig as $propertyConfig) {
+                $entityName =
+                $propertyConfig['entity_name'];
+
+                // this complex condition is needed to avoid issues on PostgreSQL databases
+                if ($propertyConfig['is_small_integer'] && $isSmallIntegerQueryTerm || $propertyConfig['is_integer'] && $isIntegerQueryTerm || $propertyConfig['is_numeric'] && $isNumericQueryTerm) {
+                    // ...
+                }
+            }
+        }
+    }
+}

--- a/crates/formatter/tests/cases/binary_alignment_before_op/settings.inc
+++ b/crates/formatter/tests/cases/binary_alignment_before_op/settings.inc
@@ -1,0 +1,4 @@
+FormatSettings {
+    line_before_binary_operator: true,
+    ..Default::default()
+}

--- a/crates/formatter/tests/cases/binary_ops_wrapping/after.php
+++ b/crates/formatter/tests/cases/binary_ops_wrapping/after.php
@@ -2,15 +2,15 @@
 
 if (
     null === $crudControllerFqcn ||
-    null ===
-        ($routeName = $thisssssss->findRouteName(
-            $dashboardControllerFqcndashboardControllerFqcndashboardControllerFqcn,
-        ))
+        null ===
+            ($routeName = $thisssssss->findRouteName(
+                $dashboardControllerFqcndashboardControllerFqcndashboardControllerFqcn,
+            ))
 ) {
 }
 
 if (
     $this->adminRouteGenerator->usesPrettyUrls() &&
-    null !== ($entityFqcnOrCrudControllerFqcn = $request->query->get(EA::CRUD_CONTROLLER_FQCN))
+        null !== ($entityFqcnOrCrudControllerFqcn = $request->query->get(EA::CRUD_CONTROLLER_FQCN))
 ) {
 }

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -107,3 +107,5 @@ test_case!(return_wrapping);
 test_case!(arrow_return);
 test_case!(match_breaking);
 test_case!(array_alignment);
+test_case!(binary_alignment);
+test_case!(binary_alignment_before_op);


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR fixes a bug in the formatter that caused incorrect indentation of multi-line binary expressions within parentheses.

## 🔍 Context & Motivation

The formatter was not correctly indenting subsequent lines in multi-line binary expressions that were enclosed in parentheses, such as those commonly found in if statement conditions. This resulted in misaligned code and reduced readability. This PR addresses this issue by ensuring that the indentation is applied correctly in these scenarios.

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed incorrect indentation of multi-line binary expressions within parentheses.
- **Tests:** Added new test cases to verify the correct indentation of binary expressions in various contexts.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
