### PR TITLE
feat(linter): add new psl plugin

### DIFF
--- a/crates/linter/src/plugin/mod.rs
+++ b/crates/linter/src/plugin/mod.rs
@@ -13,6 +13,7 @@ pub mod maintainability;
 pub mod migration;
 pub mod naming;
 pub mod phpunit;
+pub mod psl;
 pub mod redundancy;
 pub mod safety;
 pub mod security;
@@ -32,6 +33,7 @@ macro_rules! foreach_plugin {
         $do($crate::plugin::migration::MigrationPlugin);
         $do($crate::plugin::naming::NamingPlugin);
         $do($crate::plugin::phpunit::PHPUnitPlugin);
+        $do($crate::plugin::psl::PslPlugin);
         $do($crate::plugin::redundancy::RedundancyPlugin);
         $do($crate::plugin::safety::SafetyPlugin);
         $do($crate::plugin::security::SecurityPlugin);

--- a/crates/linter/src/plugin/psl/mod.rs
+++ b/crates/linter/src/plugin/psl/mod.rs
@@ -1,0 +1,47 @@
+use indoc::indoc;
+
+use crate::definition::PluginDefinition;
+use crate::plugin::Plugin;
+use crate::plugin::psl::rules::array_functions::ArrayFunctionsRule;
+use crate::plugin::psl::rules::data_structures::DataStructuresRule;
+use crate::plugin::psl::rules::datetime::DateTimeRule;
+use crate::plugin::psl::rules::math_functions::MathFunctionsRule;
+use crate::plugin::psl::rules::output::OutputRule;
+use crate::plugin::psl::rules::randomness_functions::RandomnessFunctionsRule;
+use crate::plugin::psl::rules::regex_functions::RegexFunctionsRule;
+use crate::plugin::psl::rules::sleep_functions::SleepFunctionsRule;
+use crate::plugin::psl::rules::string_functions::StringFunctionsRule;
+use crate::rule::Rule;
+
+pub mod rules;
+
+#[derive(Debug)]
+pub struct PslPlugin;
+
+impl Plugin for PslPlugin {
+    fn get_definition(&self) -> PluginDefinition {
+        PluginDefinition {
+            name: "Psl",
+            description: indoc! {"
+                Enforces the consistent usage of the PHP Standard Library (Psl). This plugin
+                helps you replace built-in PHP functions with their Psl equivalents, promoting type safety,
+                improved error handling, and a more functional programming style.
+            "},
+            enabled_by_default: false,
+        }
+    }
+
+    fn get_rules(&self) -> Vec<Box<dyn Rule>> {
+        vec![
+            Box::new(ArrayFunctionsRule),
+            Box::new(DataStructuresRule),
+            Box::new(DateTimeRule),
+            Box::new(MathFunctionsRule),
+            Box::new(OutputRule),
+            Box::new(RandomnessFunctionsRule),
+            Box::new(RegexFunctionsRule),
+            Box::new(SleepFunctionsRule),
+            Box::new(StringFunctionsRule),
+        ]
+    }
+}

--- a/crates/linter/src/plugin/psl/rules/array_functions.rs
+++ b/crates/linter/src/plugin/psl/rules/array_functions.rs
@@ -1,0 +1,174 @@
+use std::sync::LazyLock;
+
+use ahash::HashMap;
+use indoc::indoc;
+
+use mago_ast::*;
+use mago_reporting::*;
+use mago_span::HasSpan;
+
+use crate::context::LintContext;
+use crate::definition::RuleDefinition;
+use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
+use crate::plugin::psl::rules::utils::format_replacements;
+use crate::rule::Rule;
+
+#[derive(Clone, Debug)]
+pub struct ArrayFunctionsRule;
+
+impl Rule for ArrayFunctionsRule {
+    fn get_definition(&self) -> RuleDefinition {
+        RuleDefinition::enabled("Array Functions", Level::Warning)
+            .with_description(indoc! {"
+                  This rule enforces the usage of Psl array functions over their PHP counterparts.
+
+                  Psl array functions are preferred because they are type-safe and provide more consistent behavior.
+              "})
+            .with_example(RuleUsageExample::valid(
+                "Using `Psl\\Vec\\filter` instead of `array_filter`.",
+                indoc! {r#"
+                    <?php
+
+                    $filtered = Psl\Vec\filter($xs, fn($x) => $x > 2);
+                "#},
+            ))
+            .with_example(RuleUsageExample::valid(
+                "Using `Psl\\Vec\\map` instead of `array_map`.",
+                indoc! {r#"
+                    <?php
+
+                    $mapped = Psl\Vec\map($xs, fn($x) => $x * 2);
+                "#},
+            ))
+            .with_example(RuleUsageExample::invalid(
+                "Using `array_filter`.",
+                indoc! {r#"
+                    <?php
+
+                    $filtered = array_filter($xs, fn($x) => $x > 2);
+                "#},
+            ))
+            .with_example(RuleUsageExample::invalid(
+                "Using `array_map`.",
+                indoc! {r#"
+                    <?php
+
+                    $mapped = array_map($xs, fn($x) => $x * 2);
+                "#},
+            ))
+    }
+
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let Node::FunctionCall(function_call) = node else { return LintDirective::default() };
+        let Expression::Identifier(identifier) = function_call.function.as_ref() else {
+            return LintDirective::default();
+        };
+
+        let function_name = context.resolve_function_name(identifier).to_lowercase();
+        if let Some(replacements) = (*ARRAY_FUNCTION_REPLACEMENTS).get(function_name.as_str()) {
+            context.report(
+                Issue::new(
+                    context.level(),
+                    "Use the Psl array function instead of the PHP counterpart.",
+                )
+                .with_annotation(
+                    Annotation::primary(identifier.span()).with_message("This is a PHP array function."),
+                )
+                .with_note("Psl array functions are preferred because they are type-safe and provide more consistent behavior.")
+                .with_help(format!(
+                    "Use `{}` instead.",
+                    format_replacements(replacements),
+                )),
+            );
+        }
+
+        LintDirective::default()
+    }
+}
+
+static ARRAY_FUNCTION_REPLACEMENTS: LazyLock<HashMap<&'static str, Vec<&'static str>>> = LazyLock::new(|| {
+    HashMap::from_iter([
+        ("array_all", vec!["Psl\\Iter\\all"]),
+        ("array_any", vec!["Psl\\Iter\\any"]),
+        ("array_chunk", vec!["Psl\\Vec\\chunk", "Psl\\Vec\\chunk_with_keys"]),
+        ("array_combine", vec!["Psl\\Dict\\associate"]),
+        ("array_diff", vec!["Psl\\Dict\\diff"]),
+        ("array_diff_key", vec!["Psl\\Dict\\diff_by_key"]),
+        ("array_fill", vec!["Psl\\Vec\\fill"]),
+        (
+            "array_filter",
+            vec![
+                "Psl\\Vec\\filter",
+                "Psl\\Vec\\filter_keys",
+                "Psl\\Vec\\filter_with_keys",
+                "Psl\\Vec\\filter_nulls",
+                "Psl\\Dict\\filter",
+                "Psl\\Dict\\filter_keys",
+                "Psl\\Dict\\filter_with_keys",
+                "Psl\\Dict\\filter_nulls",
+            ],
+        ),
+        ("array_flip", vec!["Psl\\Dict\\flip"]),
+        ("array_find", vec!["Psl\\Iter\\search", "Psl\\Iter\\search_with_keys", "Psl\\Iter\\search_keys"]),
+        ("array_intersect", vec!["Psl\\Dict\\intersect"]),
+        ("array_intersect_key", vec!["Psl\\Dict\\intersect_by_key"]),
+        ("array_key_exists", vec!["Psl\\Iter\\contains_key"]),
+        ("array_key_first", vec!["Psl\\Iter\\first_key"]),
+        ("array_key_last", vec!["Psl\\Iter\\last_key"]),
+        ("array_keys", vec!["Psl\\Vec\\keys"]),
+        (
+            "array_map",
+            vec![
+                "Psl\\Vec\\map",
+                "Psl\\Vec\\map_with_key",
+                "Psl\\Dict\\map",
+                "Psl\\Dict\\map_keys",
+                "Psl\\Dict\\map_with_key",
+            ],
+        ),
+        ("array_merge", vec!["Psl\\Vec\\concat", "Psl\\Dict\\merge"]),
+        ("array_rand", vec!["Psl\\Iter\\random"]),
+        ("array_reduce", vec!["Psl\\Iter\\reduce", "Psl\\Iter\\reduce_keys", "Psl\\Iter\\reduce_with_keys"]),
+        ("array_reverse", vec!["Psl\\Vec\\reverse"]),
+        (
+            "array_slice",
+            vec![
+                "Psl\\Vec\\slice",
+                "Psl\\Vec\\take",
+                "Psl\\Vec\\take_while",
+                "Psl\\Vec\\drop",
+                "Psl\\Vec\\drop_while",
+                "Psl\\Dict\\slice",
+                "Psl\\Dict\\take",
+                "Psl\\Dict\\take_while",
+                "Psl\\Dict\\drop",
+                "Psl\\Dict\\drop_while",
+            ],
+        ),
+        ("array_sum", vec!["Psl\\Math\\sum", "Psl\\Math\\sum_floats"]),
+        (
+            "array_unique",
+            vec![
+                "Psl\\Vec\\unique",
+                "Psl\\Vec\\unique_by",
+                "Psl\\Vec\\unique_scalar",
+                "Psl\\Dict\\unique",
+                "Psl\\Dict\\unique_by",
+                "Psl\\Dict\\unique_scalar",
+            ],
+        ),
+        ("array_walk", vec!["Psl\\Iter\\apply"]),
+        ("uasort", vec!["Psl\\Dict\\sort", "Psl\\Dict\\sort_by", "Psl\\Vec\\sort_by"]),
+        ("asort", vec!["Psl\\Dict\\sort", "Psl\\Dict\\sort_by", "Psl\\Vec\\sort_by"]),
+        ("uksort", vec!["Psl\\Dict\\sort_by_key"]),
+        ("ksort", vec!["Psl\\Dict\\sort_by_key"]),
+        ("usort", vec!["Psl\\Vec\\sort", "Psl\\Vec\\sort_by"]),
+        ("sort", vec!["Psl\\Vec\\sort", "Psl\\Vec\\sort_by"]),
+        ("array_values", vec!["Psl\\Vec\\values"]),
+        ("sizeof", vec!["Psl\\Iter\\count"]),
+        ("count", vec!["Psl\\Iter\\count"]),
+        ("in_array", vec!["Psl\\Iter\\contains"]),
+        ("shuffle", vec!["Psl\\Iter\\shuffle"]),
+    ])
+});

--- a/crates/linter/src/plugin/psl/rules/data_structures.rs
+++ b/crates/linter/src/plugin/psl/rules/data_structures.rs
@@ -1,0 +1,112 @@
+use std::sync::LazyLock;
+
+use ahash::HashMap;
+use indoc::indoc;
+
+use mago_ast::*;
+use mago_reporting::*;
+use mago_span::HasSpan;
+
+use crate::context::LintContext;
+use crate::definition::RuleDefinition;
+use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
+use crate::plugin::psl::rules::utils::format_replacements;
+use crate::rule::Rule;
+
+#[derive(Clone, Debug)]
+pub struct DataStructuresRule;
+
+impl Rule for DataStructuresRule {
+    fn get_definition(&self) -> RuleDefinition {
+        RuleDefinition::enabled("Data Structures", Level::Warning)
+            .with_description(indoc! {"
+                This rule enforces the usage of Psl data structures over their SPL counterparts.
+
+                Psl data structures are preferred because they are type-safe and provide more consistent behavior.
+            "})
+            .with_example(RuleUsageExample::valid(
+                "Using the `Psl\\DataStructure\\Stack` class",
+                indoc! {r#"
+                    <?php
+
+                    declare(strict_types=1);
+
+                    use Psl\DataStructure\Stack;
+
+                    $stack = new Stack();
+                "#},
+            ))
+            .with_example(RuleUsageExample::valid(
+                "Using the `Psl\\DataStructure\\Queue` class",
+                indoc! {r#"
+                    <?php
+
+                    declare(strict_types=1);
+
+                    use Psl\DataStructure\Queue;
+
+                    $queue = new Queue();
+                "#},
+            ))
+            .with_example(RuleUsageExample::valid(
+                "Using the `Psl\\DataStructure\\PriorityQueue` class",
+                indoc! {r#"
+                    <?php
+
+                    declare(strict_types=1);
+
+                    use Psl\DataStructure\PriorityQueue;
+
+                    $priorityQueue = new PriorityQueue();
+                "#},
+            ))
+            .with_example(RuleUsageExample::invalid(
+                "Using the `SplStack` class",
+                indoc! {r#"
+                    <?php
+
+                    declare(strict_types=1);
+
+                    $stack = new SplStack();
+                "#},
+            ))
+            .with_example(RuleUsageExample::invalid(
+                "Using the `SplQueue` class",
+                indoc! {r#"
+                    <?php
+
+                    declare(strict_types=1);
+
+                    $queue = new SplQueue();
+                "#},
+            ))
+    }
+
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let Node::Instantiation(instantiation) = node else { return LintDirective::default() };
+        let Expression::Identifier(identifier) = instantiation.class.as_ref() else { return LintDirective::default() };
+
+        let class_name = context.lookup_name(identifier).to_lowercase();
+        if let Some(replacements) = DATA_STRUCTURE_REPLACEMENTS.get(class_name.as_str()) {
+            context.report(
+                Issue::new(context.level(), "Use the Psl data structure instead of the SPL counterpart.")
+                    .with_annotation(Annotation::primary(identifier.span()).with_message("This is an SPL data structure."))
+                    .with_note("Psl data structures are preferred because they are type-safe and provide more consistent behavior.")
+                    .with_help(format!(
+                        "Use `{}` instead.",
+                        format_replacements(replacements),
+                    )),
+            );
+        }
+
+        LintDirective::default()
+    }
+}
+
+static DATA_STRUCTURE_REPLACEMENTS: LazyLock<HashMap<&'static str, Vec<&'static str>>> = LazyLock::new(|| {
+    HashMap::from_iter([
+        ("splstack", vec!["Psl\\DataStructure\\Stack"]),
+        ("splqueue", vec!["Psl\\DataStructure\\Queue", "Psl\\DataStructure\\PriorityQueue"]),
+    ])
+});

--- a/crates/linter/src/plugin/psl/rules/datetime.rs
+++ b/crates/linter/src/plugin/psl/rules/datetime.rs
@@ -1,0 +1,141 @@
+use std::sync::LazyLock;
+
+use ahash::HashMap;
+use indoc::indoc;
+
+use mago_ast::*;
+use mago_reporting::*;
+use mago_span::HasSpan;
+
+use crate::context::LintContext;
+use crate::definition::RuleDefinition;
+use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
+use crate::plugin::psl::rules::utils::format_replacements;
+use crate::rule::Rule;
+
+#[derive(Clone, Debug)]
+pub struct DateTimeRule;
+
+impl Rule for DateTimeRule {
+    fn get_definition(&self) -> RuleDefinition {
+        RuleDefinition::enabled("DateTime", Level::Warning)
+            .with_description(indoc! {"
+                This rule enforces the usage of Psl DateTime classes and functions over their PHP counterparts.
+
+                Psl DateTime classes and functions are preferred because they are type-safe and provide more consistent behavior.
+            "})
+            .with_example(RuleUsageExample::valid(
+                "Using `Psl\\DateTime\\DateTime` instead of `DateTime`.",
+                indoc! {r#"
+                    <?php
+
+                    $dateTime = new Psl\DateTime\DateTime();
+                "#},
+            ))
+            .with_example(RuleUsageExample::valid(
+                "Using `Psl\\DateTime\\DateTime::now` instead of `new DateTime()`.",
+                indoc! {r#"
+                    <?php
+
+                    $now = Psl\DateTime\DateTime::now();
+                "#},
+            ))
+            .with_example(RuleUsageExample::invalid(
+                "Using `DateTime`.",
+                indoc! {r#"
+                    <?php
+
+                    $dateTime = new DateTime();
+                "#},
+            ))
+            .with_example(RuleUsageExample::invalid(
+                "Using `strtotime`.",
+                indoc! {r#"
+                    <?php
+
+                    $timestamp = strtotime('now');
+                "#},
+            ))
+    }
+
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let identifier = match node {
+            Node::FunctionCall(function_call) => {
+                let Expression::Identifier(identifier) = function_call.function.as_ref() else {
+                    return LintDirective::default();
+                };
+
+                let function_name = context.resolve_function_name(identifier).to_lowercase();
+
+                if let Some(replacements) = (*DATETIME_FUNCTION_REPLACEMENTS).get(function_name.as_str()) {
+                    context.report(
+                        Issue::new(context.level(), "Use the Psl DateTime function instead of the PHP counterpart.")
+                            .with_annotation(Annotation::primary(identifier.span()).with_message("This is a PHP DateTime function."))
+                            .with_note("Psl DateTime classes and functions are preferred because they are type-safe and provide more consistent behavior.")
+                            .with_help(format!("Use {} instead.", format_replacements(replacements))),
+                    );
+                }
+
+                return LintDirective::default();
+            }
+            Node::Instantiation(instantiation) => {
+                let Expression::Identifier(identifier) = instantiation.class.as_ref() else {
+                    return LintDirective::default();
+                };
+
+                identifier
+            }
+            Node::Call(Call::StaticMethod(static_method_call)) => {
+                let Expression::Identifier(identifier) = static_method_call.class.as_ref() else {
+                    return LintDirective::default();
+                };
+
+                identifier
+            }
+            _ => return LintDirective::default(),
+        };
+
+        let class_name = context.lookup_name(identifier).to_lowercase();
+        if let Some(replacements) = DATETIME_CLASS_REPLACEMENTS.get(class_name.as_str()) {
+            context.report(
+                Issue::new(context.level(), "Use the Psl DateTime class instead of the PHP counterpart.")
+                    .with_annotation(Annotation::primary(identifier.span()).with_message("This is a PHP DateTime class."))
+                    .with_note("Psl DateTime classes and functions are preferred because they are type-safe and provide more consistent behavior.")
+                    .with_help(format!("Use {} instead.", format_replacements(replacements))),
+            );
+        }
+
+        LintDirective::default()
+    }
+}
+
+static DATETIME_FUNCTION_REPLACEMENTS: LazyLock<HashMap<&'static str, Vec<&'static str>>> = LazyLock::new(|| {
+    HashMap::from_iter([
+        ("time", vec!["Psl\\DateTime\\Timestamp::now", "Psl\\DateTime\\DateTime::now"]),
+        ("microtime", vec!["Psl\\DateTime\\Timestamp::now", "Psl\\DateTime\\DateTime::now"]),
+        ("hrtime", vec!["Psl\\DateTime\\Timestamp::monotonic"]),
+        (
+            "strtotime",
+            vec![
+                "Psl\\DateTime\\Timestamp::parse",
+                "Psl\\DateTime\\Timestamp::fromString",
+                "Psl\\DateTime\\DateTime::parse",
+                "Psl\\DateTime\\DateTime::fromString",
+            ],
+        ),
+        ("date_default_timezone_get", vec!["Psl\\DateTime\\Timezone::default"]),
+    ])
+});
+
+static DATETIME_CLASS_REPLACEMENTS: LazyLock<HashMap<&'static str, Vec<&'static str>>> = LazyLock::new(|| {
+    HashMap::from_iter([
+        ("datetime", vec!["Psl\\DateTime\\DateTime"]),
+        ("datetimeimmutable", vec!["Psl\\DateTime\\DateTime"]),
+        ("datetimezone", vec!["Psl\\DateTime\\Timezone"]),
+        ("dateinterval", vec!["Psl\\DateTime\\Duration"]),
+        ("intldateformatter", vec!["Psl\\DateTime\\DateTime"]),
+        ("intltimezone", vec!["Psl\\DateTime\\Timezone"]),
+        ("intltimezone", vec!["Psl\\DateTime\\Timezone"]),
+    ])
+});

--- a/crates/linter/src/plugin/psl/rules/math_functions.rs
+++ b/crates/linter/src/plugin/psl/rules/math_functions.rs
@@ -1,0 +1,110 @@
+use std::sync::LazyLock;
+
+use ahash::HashMap;
+use indoc::indoc;
+
+use mago_ast::*;
+use mago_reporting::*;
+use mago_span::HasSpan;
+
+use crate::context::LintContext;
+use crate::definition::RuleDefinition;
+use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
+use crate::plugin::psl::rules::utils::format_replacements;
+use crate::rule::Rule;
+
+#[derive(Clone, Debug)]
+pub struct MathFunctionsRule;
+
+impl Rule for MathFunctionsRule {
+    fn get_definition(&self) -> RuleDefinition {
+        RuleDefinition::enabled("Math Functions", Level::Warning)
+            .with_description(indoc! {"
+                   This rule enforces the usage of Psl math functions over their PHP counterparts.
+
+                   Psl math functions are preferred because they are type-safe and provide more consistent behavior.
+               "})
+            .with_example(RuleUsageExample::valid(
+                "Using `Psl\\Math\\abs` instead of `abs`.",
+                indoc! {r#"
+                    <?php
+
+                    $abs = Psl\Math\abs($number);
+                "#},
+            ))
+            .with_example(RuleUsageExample::valid(
+                "Using `Psl\\Math\\maxva` instead of `max`.",
+                indoc! {r#"
+                    <?php
+
+                    $max = Psl\Math\maxva($numbers);
+                "#},
+            ))
+            .with_example(RuleUsageExample::invalid(
+                "Using `abs`.",
+                indoc! {r#"
+                    <?php
+
+                    $abs = abs($number);
+                "#},
+            ))
+            .with_example(RuleUsageExample::invalid(
+                "Using `max`.",
+                indoc! {r#"
+                    <?php
+
+                    $max = max(...$numbers);
+                "#},
+            ))
+    }
+
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let Node::FunctionCall(function_call) = node else { return LintDirective::default() };
+        let Expression::Identifier(identifier) = function_call.function.as_ref() else {
+            return LintDirective::default();
+        };
+
+        let function_name = context.resolve_function_name(identifier).to_lowercase();
+        if let Some(replacements) = MATH_FUNCTION_REPLACEMENTS.get(function_name.as_str()) {
+            context.report(
+                Issue::new(context.level(), "Use the Psl math function instead of the PHP counterpart.")
+                    .with_annotation(Annotation::primary(identifier.span()).with_message("This is a PHP math function."))
+                    .with_note(
+                        "Psl math functions are preferred because they are type-safe and provide more consistent behavior.",
+                    )
+                    .with_help(format!("Use `{}` instead.", format_replacements(replacements))),
+            );
+        }
+
+        LintDirective::default()
+    }
+}
+
+static MATH_FUNCTION_REPLACEMENTS: LazyLock<HashMap<&'static str, Vec<&'static str>>> = LazyLock::new(|| {
+    HashMap::from_iter([
+        ("abs", vec!["Psl\\Math\\abs"]),
+        ("acos", vec!["Psl\\Math\\acos"]),
+        ("acos", vec!["Psl\\Math\\acos"]),
+        ("asin", vec!["Psl\\Math\\asin"]),
+        ("atan", vec!["Psl\\Math\\atan2"]),
+        ("base_convert", vec!["Psl\\Math\\base_convert"]),
+        ("ceil", vec!["Psl\\Math\\ceil"]),
+        ("cos", vec!["Psl\\Math\\cos"]),
+        ("intdiv", vec!["Psl\\Math\\div"]),
+        ("exp", vec!["Psl\\Math\\exp"]),
+        ("floor", vec!["Psl\\Math\\floor"]),
+        ("hexdec", vec!["Psl\\Math\\from_base"]),
+        ("bindec", vec!["Psl\\Math\\from_base"]),
+        ("decbin", vec!["Psl\\Math\\to_base"]),
+        ("dechex", vec!["Psl\\Math\\to_base"]),
+        ("decoct", vec!["Psl\\Math\\to_base"]),
+        ("log", vec!["Psl\\Math\\log"]),
+        ("max", vec!["Psl\\Math\\max", "Psl\\Math\\maxva", "Psl\\Math\\max_by"]),
+        ("min", vec!["Psl\\Math\\min", "Psl\\Math\\minva", "Psl\\Math\\min_by"]),
+        ("round", vec!["Psl\\Math\\round"]),
+        ("sin", vec!["Psl\\Math\\sin"]),
+        ("sqrt", vec!["Psl\\Math\\sqrt"]),
+        ("tan", vec!["Psl\\Math\\tan"]),
+    ])
+});

--- a/crates/linter/src/plugin/psl/rules/mod.rs
+++ b/crates/linter/src/plugin/psl/rules/mod.rs
@@ -1,0 +1,11 @@
+mod utils;
+
+pub mod array_functions;
+pub mod data_structures;
+pub mod datetime;
+pub mod math_functions;
+pub mod output;
+pub mod randomness_functions;
+pub mod regex_functions;
+pub mod sleep_functions;
+pub mod string_functions;

--- a/crates/linter/src/plugin/psl/rules/output.rs
+++ b/crates/linter/src/plugin/psl/rules/output.rs
@@ -1,0 +1,121 @@
+use indoc::indoc;
+
+use mago_ast::*;
+use mago_reporting::*;
+use mago_span::HasSpan;
+
+use crate::context::LintContext;
+use crate::definition::RuleDefinition;
+use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
+use crate::plugin::psl::rules::utils::format_replacements;
+use crate::rule::Rule;
+
+#[derive(Clone, Debug)]
+pub struct OutputRule;
+
+impl Rule for OutputRule {
+    fn get_definition(&self) -> RuleDefinition {
+        RuleDefinition::enabled("Output", Level::Error)
+            .with_description(indoc! {"
+                This rule enforces the usage of Psl output functions over their PHP counterparts.
+
+                Psl output functions are preferred because they are type-safe and provide more consistent behavior.
+            "})
+            .with_example(RuleUsageExample::valid(
+                "Using `Psl\\IO\\write_line` instead of `echo`.",
+                indoc! {r#"
+                    <?php
+
+                    Psl\IO\write_line("Hello, world!");
+                "#},
+            ))
+            .with_example(RuleUsageExample::valid(
+                "Using `Psl\\IO\\write_error_line` instead of `fwrite(STDERR, ...)`.",
+                indoc! {r#"
+                    <?php
+
+                    Psl\IO\write_error_line("Error message.");
+                "#},
+            ))
+            .with_example(RuleUsageExample::invalid(
+                "Using `echo`.",
+                indoc! {r#"
+                    <?php
+
+                    echo "Hello, world!";
+                "#},
+            ))
+            .with_example(RuleUsageExample::invalid(
+                "Using `fwrite(STDERR, ...)`.",
+                indoc! {r#"
+                    <?php
+
+                    fwrite(STDERR, "Hello, world!");
+                "#},
+            ))
+    }
+
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let (used_directive, is_stdout) = match node {
+            Node::Echo(_) => ("echo", true),
+            Node::PrintConstruct(_) => ("print", true),
+            Node::FunctionCall(function_call) => {
+                let Expression::Identifier(identifier) = function_call.function.as_ref() else {
+                    return LintDirective::default();
+                };
+
+                let function_name = context.resolve_function_name(identifier);
+
+                match true {
+                    _ if function_name.eq_ignore_ascii_case("printf") => ("printf", true),
+                    _ if function_name.eq_ignore_ascii_case("fwrite") => {
+                        let Some(argument) = function_call.argument_list.arguments.get(0) else {
+                            return LintDirective::default();
+                        };
+
+                        let Expression::ConstantAccess(constant) = argument.value() else {
+                            return LintDirective::default();
+                        };
+
+                        let name = context.resolve_constant_name(&constant.name);
+
+                        match true {
+                            _ if name.eq_ignore_ascii_case("STDOUT") => ("fwrite", true),
+                            _ if name.eq_ignore_ascii_case("STDERR") => ("fwrite", false),
+                            _ => return LintDirective::default(),
+                        }
+                    }
+                    _ => {
+                        return LintDirective::default();
+                    }
+                }
+            }
+            _ => return LintDirective::default(),
+        };
+
+        let replacements = if is_stdout { &STDOUT_FUNCTIONS } else { &STDERR_FUNCTIONS };
+
+        context.report(
+            Issue::new(
+                context.level(),
+                "Use the Psl output function instead of the PHP counterpart.",
+            )
+            .with_annotation(
+                Annotation::primary(node.span()).with_message(format!("Using PHP's `{used_directive}`.")),
+            )
+            .with_note(
+                "Psl output functions are preferred because they are type-safe and provide more consistent behavior.",
+            )
+            .with_help(format!(
+                "Use `{}` instead.",
+                format_replacements(replacements)
+            )),
+        );
+
+        LintDirective::default()
+    }
+}
+
+const STDOUT_FUNCTIONS: [&str; 2] = ["Psl\\IO\\write", "Psl\\IO\\write_line"];
+const STDERR_FUNCTIONS: [&str; 2] = ["Psl\\IO\\write_error", "Psl\\IO\\write_error_line"];

--- a/crates/linter/src/plugin/psl/rules/randomness_functions.rs
+++ b/crates/linter/src/plugin/psl/rules/randomness_functions.rs
@@ -1,0 +1,103 @@
+use std::sync::LazyLock;
+
+use ahash::HashMap;
+use indoc::indoc;
+
+use mago_ast::*;
+use mago_reporting::*;
+use mago_span::HasSpan;
+
+use crate::context::LintContext;
+use crate::definition::RuleDefinition;
+use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
+use crate::plugin::psl::rules::utils::format_replacements;
+use crate::rule::Rule;
+
+#[derive(Clone, Debug)]
+pub struct RandomnessFunctionsRule;
+
+impl Rule for RandomnessFunctionsRule {
+    fn get_definition(&self) -> RuleDefinition {
+        RuleDefinition::enabled("Randomness Functions", Level::Warning)
+            .with_description(indoc! {"
+                This rule enforces the usage of Psl randomness functions over their PHP counterparts.
+
+                Psl randomness functions are preferred because they are type-safe and provide more consistent behavior.
+            "})
+            .with_example(RuleUsageExample::valid(
+                "Using `Psl\\SecureRandom\\int` instead of `random_int`.",
+                indoc! {r#"
+                    <?php
+
+                    $randomInt = Psl\SecureRandom\int(0, 10);
+                "#},
+            ))
+            .with_example(RuleUsageExample::valid(
+                "Using `Psl\\PseudoRandom\\int` instead of `rand`.",
+                indoc! {r#"
+                    <?php
+
+                    $randomInt = Psl\PseudoRandom\int(0, 10);
+                "#},
+            ))
+            .with_example(RuleUsageExample::invalid(
+                "Using `random_int`.",
+                indoc! {r#"
+                    <?php
+
+                    $randomInt = random_int(0, 10);
+                "#},
+            ))
+            .with_example(RuleUsageExample::invalid(
+                "Using `rand`.",
+                indoc! {r#"
+                    <?php
+
+                    $randomInt = rand(0, 10);
+                "#},
+            ))
+    }
+
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let Node::FunctionCall(function_call) = node else { return LintDirective::default() };
+        let Expression::Identifier(identifier) = function_call.function.as_ref() else {
+            return LintDirective::default();
+        };
+
+        let function_name = context.resolve_function_name(identifier).to_lowercase();
+
+        let replacements = match RANDOM_FUNCTION_REPLACEMENTS.get(function_name.as_str()) {
+            Some(replacements) => replacements,
+            None => return LintDirective::default(),
+        };
+
+        context.report(
+            Issue::new(
+                context.level(),
+                "Use the Psl randomness function instead of the PHP counterpart.",
+            )
+            .with_annotation(
+                Annotation::primary(identifier.span()).with_message("This is a PHP randomness function."),
+            )
+            .with_note(
+                "Psl randomness functions are preferred because they are type-safe and provide more consistent behavior.",
+            )
+            .with_help(format!(
+                "Use `{}` instead.",
+                format_replacements(replacements),
+            )),
+        );
+
+        LintDirective::default()
+    }
+}
+
+static RANDOM_FUNCTION_REPLACEMENTS: LazyLock<HashMap<&'static str, Vec<&'static str>>> = LazyLock::new(|| {
+    HashMap::from_iter([
+        ("rand", vec!["Psl\\PseudoRandom\\int", "Psl\\PseudoRandom\\float"]),
+        ("mt_rand", vec!["Psl\\PseudoRandom\\int", "Psl\\PseudoRandom\\float"]),
+        ("random_int", vec!["Psl\\SecureRandom\\int", "Psl\\SecureRandom\\float"]),
+        ("random_bytes", vec!["Psl\\SecureRandom\\bytes", "Psl\\SecureRandom\\string"]),
+    ])
+});

--- a/crates/linter/src/plugin/psl/rules/regex_functions.rs
+++ b/crates/linter/src/plugin/psl/rules/regex_functions.rs
@@ -1,0 +1,108 @@
+use std::sync::LazyLock;
+
+use ahash::HashMap;
+use indoc::indoc;
+
+use mago_ast::*;
+use mago_reporting::*;
+use mago_span::HasSpan;
+
+use crate::context::LintContext;
+use crate::definition::RuleDefinition;
+use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
+use crate::plugin::psl::rules::utils::format_replacements;
+use crate::rule::Rule;
+
+#[derive(Clone, Debug)]
+pub struct RegexFunctionsRule;
+
+impl Rule for RegexFunctionsRule {
+    fn get_definition(&self) -> RuleDefinition {
+        RuleDefinition::enabled("Regex Functions", Level::Warning)
+            .with_description(indoc! {"
+                This rule enforces the usage of Psl regex functions over their PHP counterparts.
+
+                Psl regex functions are preferred because they are type-safe and provide more consistent behavior.
+            "})
+            .with_example(RuleUsageExample::valid(
+                "Using `Psl\\Regex\\matches` instead of `preg_match`.",
+                indoc! {r#"
+                    <?php
+
+                    $result = Psl\Regex\matches('Hello, World!', '/\w+/');
+                "#},
+            ))
+            .with_example(RuleUsageExample::valid(
+                "Using `Psl\\Regex\\replace` instead of `preg_replace`.",
+                indoc! {r#"
+                    <?php
+
+                    $result = Psl\Regex\replace('Hello, World!', '/\w+/', 'Goodbye');
+                "#},
+            ))
+            .with_example(RuleUsageExample::invalid(
+                "Using `preg_match`.",
+                indoc! {r#"
+                    <?php
+
+                    $result = preg_match('/\w+/', 'Hello, World!');
+                "#},
+            ))
+            .with_example(RuleUsageExample::invalid(
+                "Using `preg_replace`.",
+                indoc! {r#"
+                    <?php
+
+                    $result = preg_replace('/\w+/', 'Goodbye', 'Hello, World!');
+                "#},
+            ))
+    }
+
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let Node::FunctionCall(function_call) = node else { return LintDirective::default() };
+        let Expression::Identifier(identifier) = function_call.function.as_ref() else {
+            return LintDirective::default();
+        };
+
+        let function_name = context.resolve_function_name(identifier).to_lowercase();
+
+        let replacements = match REGEX_FUNCTION_REPLACEMENTS.get(function_name.as_str()) {
+            Some(replacements) => replacements,
+            None => return LintDirective::default(),
+        };
+
+        context.report(
+            Issue::new(
+                context.level(),
+                "Use the Psl regex function instead of the PHP counterpart.",
+            )
+            .with_annotation(
+                Annotation::primary(identifier.span()).with_message("This is a PHP regex function."),
+            )
+            .with_note(
+                "Psl regex functions are preferred because they are type-safe and provide more consistent behavior.",
+            )
+            .with_help(format!(
+                "Use `{}` instead.",
+                format_replacements(replacements)
+            )),
+        );
+
+        LintDirective::default()
+    }
+}
+
+static REGEX_FUNCTION_REPLACEMENTS: LazyLock<HashMap<&'static str, Vec<&'static str>>> = LazyLock::new(|| {
+    HashMap::from_iter([
+        ("preg_match", vec!["Psl\\Regex\\matches"]),
+        ("preg_match_all", vec!["Psl\\Regex\\matches"]),
+        ("preg_replace", vec!["Psl\\Regex\\replace"]),
+        ("preg_replace_callback", vec!["Psl\\Regex\\replace_with"]),
+        ("preg_replace_callback_array", vec!["Psl\\Regex\\replace_with"]),
+        ("preg_split", vec!["Psl\\Regex\\split"]),
+        ("preg_grep", vec!["Psl\\Regex\\every_match"]),
+        ("preg_filter", vec!["Psl\\Regex\\every_match"]),
+        ("preg_quote", vec!["Psl\\Regex\\quote"]),
+    ])
+});

--- a/crates/linter/src/plugin/psl/rules/sleep_functions.rs
+++ b/crates/linter/src/plugin/psl/rules/sleep_functions.rs
@@ -1,0 +1,102 @@
+use std::sync::LazyLock;
+
+use ahash::HashMap;
+use indoc::indoc;
+
+use mago_ast::*;
+use mago_reporting::*;
+use mago_span::HasSpan;
+
+use crate::context::LintContext;
+use crate::definition::RuleDefinition;
+use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
+use crate::plugin::psl::rules::utils::format_replacements;
+use crate::rule::Rule;
+
+#[derive(Clone, Debug)]
+pub struct SleepFunctionsRule;
+
+impl Rule for SleepFunctionsRule {
+    fn get_definition(&self) -> RuleDefinition {
+        RuleDefinition::enabled("Sleep Functions", Level::Warning)
+            .with_description(indoc! {"
+                This rule enforces the usage of Psl sleep functions over their PHP counterparts.
+
+                Psl sleep functions are preferred because they are type-safe, provide more consistent behavior,
+                and allow other tasks within the event loop to continue executing while the current Fiber pauses.
+            "})
+            .with_example(RuleUsageExample::valid(
+                "Using `Psl\\Async\\sleep` instead of `sleep`.",
+                indoc! {r#"
+                    <?php
+
+                    use Psl\Async;
+                    use Psl\DateTime;
+
+                    Async\sleep(DateTime\Duration::seconds(1));
+                "#},
+            ))
+            .with_example(RuleUsageExample::valid(
+                "Using `Psl\\Async\\sleep` instead of `usleep`.",
+                indoc! {r#"
+                    <?php
+
+                    use Psl\Async;
+                    use Psl\DateTime;
+
+                    Async\sleep(DateTime\Duration::milliseconds(1500));
+                "#},
+            ))
+            .with_example(RuleUsageExample::invalid(
+                "Using `sleep`.",
+                indoc! {r#"
+                    <?php
+
+                    sleep(1);
+                "#},
+            ))
+            .with_example(RuleUsageExample::invalid(
+                "Using `usleep`.",
+                indoc! {r#"
+                    <?php
+
+                    usleep(1500);
+                "#},
+            ))
+    }
+
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let Node::FunctionCall(function_call) = node else { return LintDirective::default() };
+        let Expression::Identifier(identifier) = function_call.function.as_ref() else {
+            return LintDirective::default();
+        };
+
+        let function_name = context.resolve_function_name(identifier).to_lowercase();
+
+        let Some(replacements) = (*SLEEP_FUNCTION_REPLACEMENTS).get(function_name.as_str()) else {
+            return LintDirective::default();
+        };
+
+        context.report(
+            Issue::new(
+                context.level(),
+                "Use the Psl sleep function instead of the PHP counterpart.",
+            )
+            .with_annotation(Annotation::primary(identifier.span()).with_message("This is a PHP sleep function."))
+            .with_note("Psl sleep functions are preferred because they are type-safe, provide more consistent behavior, and allow other tasks within the event loop to continue executing while the current Fiber pauses.")
+            .with_help(format!("Use `{}` instead.", format_replacements(replacements))),
+        );
+
+        LintDirective::default()
+    }
+}
+
+static SLEEP_FUNCTION_REPLACEMENTS: LazyLock<HashMap<&'static str, Vec<&'static str>>> = LazyLock::new(|| {
+    HashMap::from_iter([
+        ("sleep", vec!["Psl\\Async\\sleep"]),
+        ("usleep", vec!["Psl\\Async\\sleep"]),
+        ("time_sleep_until", vec!["Psl\\Async\\sleep"]),
+        ("time_nanosleep", vec!["Psl\\Async\\sleep"]),
+    ])
+});

--- a/crates/linter/src/plugin/psl/rules/string_functions.rs
+++ b/crates/linter/src/plugin/psl/rules/string_functions.rs
@@ -1,0 +1,201 @@
+use std::sync::LazyLock;
+
+use ahash::HashMap;
+use indoc::indoc;
+
+use mago_ast::*;
+use mago_reporting::*;
+use mago_span::HasSpan;
+
+use crate::context::LintContext;
+use crate::definition::RuleDefinition;
+use crate::definition::RuleUsageExample;
+use crate::directive::LintDirective;
+use crate::plugin::psl::rules::utils::format_replacements;
+use crate::rule::Rule;
+
+#[derive(Clone, Debug)]
+pub struct StringFunctionsRule;
+
+impl Rule for StringFunctionsRule {
+    fn get_definition(&self) -> RuleDefinition {
+        RuleDefinition::enabled("String Functions", Level::Warning)
+            .with_description(indoc! {"
+                This rule enforces the usage of Psl string functions over their PHP counterparts.
+
+                Psl string functions are preferred because they are type-safe and provide more consistent behavior.
+            "})
+            .with_example(RuleUsageExample::valid(
+                "Using `Psl\\Str\\capitalize` instead of `ucfirst`.",
+                indoc! {r#"
+                    <?php
+
+                    $capitalized = Psl\Str\capitalize($string);
+                "#},
+            ))
+            .with_example(RuleUsageExample::valid(
+                "Using `Psl\\Str\\length` instead of `strlen`.",
+                indoc! {r#"
+                    <?php
+
+                    $length = Psl\Str\length($string);
+                "#},
+            ))
+            .with_example(RuleUsageExample::invalid(
+                "Using `ucfirst`.",
+                indoc! {r#"
+                    <?php
+
+                    $capitalized = ucfirst($string);
+                "#},
+            ))
+            .with_example(RuleUsageExample::invalid(
+                "Using `strlen`.",
+                indoc! {r#"
+                    <?php
+
+                    $length = strlen($string);
+                "#},
+            ))
+    }
+
+    fn lint_node(&self, node: Node<'_>, context: &mut LintContext<'_>) -> LintDirective {
+        let Node::FunctionCall(function_call) = node else { return LintDirective::default() };
+        let Expression::Identifier(identifier) = function_call.function.as_ref() else {
+            return LintDirective::default();
+        };
+
+        let function_name = context.resolve_function_name(identifier).to_lowercase();
+
+        let Some(replacements) = (*STRING_FUNCTION_REPLACEMENTS).get(function_name.as_str()) else {
+            return LintDirective::default();
+        };
+
+        context.report(
+            Issue::new(
+                context.level(),
+                "Use the Psl string function instead of the PHP counterpart.",
+            )
+            .with_annotation(Annotation::primary(identifier.span()).with_message("This is a PHP string function."))
+            .with_note(
+                "Psl string functions are preferred because they are type-safe and provide more consistent behavior.",
+            )
+            .with_help(format!("Use {} instead.", format_replacements(replacements))),
+        );
+
+        LintDirective::default()
+    }
+}
+
+static STRING_FUNCTION_REPLACEMENTS: LazyLock<HashMap<&'static str, Vec<&'static str>>> = LazyLock::new(|| {
+    HashMap::from_iter([
+        ("ucfirst", vec!["Psl\\Str\\Byte\\capitalize", "Psl\\Str\\capitalize"]),
+        ("ucwords", vec!["Psl\\Str\\Byte\\capitalize_words"]),
+        ("chr", vec!["Psl\\Str\\Byte\\chr"]),
+        ("strncmp", vec!["Psl\\Str\\Byte\\compare"]),
+        ("strcmp", vec!["Psl\\Str\\Byte\\compare"]),
+        ("strncasecmp", vec!["Psl\\Str\\Byte\\compare_ci"]),
+        ("strcasecmp", vec!["Psl\\Str\\Byte\\compare_ci"]),
+        (
+            "str_contains",
+            vec![
+                "Psl\\Str\\contains",
+                "Psl\\Str\\contains_ci",
+                "Psl\\Str\\Byte\\contains",
+                "Psl\\Str\\Byte\\contains_ci",
+            ],
+        ),
+        (
+            "str_starts_with",
+            vec![
+                "Psl\\Str\\starts_with",
+                "Psl\\Str\\starts_with_ci",
+                "Psl\\Str\\Byte\\starts_with",
+                "Psl\\Str\\Byte\\starts_with_ci",
+            ],
+        ),
+        (
+            "str_ends_with",
+            vec![
+                "Psl\\Str\\ends_with",
+                "Psl\\Str\\ends_with_ci",
+                "Psl\\Str\\Byte\\ends_with",
+                "Psl\\Str\\Byte\\ends_with_ci",
+            ],
+        ),
+        ("strlen", vec!["Psl\\Str\\Byte\\length"]),
+        ("strtolower", vec!["Psl\\Str\\Byte\\lowercase"]),
+        ("str_ord", vec!["Psl\\Str\\Byte\\ord"]),
+        (
+            "str_pad",
+            vec!["Psl\\Str\\pad_right", "Psl\\Str\\pad_left", "Psl\\Str\\Byte\\pad_right", "Psl\\Str\\Byte\\pad_left"],
+        ),
+        ("str_replace", vec!["Psl\\Str\\replace", "Psl\\Str\\Byte\\replace", "Psl\\Str\\Byte\\replace_every"]),
+        (
+            "str_ireplace",
+            vec!["Psl\\Str\\replace_ci", "Psl\\Str\\Byte\\replace_ci", "Psl\\Str\\Byte\\replace_every_ci"],
+        ),
+        ("strrev", vec!["Psl\\Str\\Byte\\reverse"]),
+        ("str_rot13", vec!["Psl\\Str\\Byte\\rot13"]),
+        ("strpos", vec!["Psl\\Str\\Byte\\search"]),
+        ("stripos", vec!["Psl\\Str\\Byte\\search_ci"]),
+        ("strrpos", vec!["Psl\\Str\\Byte\\search_last"]),
+        ("strripos", vec!["Psl\\Str\\Byte\\search_last_ci"]),
+        ("str_shuffle", vec!["Psl\\Str\\Byte\\shuffle"]),
+        (
+            "substr",
+            vec![
+                "Psl\\Str\\Byte\\slice",
+                "Psl\\Str\\Byte\\range",
+                "Psl\\Str\\Byte\\strip_prefix",
+                "Psl\\Str\\Byte\\strip_suffix",
+            ],
+        ),
+        ("substr_replace", vec!["Psl\\Str\\Byte\\splice"]),
+        ("explode", vec!["Psl\\Str\\Byte\\split"]),
+        ("str_split", vec!["Psl\\Str\\Byte\\chunk", "Psl\\Str\\Byte\\split"]),
+        ("trim", vec!["Psl\\Str\\trim", "Psl\\Str\\Byte\\trim"]),
+        ("ltrim", vec!["Psl\\Str\\trim_left", "Psl\\Str\\Byte\\trim_left"]),
+        ("rtrim", vec!["Psl\\Str\\trim_right", "Psl\\Str\\Byte\\trim_right"]),
+        ("strtoupper", vec!["Psl\\Str\\Byte\\uppercase"]),
+        ("wordwrap", vec!["Psl\\Str\\Byte\\wrap", "Psl\\Str\\wrap"]),
+        ("str_word_count", vec!["Psl\\Str\\Byte\\words"]),
+        ("mb_strwidth", vec!["Psl\\Str\\width"]),
+        ("mb_strtoupper", vec!["Psl\\Str\\uppercase"]),
+        ("mb_strtolower", vec!["Psl\\Str\\lowercase"]),
+        ("mb_convert_case", vec!["Psl\\Str\\uppercase", "Psl\\Str\\lowercase", "Psl\\Str\\capitalize_words"]),
+        ("mb_chr", vec!["Psl\\Str\\chr"]),
+        ("mb_str_split", vec!["Psl\\Str\\split"]),
+        ("mb_convert_encoding", vec!["Psl\\Str\\convert_encoding"]),
+        ("mb_detect_encoding", vec!["Psl\\Str\\detect_encoding", "Psl\\Str\\is_utf8"]),
+        ("sprintf", vec!["Psl\\Str\\format"]),
+        ("vsprintf", vec!["Psl\\Str\\format"]),
+        ("number_format", vec!["Psl\\Str\\format_number"]),
+        ("implode", vec!["Psl\\Str\\join"]),
+        ("join", vec!["Psl\\Str\\join"]),
+        ("mb_strlen", vec!["Psl\\Str\\length"]),
+        ("levenshtein", vec!["Psl\\Str\\levenshtein"]),
+        ("mb_strtolower", vec!["Psl\\Str\\lowercase"]),
+        ("metaphone", vec!["Psl\\Str\\metaphone"]),
+        ("mb_ord", vec!["Psl\\Str\\ord"]),
+        ("mb_ord", vec!["Psl\\Str\\ord"]),
+        ("str_repeat", vec!["Psl\\Str\\repeat"]),
+        ("str_repeat", vec!["Psl\\Str\\repeat"]),
+        ("mb_substr", vec!["Psl\\Str\\slice", "Psl\\Str\\range", "Psl\\Str\\strip_prefix", "Psl\\Str\\strip_suffix"]),
+        ("mb_strimwidth", vec!["Psl\\Str\\truncate"]),
+        (
+            "grapheme_substr",
+            vec![
+                "Psl\\Str\\Grapheme\\slice",
+                "Psl\\Str\\Grapheme\\range",
+                "Psl\\Str\\Grapheme\\strip_prefix",
+                "Psl\\Str\\Grapheme\\strip_suffix",
+            ],
+        ),
+        ("grapheme_strripos", vec!["Psl\\Str\\Grapheme\\search_last_ci"]),
+        ("grapheme_strrpos", vec!["Psl\\Str\\Grapheme\\search_last"]),
+        ("grapheme_stripos", vec!["Psl\\Str\\Grapheme\\search_ci"]),
+        ("grapheme_strpos", vec!["Psl\\Str\\Grapheme\\search"]),
+        ("grapheme_strlen", vec!["Psl\\Str\\Grapheme\\length"]),
+    ])
+});

--- a/crates/linter/src/plugin/psl/rules/utils.rs
+++ b/crates/linter/src/plugin/psl/rules/utils.rs
@@ -1,0 +1,26 @@
+#[inline]
+pub fn format_replacements(replacements: &'static [&'static str]) -> String {
+    let count = replacements.len();
+    if count == 0 {
+        return String::new();
+    }
+
+    if count == 1 {
+        return format!("`{}`", replacements[0]);
+    }
+
+    let mut result = String::new();
+    for (i, replacement) in replacements.iter().enumerate() {
+        if i == count - 1 {
+            result.push_str("or ");
+        } else if i > 0 {
+            result.push_str(", ");
+        }
+
+        result.push('`');
+        result.push_str(replacement);
+        result.push('`');
+    }
+
+    result
+}

--- a/crates/linter/tests/plugins/mod.rs
+++ b/crates/linter/tests/plugins/mod.rs
@@ -8,6 +8,7 @@ pub mod maintainability;
 pub mod migration;
 pub mod naming;
 pub mod phpunit;
+pub mod psl;
 pub mod redundancy;
 pub mod safety;
 pub mod security;

--- a/crates/linter/tests/plugins/psl.rs
+++ b/crates/linter/tests/plugins/psl.rs
@@ -1,0 +1,21 @@
+use mago_linter::plugin::psl::rules::array_functions::ArrayFunctionsRule;
+use mago_linter::plugin::psl::rules::data_structures::DataStructuresRule;
+use mago_linter::plugin::psl::rules::datetime::DateTimeRule;
+use mago_linter::plugin::psl::rules::math_functions::MathFunctionsRule;
+use mago_linter::plugin::psl::rules::output::OutputRule;
+use mago_linter::plugin::psl::rules::randomness_functions::RandomnessFunctionsRule;
+use mago_linter::plugin::psl::rules::regex_functions::RegexFunctionsRule;
+use mago_linter::plugin::psl::rules::sleep_functions::SleepFunctionsRule;
+use mago_linter::plugin::psl::rules::string_functions::StringFunctionsRule;
+
+use crate::rule_test;
+
+rule_test!(test_array_functions, ArrayFunctionsRule);
+rule_test!(test_data_structures, DataStructuresRule);
+rule_test!(test_datetime, DateTimeRule);
+rule_test!(test_math_functions, MathFunctionsRule);
+rule_test!(test_output, OutputRule);
+rule_test!(test_randomness_functions, RandomnessFunctionsRule);
+rule_test!(test_regex_functions, RegexFunctionsRule);
+rule_test!(test_sleep_functions, SleepFunctionsRule);
+rule_test!(test_string_functions, StringFunctionsRule);

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -41,6 +41,7 @@ default_plugins = true
 plugins = [{plugins}]
 "#;
 
+const PSL_PLUGIN: &str = "psl";
 const SYMFONY_PLUGIN: &str = "symfony";
 const LARAVEL_PLUGIN: &str = "laravel";
 const PHPUNIT_PLUGIN: &str = "php-unit";
@@ -221,6 +222,14 @@ fn extract_paths_from_composer(composer: &ComposerPackage) -> Vec<String> {
 /// A vector of plugin names to enable
 fn detect_plugins_from_composer(composer: &ComposerPackage) -> Vec<String> {
     let mut plugins = vec![];
+
+    // Detect PSL
+    if has_exact_package(composer, "azjezz/psl")
+        || has_exact_package(composer, "php-standard-library/psalm-plugin")
+        || has_exact_package(composer, "php-standard-library/phpstan-extension")
+    {
+        plugins.push(PSL_PLUGIN.to_string());
+    }
 
     // Detect Symfony framework
     if has_package_prefix(composer, "symfony/") || has_package_prefix(composer, "symfony-") {


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR introduces a new linter plugin for the PHP Standard Library (Psl) and enhances the `mago init` command to automatically detect and enable the plugin when initializing a project with a `composer.json` file that utilizes Psl.

## 🔍 Context & Motivation

The new Psl plugin provides rules that encourage the use of Psl functions over their built-in PHP counterparts. This promotes better code style, type safety, and consistency when using Psl in a project.

Enhancing the `mago init` command to automatically detect and enable the Psl plugin when appropriate improves the developer experience by streamlining the configuration process and encouraging the adoption of best practices for Psl usage.

## 🛠️ Summary of Changes

- **Feature:** Added a new linter plugin for the PHP Standard Library (Psl).
- **Feature:** Updated the `mago init` command to detect Psl usage in `composer.json` and enable the Psl plugin automatically.

## 📂 Affected Areas

- [x] Linter
- [ ] Formatter
- [x] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Closes #109

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
