### PR TITLE
feat(linter): add new laravel linting rules

### DIFF
--- a/crates/linter/src/plugin/laravel/mod.rs
+++ b/crates/linter/src/plugin/laravel/mod.rs
@@ -1,7 +1,8 @@
 use crate::definition::PluginDefinition;
-use crate::plugin::laravel::rules::safety::no_request_all::NoRequestAllRule;
-
 use crate::plugin::Plugin;
+use crate::plugin::laravel::rules::best_practices::middleware_in_routes::MiddlewareInRoutesRule;
+use crate::plugin::laravel::rules::best_practices::view_array_parameter::ViewArrayParameterRule;
+use crate::plugin::laravel::rules::safety::no_request_all::NoRequestAllRule;
 use crate::rule::Rule;
 
 pub mod rules;
@@ -19,6 +20,6 @@ impl Plugin for LaravelPlugin {
     }
 
     fn get_rules(&self) -> Vec<Box<dyn Rule>> {
-        vec![Box::new(NoRequestAllRule)]
+        vec![Box::new(NoRequestAllRule), Box::new(MiddlewareInRoutesRule), Box::new(ViewArrayParameterRule)]
     }
 }

--- a/crates/linter/src/plugin/laravel/rules/best_practices/anonymous_migration.rs
+++ b/crates/linter/src/plugin/laravel/rules/best_practices/anonymous_migration.rs
@@ -1,0 +1,113 @@
+use indoc::indoc;
+
+use mago_ast::*;
+use mago_reporting::*;
+use mago_span::HasSpan;
+
+use crate::context::LintContext;
+use crate::definition::RuleDefinition;
+use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
+use crate::rule::Rule;
+
+#[derive(Clone, Debug)]
+pub struct AnonymousMigrationRule;
+
+impl Rule for AnonymousMigrationRule {
+    fn get_definition(&self) -> RuleDefinition {
+        RuleDefinition::enabled("Anonymous Migration", Level::Warning)
+            .with_description(indoc! {"
+                Prefer using anonymous classes for Laravel migrations instead of named classes.
+
+                Anonymous classes are more concise and reduce namespace pollution,
+                making them the recommended approach for migrations.
+            "})
+            .with_example(RuleUsageExample::valid(
+                "Using an anonymous migration class.",
+                indoc! {r#"
+                    <?php
+
+                    use Illuminate\Database\Migrations\Migration;
+                    use Illuminate\Database\Schema\Blueprint;
+                    use Illuminate\Support\Facades\Schema;
+
+                    return new class extends Migration {
+                        public function up(): void {
+                            Schema::create('flights', function (Blueprint $table) {
+                                $table->id();
+                                $table->string('name');
+                                $table->string('airline');
+                                $table->timestamps();
+                            });
+                        }
+
+                        public function down(): void {
+                            Schema::drop('flights');
+                        }
+                    };
+                "#},
+            ))
+            .with_example(RuleUsageExample::invalid(
+                "Using a named migration class.",
+                indoc! {r#"
+                    <?php
+
+                    use Illuminate\Database\Migrations\Migration;
+                    use Illuminate\Database\Schema\Blueprint;
+                    use Illuminate\Support\Facades\Schema;
+
+                    class MyMigration extends Migration {
+                        public function up(): void {
+                            Schema::create('flights', function (Blueprint $table) {
+                                $table->id();
+                                $table->string('name');
+                                $table->string('airline');
+                                $table->timestamps();
+                            });
+                        }
+
+                        public function down(): void {
+                            Schema::drop('flights');
+                        }
+                    }
+
+                    return new MyMigration();
+                "#},
+            ))
+    }
+
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let Node::Class(class) = node else {
+            return LintDirective::default();
+        };
+
+        let Some(extends) = class.extends.as_ref() else {
+            return LintDirective::default();
+        };
+
+        let mut is_migration = false;
+        for extended_type in extends.types.iter() {
+            let name = context.lookup_name(&extended_type);
+
+            if name.eq_ignore_ascii_case("Illuminate\\Database\\Migrations\\Migration") {
+                is_migration = true;
+                break;
+            }
+        }
+
+        if !is_migration {
+            return LintDirective::default();
+        }
+
+        context.report(
+            Issue::new(context.level(), "Use anonymous classes for migrations instead of named classes.")
+                .with_annotation(
+                    Annotation::primary(class.span()).with_message("This migration class should be anonymous."),
+                )
+                .with_note("Anonymous classes are the recommended approach for Laravel migrations.")
+                .with_help("Refactor the migration to use an anonymous class by removing the class name."),
+        );
+
+        LintDirective::Prune
+    }
+}

--- a/crates/linter/src/plugin/laravel/rules/best_practices/middleware_in_routes.rs
+++ b/crates/linter/src/plugin/laravel/rules/best_practices/middleware_in_routes.rs
@@ -1,0 +1,76 @@
+use indoc::indoc;
+
+use mago_ast::*;
+use mago_reporting::*;
+use mago_span::HasSpan;
+
+use crate::context::LintContext;
+use crate::definition::RuleDefinition;
+use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
+use crate::plugin::laravel::rules::utils::is_method_named;
+use crate::plugin::laravel::rules::utils::is_this;
+use crate::plugin::laravel::rules::utils::is_within_controller;
+use crate::rule::Rule;
+
+#[derive(Clone, Debug)]
+pub struct MiddlewareInRoutesRule;
+
+impl Rule for MiddlewareInRoutesRule {
+    fn get_definition(&self) -> RuleDefinition {
+        RuleDefinition::enabled("Middleware In Routes", Level::Warning)
+            .with_description(indoc! {"
+                This rule warns against applying middlewares in controllers.
+
+                Middlewares should be applied in the routes file, not in the controller.
+            "})
+            .with_example(RuleUsageExample::valid(
+                "Applying middleware in the routes file",
+                indoc! {r#"
+                    <?php
+
+                    // routes/web.php
+                    Route::get('/user', 'UserController@index')->middleware('auth');
+                "#},
+            ))
+            .with_example(RuleUsageExample::invalid(
+                "Applying middleware in the controller",
+                indoc! {r#"
+                    <?php
+
+                    namespace App\Http\Controllers;
+
+                    class UserController extends Controller
+                    {
+                        public function __construct()
+                        {
+                            $this->middleware('auth');
+                        }
+                    }
+                "#},
+            ))
+    }
+
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        if !is_within_controller(context) {
+            return LintDirective::default();
+        }
+
+        let Node::MethodCall(call @ MethodCall { object, method, .. }) = node else {
+            return LintDirective::default();
+        };
+
+        if !is_this(context, object) || !is_method_named(context, method, "middleware") {
+            return LintDirective::default();
+        }
+
+        let issue = Issue::new(context.level(), "Avoid applying middlewares in controllers.")
+            .with_annotation(Annotation::primary(call.span()).with_message("Middleware applied here."))
+            .with_note("Middlewares should be applied in the routes file, not in the controller.")
+            .with_help("Move the middleware to the routes file.");
+
+        context.report(issue);
+
+        LintDirective::Prune
+    }
+}

--- a/crates/linter/src/plugin/laravel/rules/best_practices/view_array_parameter.rs
+++ b/crates/linter/src/plugin/laravel/rules/best_practices/view_array_parameter.rs
@@ -1,0 +1,72 @@
+use indoc::indoc;
+
+use mago_ast::*;
+use mago_reporting::*;
+use mago_span::HasSpan;
+
+use crate::context::LintContext;
+use crate::definition::RuleDefinition;
+use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
+use crate::plugin::laravel::rules::utils::is_function_call_to;
+use crate::plugin::laravel::rules::utils::is_method_named;
+use crate::rule::Rule;
+
+#[derive(Clone, Debug)]
+pub struct ViewArrayParameterRule;
+
+impl Rule for ViewArrayParameterRule {
+    fn get_definition(&self) -> RuleDefinition {
+        RuleDefinition::enabled("View Array Parameter", Level::Help)
+            .with_description(indoc! {"
+                Prefer passing data to views using the array parameter in the `view()` function,
+                rather than chaining the `with()` method.
+
+                Using the array parameter directly is more concise and readable.
+            "})
+            .with_example(RuleUsageExample::valid(
+                "Using `view(..., [...])`",
+                indoc! {r#"
+                    <?php
+
+                    return view('user.profile', [
+                        'user' => $user,
+                        'profile' => $profile,
+                    ]);
+                "#},
+            ))
+            .with_example(RuleUsageExample::invalid(
+                "Using `view(...)->with([...])`",
+                indoc! {r#"
+                    <?php
+
+                    return view('user.profile')->with([
+                        'user' => $user,
+                        'profile' => $profile,
+                    ]);
+                "#},
+            ))
+    }
+
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let Node::MethodCall(call @ MethodCall { object, method, .. }) = node else {
+            return LintDirective::default();
+        };
+
+        if !is_function_call_to(context, object.as_ref(), "view") || !is_method_named(context, method, "with") {
+            return LintDirective::default();
+        }
+
+        context.report(
+            Issue::new(context.level(), "Use array parameter in `view()` instead of chaining `with()`.")
+                .with_annotation(
+                    Annotation::primary(call.span())
+                        .with_message("Chaining `with()` here is less readable and idiomatic."),
+                )
+                .with_note("Passing data directly as an array parameter to `view()` is preferred.")
+                .with_help("Refactor the code to use the array parameter in the `view()` function."),
+        );
+
+        LintDirective::Prune
+    }
+}

--- a/crates/linter/src/plugin/laravel/rules/mod.rs
+++ b/crates/linter/src/plugin/laravel/rules/mod.rs
@@ -1,3 +1,11 @@
+mod utils;
+
 pub mod safety {
     pub mod no_request_all;
+}
+
+pub mod best_practices {
+    pub mod anonymous_migration;
+    pub mod middleware_in_routes;
+    pub mod view_array_parameter;
 }

--- a/crates/linter/src/plugin/laravel/rules/utils.rs
+++ b/crates/linter/src/plugin/laravel/rules/utils.rs
@@ -1,0 +1,41 @@
+use mago_ast::*;
+
+use crate::context::LintContext;
+use crate::scope::ClassLikeScope;
+
+pub fn is_within_controller(context: &LintContext<'_>) -> bool {
+    let Some(ClassLikeScope::Class(classname_id)) = context.scope.get_class_like_scope() else {
+        return false;
+    };
+
+    context.interner.lookup(classname_id).ends_with("Controller")
+}
+
+pub fn is_this<'a>(context: &LintContext<'a>, expression: &'a Expression) -> bool {
+    if let Expression::Variable(Variable::Direct(var)) = expression {
+        context.interner.lookup(&var.name).eq_ignore_ascii_case("$this")
+    } else {
+        false
+    }
+}
+
+pub fn is_method_named<'a>(context: &LintContext<'a>, member: &'a ClassLikeMemberSelector, name: &str) -> bool {
+    match member {
+        ClassLikeMemberSelector::Identifier(method) => {
+            context.interner.lookup(&method.value).eq_ignore_ascii_case(name)
+        }
+        _ => false,
+    }
+}
+
+pub fn is_function_call_to<'a>(context: &LintContext<'a>, expression: &'a Expression, function_name: &str) -> bool {
+    let Expression::Call(Call::Function(FunctionCall { function, .. })) = expression else {
+        return false;
+    };
+
+    let Expression::Identifier(function_identifier) = function.as_ref() else { return false };
+
+    let called_function_name = context.resolve_function_name(function_identifier);
+
+    called_function_name.eq_ignore_ascii_case(function_name)
+}

--- a/crates/linter/tests/plugins/laravel.rs
+++ b/crates/linter/tests/plugins/laravel.rs
@@ -1,5 +1,11 @@
+use mago_linter::plugin::laravel::rules::best_practices::anonymous_migration::AnonymousMigrationRule;
+use mago_linter::plugin::laravel::rules::best_practices::middleware_in_routes::MiddlewareInRoutesRule;
+use mago_linter::plugin::laravel::rules::best_practices::view_array_parameter::ViewArrayParameterRule;
 use mago_linter::plugin::laravel::rules::safety::no_request_all::NoRequestAllRule;
 
 use crate::rule_test;
 
 rule_test!(test_no_request_all, NoRequestAllRule);
+rule_test!(test_anonymous_migration, AnonymousMigrationRule);
+rule_test!(test_view_array_parameter, ViewArrayParameterRule);
+rule_test!(test_middleware_in_routes, MiddlewareInRoutesRule);


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR adds three new linter rules to the Laravel plugin, enhancing Mago's ability to analyze and improve Laravel-specific code.

## 🔍 Context & Motivation

These rules are designed to help Laravel developers adhere to best practices and improve the quality of their code. They address specific patterns and conventions common in Laravel applications, providing valuable insights and suggestions for improvement.

## 🛠️ Summary of Changes

- **Feature:** Added `laravel/anonymous-migration` rule to encourage the use of anonymous classes for migrations.
- **Feature:** Added `laravel/middleware-in-routes` rule to enforce applying middleware in routes files instead of controllers.
- **Feature:** Added `laravel/view-array-parameter` rule to promote passing data to views using the array parameter in the view() function.

## 📂 Affected Areas

- [x] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
