### PR TITLE
feat(formatter): always break property hooks into multiple lines

### DIFF
--- a/crates/formatter/tests/cases/hooks_always_break/after.php
+++ b/crates/formatter/tests/cases/hooks_always_break/after.php
@@ -1,0 +1,45 @@
+<?php
+
+final readonly class DatabaseConfig
+{
+    public string $dsn {
+        get => sprintf('mysql:host=%s:%s;dbname=%s', $this->host, $this->port, $this->database);
+    }
+
+    public DatabaseDialect $dialect {
+        get => DatabaseDialect::MYSQL;
+    }
+
+    public DatabaseDialect $dialect { // foo
+        get => DatabaseDialect::MYSQL;
+        // bar
+    } // baz
+
+    public DatabaseDialect $dialect { // foo
+        get {
+            $a = 1;
+            $b = 2;
+
+            return DatabaseDialect::MYSQL;
+        }
+        set($value) {
+            $this->dialect = $value;
+        }
+        // bar
+    } // baz
+
+    public DatabaseDialect $dialect {
+        get {
+            return DatabaseDialect::MYSQL;
+        }
+        set($value) {
+            $this->dialect = $value;
+        }
+    }
+
+    public DatabaseDialect $dialect {}
+
+    public DatabaseDialect $dialect { // foo
+        // bar
+    } // baz
+}

--- a/crates/formatter/tests/cases/hooks_always_break/before.php
+++ b/crates/formatter/tests/cases/hooks_always_break/before.php
@@ -1,0 +1,56 @@
+<?php
+
+final readonly class DatabaseConfig
+{
+    public string $dsn {
+        get => sprintf(
+            'mysql:host=%s:%s;dbname=%s',
+            $this->host,
+            $this->port,
+            $this->database,
+        );
+    }
+    
+public DatabaseDialect $dialect {
+   get => DatabaseDialect::MYSQL;
+}
+
+
+
+public DatabaseDialect $dialect { // foo
+get => DatabaseDialect::MYSQL;
+
+// bar
+} // baz
+
+public DatabaseDialect $dialect { // foo
+    get  {
+        $a = 1;
+        $b = 2;
+        
+        return DatabaseDialect::MYSQL;
+    }
+    set($value)  {
+        $this->dialect = $value;
+    }
+// bar
+} // baz
+
+public DatabaseDialect $dialect {
+    get  {
+        return DatabaseDialect::MYSQL;
+    }
+    set($value)  {
+        $this->dialect = $value;
+    }
+}
+
+public DatabaseDialect $dialect {
+
+}
+
+public DatabaseDialect $dialect { // foo
+    // bar
+    } // baz
+
+}

--- a/crates/formatter/tests/cases/hooks_always_break/settings.inc
+++ b/crates/formatter/tests/cases/hooks_always_break/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings::default()

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -122,6 +122,7 @@ test_case!(preserve_breaking_parameter_list);
 test_case!(preserve_breaking_parameter_list_disabled);
 test_case!(preserve_breaking_attribute_list);
 test_case!(preserve_breaking_attribute_list_disabled);
+test_case!(hooks_always_break);
 
 // GitHub issue test cases
 test_case!(issue_122);


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR modifies the formatter to always break property hooks (getters and setters) into multiple lines, regardless of the `print_width` setting.

## 🔍 Context & Motivation

Previously, property hooks were only broken into multiple lines if they didn't fit within the `print_width`. This could lead to unexpected single-line property hooks when users had a very large `print_width` value, compromising readability. This change ensures consistent formatting and improves readability for all users.

## 🛠️ Summary of Changes

- **Feature:** Changed the formatter to always break property hooks into multiple lines.
- **Exception:** Property hook lists with no hooks ({}) remain on a single line.
- **Tests:** Updated test snapshots to reflect the new formatting.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Closes #124 

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
