### PR TITLE
fix(formatter): fix printing member access chain comments

### DIFF
--- a/crates/formatter/tests/cases/chain_comments/after.php
+++ b/crates/formatter/tests/cases/chain_comments/after.php
@@ -1,0 +1,23 @@
+<?php
+
+// ...
+
+final class MenuFactory implements MenuFactoryInterface
+{
+    // ...
+
+    private function generateMenuItemUrl(MenuItemDto $menuItemDto): string
+    {
+        // ...
+
+        if (MenuItemDto::TYPE_CRUD === $menuItemType) {
+            // ...
+
+            $this->adminUrlGenerator
+                // remove all existing query params to avoid keeping search queries, filters and pagination
+                ->unsetAll()
+                // set any other parameters defined by the menu item
+                ->setAll($routeParameters);
+        }
+    }
+}

--- a/crates/formatter/tests/cases/chain_comments/before.php
+++ b/crates/formatter/tests/cases/chain_comments/before.php
@@ -1,0 +1,21 @@
+<?php
+
+// ...
+
+final class MenuFactory implements MenuFactoryInterface {
+    // ...
+
+    private function generateMenuItemUrl(MenuItemDto $menuItemDto): string {
+        // ...
+
+        if (MenuItemDto::TYPE_CRUD === $menuItemType) {
+            // ...
+
+            $this->adminUrlGenerator
+                // remove all existing query params to avoid keeping search queries, filters and pagination
+                ->unsetAll()
+                // set any other parameters defined by the menu item
+                ->setAll($routeParameters);
+        }
+    }
+}

--- a/crates/formatter/tests/cases/chain_comments/settings.inc
+++ b/crates/formatter/tests/cases/chain_comments/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings::default()

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -109,3 +109,4 @@ test_case!(match_breaking);
 test_case!(array_alignment);
 test_case!(binary_alignment);
 test_case!(binary_alignment_before_op);
+test_case!(chain_comments);


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR fixes a bug in the formatter that caused comments in member access chains to be printed after the access operator (`->` or `?->`) instead of before it.

## 🔍 Context & Motivation

The formatter was incorrectly positioning comments within member access chains, leading to misaligned and less readable code. This PR addresses this issue by ensuring that comments are printed in their correct location, before the access operator, preserving the intended code structure and improving readability.

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed the printing of comments in member access chains to ensure they are positioned before the access operator.
- **Tests:** Added new test cases to verify the correct placement of comments in member access chains.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Tests
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
