### PR TITLE
fix(linter): ignore boolean promoted properties in `best-practices/no-boolean-flag-parameter`

### DIFF
--- a/crates/linter/src/plugin/best_practices/rules/no_boolean_flag_parameter.rs
+++ b/crates/linter/src/plugin/best_practices/rules/no_boolean_flag_parameter.rs
@@ -34,6 +34,12 @@ impl Rule for NoBooleanFlagParameterRule {
                     function get_difference_case_insensitive(string $a, string $b): string {
                         // ...
                     }
+
+                    class Example {
+                        public function __construct(
+                            private bool $flag,
+                        ) {}
+                    }
                 "#},
             ))
             .with_example(RuleUsageExample::invalid(
@@ -50,6 +56,11 @@ impl Rule for NoBooleanFlagParameterRule {
 
     fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
         let Node::FunctionLikeParameter(parameter) = node else { return LintDirective::default() };
+
+        // Skip promoted properties
+        if parameter.is_promoted_property() {
+            return LintDirective::default();
+        }
 
         let Some(Hint::Bool(bool_hint)) = &parameter.hint else { return LintDirective::default() };
 


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR fixes an issue in `best-practices/no-boolean-flag-parameter` rule to allow for promoted properties to have `bool` type.

## 🔍 Context & Motivation

This change addresses a bug reported in issue #110 where the 
`no-boolean-flag-parameter` rule was not correctly handling promoted properties. Promoted properties, while having a bool type, are fundamentally different from boolean flags passed as function parameters. This rule is intended to discourage the use of boolean flags as parameters, as they can make code harder to understand and maintain. However, promoted properties do not have the same drawbacks and should not be flagged by this rule.

## 🛠️ Summary of Changes

- **Feature:** Updated the best-practices/no-boolean-flag-parameter rule to correctly handle promoted properties with bool types.
- **Feature:** Added new test cases to verify the correct behavior of the rule with promoted properties.

## 📂 Affected Areas

- [x] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Closes #110 

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
