### PR TITLE
fix(formatter): correct argument printing and member access chain logic

### DIFF
--- a/crates/formatter/tests/cases/issue_128/after.php
+++ b/crates/formatter/tests/cases/issue_128/after.php
@@ -1,0 +1,15 @@
+<?php
+
+$permission = Permission::query()->whereField('name', $name)->first();
+
+$this->renderer = new ChoiceRenderer(multiple: $multiple, default: (string) $default);
+
+$this->writeln(implode(PHP_EOL, $complete->complete(
+    $command,
+    $argumentBag,
+    $current,
+)));
+
+return new ImmutableString($string)
+    ->truncate(($this->maxLineCharacters - 1) - $maxLineOffset, end: '…') // -1 is for the ellipsis
+    ->toString();

--- a/crates/formatter/tests/cases/issue_128/before.php
+++ b/crates/formatter/tests/cases/issue_128/before.php
@@ -1,0 +1,15 @@
+<?php
+
+$permission = Permission::query()->whereField('name', $name)->first();
+
+$this->renderer = new ChoiceRenderer(multiple: $multiple, default: (string) $default);
+
+$this->writeln(implode(PHP_EOL, $complete->complete(
+    $command,
+    $argumentBag,
+    $current,
+)));
+
+return new ImmutableString($string)
+    ->truncate($this->maxLineCharacters - 1 - $maxLineOffset, end: '…') // -1 is for the ellipsis
+    ->toString();

--- a/crates/formatter/tests/cases/issue_128/settings.inc
+++ b/crates/formatter/tests/cases/issue_128/settings.inc
@@ -1,0 +1,6 @@
+FormatSettings {
+    preserve_breaking_argument_list: true,
+    preserve_breaking_member_access_chain: true,
+    always_break_named_arguments_list: false,
+    ..Default::default()
+}

--- a/crates/formatter/tests/cases/issue_130/after.php
+++ b/crates/formatter/tests/cases/issue_130/after.php
@@ -1,0 +1,15 @@
+<?php
+
+function getControls(): array
+{
+    return [
+        ...(
+            $this->bufferEnabled
+                ? ['esc' => 'select']
+                : ['/' => 'filter', 'space' => 'select']
+        ),
+        '↑' => 'up',
+        '↓' => 'down',
+        'ctrl+c' => 'cancel',
+    ];
+}

--- a/crates/formatter/tests/cases/issue_130/before.php
+++ b/crates/formatter/tests/cases/issue_130/before.php
@@ -1,0 +1,11 @@
+<?php
+
+function getControls(): array
+{
+    return [
+        ...($this->bufferEnabled ? ['esc' => 'select'] : ['/' => 'filter', 'space' => 'select']),
+        '↑' => 'up',
+        '↓' => 'down',
+        'ctrl+c' => 'cancel',
+    ];
+}

--- a/crates/formatter/tests/cases/issue_130/settings.inc
+++ b/crates/formatter/tests/cases/issue_130/settings.inc
@@ -1,0 +1,4 @@
+FormatSettings {
+    print_width: 60, // we want the conditional expression to break into multiple lines
+    ..Default::default()
+}

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -127,3 +127,5 @@ test_case!(hooks_always_break);
 // GitHub issue test cases
 test_case!(issue_122);
 test_case!(issue_123);
+test_case!(issue_128);
+test_case!(issue_130);


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR addresses and fixes multiple bugs in the formatter related to argument lists, indentation, and member access chain breaking, as reported in issue #128.

## 🔍 Context & Motivation

The bugs fixed in this PR were causing incorrect formatting in specific scenarios involving argument lists, indentation within nested structures, and member access chain line breaking. These issues were reported by a user and negatively impacted the formatter's reliability and usability.

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed multiple bugs in the formatter related to argument lists printing, indentation, and member access chain breaking.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Closes #128 

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
