### PR TITLE
feat(formatter): add options to control formatting of arrays, named arguments, and attributes

### DIFF
--- a/crates/formatter/src/internal/format/call_node.rs
+++ b/crates/formatter/src/internal/format/call_node.rs
@@ -26,6 +26,11 @@ impl<'a> CallLikeNode<'a> {
         matches!(self, CallLikeNode::DieConstruct(_) | CallLikeNode::ExitConstruct(_))
     }
 
+    #[inline]
+    pub const fn is_attribute(&self) -> bool {
+        matches!(self, CallLikeNode::Attribute(_))
+    }
+
     pub fn arguments(&self) -> Option<&'a ArgumentList> {
         match self {
             CallLikeNode::Call(call) => Some(match call {

--- a/crates/formatter/src/internal/format/class_like.rs
+++ b/crates/formatter/src/internal/format/class_like.rs
@@ -3,9 +3,8 @@ use mago_span::Span;
 
 use crate::document::Document;
 use crate::internal::FormatterState;
+use crate::internal::format::block::print_block_of_nodes;
 use crate::settings::BraceStyle;
-
-use super::block::print_block_of_nodes;
 
 pub fn print_class_like_body<'a>(
     f: &mut FormatterState<'a>,

--- a/crates/formatter/src/internal/format/expression.rs
+++ b/crates/formatter/src/internal/format/expression.rs
@@ -4,6 +4,7 @@ use mago_span::HasSpan;
 use crate::document::Document;
 use crate::document::Line;
 use crate::internal::FormatterState;
+use crate::internal::format::Format;
 use crate::internal::format::Group;
 use crate::internal::format::IfBreak;
 use crate::internal::format::IndentIfBreak;
@@ -28,8 +29,6 @@ use crate::internal::format::string::print_string;
 use crate::internal::utils;
 use crate::settings::*;
 use crate::wrap;
-
-use crate::internal::format::Format;
 
 impl<'a> Format<'a> for Expression {
     fn format(&'a self, f: &mut FormatterState<'a>) -> Document<'a> {
@@ -1148,7 +1147,7 @@ impl<'a> Format<'a> for AnonymousClass {
 
             signature.push(self.class.format(f));
             if let Some(argument_list) = &self.arguments {
-                signature.push(print_argument_list(f, argument_list));
+                signature.push(print_argument_list(f, argument_list, false));
             }
 
             if let Some(extends) = &self.extends {

--- a/crates/formatter/src/internal/format/member_access.rs
+++ b/crates/formatter/src/internal/format/member_access.rs
@@ -6,9 +6,8 @@ use crate::document::Group;
 use crate::document::Line;
 use crate::internal::FormatterState;
 use crate::internal::format::Format;
+use crate::internal::format::call_arguments::print_argument_list;
 use crate::internal::parens::instantiation_needs_parens;
-
-use super::call_arguments::print_argument_list;
 
 #[derive(Debug)]
 pub(super) struct MemberAccessChain<'a> {
@@ -244,7 +243,7 @@ pub(super) fn print_member_access_chain<'a>(
             parts.push(method);
 
             if let Some(argument_list) = first_chain_link.get_arguments_list() {
-                parts.push(Document::Group(Group::new(vec![print_argument_list(f, argument_list)])));
+                parts.push(Document::Group(Group::new(vec![print_argument_list(f, argument_list, false)])));
             }
         }
     }
@@ -287,7 +286,7 @@ pub(super) fn print_member_access_chain<'a>(
         });
 
         if let Some(argument_list) = chain_link.get_arguments_list() {
-            contents.push(Document::Group(Group::new(vec![print_argument_list(f, argument_list)])));
+            contents.push(Document::Group(Group::new(vec![print_argument_list(f, argument_list, false)])));
         }
 
         parts.push(Document::Indent(contents));

--- a/crates/formatter/src/settings.rs
+++ b/crates/formatter/src/settings.rs
@@ -566,9 +566,28 @@ pub struct FormatSettings {
     /// die;    // `parentheses_in_exit_and_die = false`
     /// ```
     ///
-    /// Default: `true` (Add parentheses for consistency)
+    /// Default: `true`
     #[serde(default = "default_true")]
     pub parentheses_in_exit_and_die: bool,
+
+    /// Controls whether to include parentheses in attributes when they contain no arguments.
+    ///
+    /// If enabled, the formatter will add parentheses to attributes that don't have them.
+    ///
+    /// For example:
+    ///
+    /// ```php
+    /// #[SomeAttribute()] // `parentheses_in_attribute = true`
+    /// class Foo {}
+    ///
+    /// // or
+    /// #[SomeAttribute]   // `parentheses_in_attribute = false`
+    /// class Bar {}
+    /// ```
+    ///
+    /// Default: `false`
+    #[serde(default = "default_false")]
+    pub parentheses_in_attribute: bool,
 
     /// Controls whether to add a space after `!` operator and before the expression.
     ///
@@ -587,6 +606,65 @@ pub struct FormatSettings {
     /// Default: `false`
     #[serde(default = "default_false")]
     pub space_after_not_operator: bool,
+
+    /// Controls whether to use table-style alignment for arrays.
+    ///
+    /// If enabled, the formatter will attempt to align array elements in a table-like format,
+    /// making them more readable. This is particularly useful for arrays with consistent elements,
+    /// such as those used for data structures or configuration.
+    ///
+    /// For example:
+    ///
+    /// ```php
+    /// $array = [
+    ///     ['foo',  1.2,  123, false],
+    ///     ['bar',  52.4, 456, true],
+    ///     ['baz',  3.6,  789, false],
+    ///     ['qux',  4.8,    1, true],
+    ///     ['quux', 5.0,   12, false],
+    /// ];
+    /// ```
+    ///
+    /// Default: `true`
+    #[serde(default = "default_true")]
+    pub array_table_style_alignment: bool,
+
+    /// Controls whether to always break named argument lists into multiple lines.
+    ///
+    /// If enabled, the formatter will always break named argument lists into multiple lines,
+    /// making them more readable.
+    ///
+    /// For example:
+    ///
+    /// ```php
+    /// $foo = some_function(
+    ///     argument1: 'value1',
+    ///     argument2: 'value2',
+    /// );
+    /// ```
+    ///
+    /// Default: `true`
+    #[serde(default = "default_true")]
+    pub always_break_named_arguments_list: bool,
+
+    /// Controls whether to always long named argument lists in attributes into multiple lines.
+    ///
+    /// If enabled, the formatter will always break named argument lists in attributes into multiple lines,
+    /// making them more readable.
+    ///
+    /// For example:
+    ///
+    /// ```php
+    /// #[SomeAttribute(
+    ///     argument1: 'value1',
+    ///     argument2: 'value2',
+    /// )]
+    /// class Foo {}
+    /// ```
+    ///
+    /// Default: `false`
+    #[serde(default = "default_false")]
+    pub always_break_attribute_named_argument_lists: bool,
 }
 
 impl Default for FormatSettings {
@@ -624,7 +702,11 @@ impl Default for FormatSettings {
             parentheses_around_new_in_member_access: false,
             parentheses_in_new_expression: true,
             parentheses_in_exit_and_die: true,
+            parentheses_in_attribute: false,
             space_after_not_operator: false,
+            array_table_style_alignment: true,
+            always_break_named_arguments_list: true,
+            always_break_attribute_named_argument_lists: false,
         }
     }
 }

--- a/docs/formatter/settings.md
+++ b/docs/formatter/settings.md
@@ -392,7 +392,21 @@ If enabled, the formatter will add parentheses to `exit` and `die` statements th
   parentheses_in_exit_and_die = false
   ```
 
-### `space_after_not_operator`
+### `parentheses_in_attribute`
+
+Controls whether to include parentheses in attributes when they contain no arguments.
+
+If enabled, the formatter will add parentheses to attributes that don't have them.
+
+- Default: `false`
+- Type: `boolean`
+- Example:
+
+  ```toml
+  parentheses_in_attribute = true
+  ```
+
+### `space_after_not_operator`
 
 Controls whether to add a space after the `!` operator.
 
@@ -404,4 +418,46 @@ If enabled, the formatter will add a space after the `!` operator in logical neg
 
   ```toml
   space_after_not_operator = false
+  ```
+
+### `array_table_style_alignment`
+
+Controls whether to use table-style alignment for arrays.
+
+If enabled, the formatter will attempt to align array elements in a table-like format, making them more readable. This is particularly useful for arrays with consistent elements, such as those used for data structures or configuration.
+
+- Default: `true`
+- Type: `boolean`
+- Example:
+
+  ```toml
+  array_table_style_alignment = true
+  ```
+
+### `always_break_named_arguments_list`
+
+Controls whether to always break named argument lists into multiple lines.
+
+If enabled, the formatter will always break named argument lists into multiple lines, making them more readable.
+
+- Default: `true`
+- Type: `boolean`
+- Example:
+
+  ```toml
+  always_break_named_arguments_list = false
+  ```
+
+### `always_break_attribute_named_argument_lists`
+
+Controls whether to always break long named argument lists in attributes into multiple lines.
+
+If enabled, the formatter will always break named argument lists in attributes into multiple lines, making them more readable.
+
+- Default: `false`
+- Type: `boolean`
+- Example:
+
+  ```toml
+  always_break_attribute_named_argument_lists = true
   ```

--- a/src/config/formatter.rs
+++ b/src/config/formatter.rs
@@ -146,9 +146,25 @@ pub struct FormatterConfiguration {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parentheses_in_exit_and_die: Option<bool>,
 
+    /// Controls whether to include parentheses in attributes when they contain no arguments.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parentheses_in_attribute: Option<bool>,
+
     /// Controls whether to include a space after the `!` operator.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub space_after_not_operator: Option<bool>,
+
+    /// Controls whether to use table-style alignment for arrays.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub array_table_style_alignment: Option<bool>,
+
+    /// Controls whether to always break named argument lists into multiple lines.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub always_break_named_arguments_list: Option<bool>,
+
+    /// Controls whether to always long named argument lists in attributes into multiple lines.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub always_break_attribute_named_argument_lists: Option<bool>,
 }
 
 impl FormatterConfiguration {
@@ -207,7 +223,17 @@ impl FormatterConfiguration {
             parentheses_in_exit_and_die: self
                 .parentheses_in_exit_and_die
                 .unwrap_or(default.parentheses_in_exit_and_die),
+            parentheses_in_attribute: self.parentheses_in_attribute.unwrap_or(default.parentheses_in_attribute),
             space_after_not_operator: self.space_after_not_operator.unwrap_or(default.space_after_not_operator),
+            array_table_style_alignment: self
+                .array_table_style_alignment
+                .unwrap_or(default.array_table_style_alignment),
+            always_break_named_arguments_list: self
+                .always_break_named_arguments_list
+                .unwrap_or(default.always_break_named_arguments_list),
+            always_break_attribute_named_argument_lists: self
+                .always_break_attribute_named_argument_lists
+                .unwrap_or(default.always_break_attribute_named_argument_lists),
         }
     }
 }


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR adds new configuration options to the formatter, allowing for more precise control over the formatting of arrays, named arguments, and attributes.

## 🔍 Context & Motivation

This change is motivated by the desire to provide users with greater flexibility and control over the formatting of their code. The new options allow for fine-tuning the formatting of specific language constructs to better suit individual preferences and project conventions.

## 🛠️ Summary of Changes

- **Feature:** Added array_table_style_alignment option to control the use of table-style alignment for arrays.
- **Feature:** Added always_break_named_arguments_list option to control the breaking of named argument lists.
- **Feature:** Added always_break_attribute_named_argument_lists option to control the breaking of named argument lists in attributes.
- **Feature:** Added parentheses_in_attribute option to control the inclusion of parentheses in attributes with no arguments.
- **Docs:** Updated the formatter documentation to include the new options.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [x] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
