### PR TITLE
feat(formatter): add `preserve_breaking_conditional_expression` option

### DIFF
--- a/crates/formatter/src/internal/format/array.rs
+++ b/crates/formatter/src/internal/format/array.rs
@@ -395,6 +395,9 @@ fn is_table_style<'a>(f: &mut FormatterState<'a>, array_like: &ArrayLike<'a>) ->
                 | Expression::LegacyArray(LegacyArray { elements, .. }) = element.value.as_ref()
                 {
                     let size = elements.len();
+                    if 0 == size {
+                        return false; // Empty row
+                    }
 
                     // Check if row size is consistent
                     row_size = row_size.max(size);
@@ -438,19 +441,11 @@ fn is_table_style<'a>(f: &mut FormatterState<'a>, array_like: &ArrayLike<'a>) ->
 
     // Check if row size is within reasonable bounds (3-10 columns)
     if !(3..=12).contains(&row_size) {
-        println!("Row size: {}", row_size);
-
         return false;
     }
 
     // At least 60% of the rows should have the same size
-    let is = (sizes.iter().filter(|size| **size == row_size).count() as f64) / (sizes.len() as f64) >= 0.6;
-
-    println!("Row size: {}", row_size);
-    println!("Sizes: {:?}", sizes);
-    println!("Is: {}", is);
-
-    is
+    (sizes.iter().filter(|size| **size == row_size).count() as f64) / (sizes.len() as f64) >= 0.6
 }
 
 fn calculate_column_widths<'a>(f: &mut FormatterState<'a>, array_like: &ArrayLike<'a>) -> Option<Vec<usize>> {

--- a/crates/formatter/src/internal/format/assignment.rs
+++ b/crates/formatter/src/internal/format/assignment.rs
@@ -89,7 +89,10 @@ pub(super) fn print_assignment<'a>(
             Document::Group(Group::new(vec![lhs])),
             Document::space(),
             operator,
-            Document::Group(Group::new(vec![Document::Indent(vec![Document::Line(Line::default()), rhs])])),
+            Document::Group(Group::new(vec![Document::IndentIfBreak(IndentIfBreak::new(vec![
+                Document::Line(Line::default()),
+                rhs,
+            ]))])),
         ])),
         Layout::NeverBreakAfterOperator => Document::Group(Group::new(vec![
             Document::Group(Group::new(vec![lhs])),

--- a/crates/formatter/src/internal/format/member_access.rs
+++ b/crates/formatter/src/internal/format/member_access.rs
@@ -115,6 +115,10 @@ impl MemberAccessChain<'_> {
 
     #[inline]
     fn must_break(&self, f: &FormatterState) -> bool {
+        if self.is_first_link_static_method_call() && self.accesses.len() > 3 {
+            return true;
+        }
+
         let must_break = match self.base {
             Expression::Instantiation(_) => {
                 self.accesses.iter().all(|access| {

--- a/crates/formatter/src/internal/format/misc.rs
+++ b/crates/formatter/src/internal/format/misc.rs
@@ -4,6 +4,7 @@ use mago_span::Span;
 
 use crate::document::Document;
 use crate::document::Group;
+use crate::document::IndentIfBreak;
 use crate::document::Line;
 use crate::document::Separator;
 use crate::internal::FormatterState;
@@ -355,10 +356,10 @@ pub(super) fn adjust_clause<'a>(
 pub(super) fn print_condition<'a>(f: &mut FormatterState<'a>, condition: &'a Expression) -> Document<'a> {
     Document::Group(Group::new(vec![
         Document::String("("),
-        Document::Indent(vec![
+        Document::IndentIfBreak(IndentIfBreak::new(vec![
             Document::Line(if f.settings.control_space_parens { Line::default() } else { Line::soft() }),
             condition.format(f),
-        ]),
+        ])),
         Document::Line(if f.settings.control_space_parens { Line::default() } else { Line::soft() }),
         Document::String(")"),
     ]))

--- a/crates/formatter/src/lib.rs
+++ b/crates/formatter/src/lib.rs
@@ -104,8 +104,6 @@ impl<'a> Formatter<'a> {
     pub fn format(&self, source: &'a Source, program: &'a Program) -> String {
         let document = self.build(source, program);
 
-        // println!("Document: {}", document);
-
         self.print(document, Some(source.size))
     }
 

--- a/crates/formatter/src/settings.rs
+++ b/crates/formatter/src/settings.rs
@@ -716,6 +716,16 @@ pub struct FormatSettings {
     /// Default: `false`
     #[serde(default = "default_false")]
     pub preserve_breaking_attribute_list: bool,
+
+    /// Controls whether to preserve line breaks in conditional ( ternary ) expressions, even if they could fit on a single line.
+    ///
+    /// If enabled, the formatter will not attempt to collapse conditional expressions onto a single line if they
+    /// were originally written with line breaks. This can be useful for preserving the original formatting
+    /// of complex or lengthy conditional expressions.
+    ///
+    /// Default: `false`
+    #[serde(default = "default_false")]
+    pub preserve_breaking_conditional_expression: bool,
 }
 
 impl Default for FormatSettings {
@@ -763,6 +773,7 @@ impl Default for FormatSettings {
             preserve_breaking_array_like: true,
             preserve_breaking_parameter_list: false,
             preserve_breaking_attribute_list: false,
+            preserve_breaking_conditional_expression: false,
         }
     }
 }

--- a/crates/formatter/tests/cases/preserve_breaking_conditional_expression/after.php
+++ b/crates/formatter/tests/cases/preserve_breaking_conditional_expression/after.php
@@ -1,0 +1,30 @@
+<?php
+
+$options = $this->multiple
+    ? ($this->search)($query)
+    : [self::CANCEL, self::SEARCH_AGAIN, ...($this->search)($query)];
+
+$this->now = ($now instanceof DateTimeInterface)
+    ? DateTimeImmutable::createFromInterface($now)
+    : new DateTimeImmutable($now);
+
+function getControls(): array
+{
+    return [
+        ...(
+            $this->bufferEnabled
+                ? [
+                    'esc' => 'select',
+                ] : [
+                    '/' => 'filter',
+                    'space' => 'select',
+                ]
+        ),
+        '↑' => 'up',
+        '↓' => 'down',
+        'enter' => $this->options->getSelectedOptions() === []
+            ? 'skip'
+            : 'confirm',
+        'ctrl+c' => 'cancel',
+    ];
+}

--- a/crates/formatter/tests/cases/preserve_breaking_conditional_expression/before.php
+++ b/crates/formatter/tests/cases/preserve_breaking_conditional_expression/before.php
@@ -1,0 +1,27 @@
+<?php
+
+$options = $this->multiple
+    ? ($this->search)($query)
+    : [self::CANCEL, self::SEARCH_AGAIN, ...($this->search)($query)];
+
+    $this->now = $now instanceof DateTimeInterface
+        ? DateTimeImmutable::createFromInterface($now)
+        : new DateTimeImmutable($now);
+
+         function getControls(): array
+        {
+            return [
+                ...($this->bufferEnabled ? [
+                    'esc' => 'select',
+                ] : [
+                    '/' => 'filter',
+                    'space' => 'select',
+                ]),
+                '↑' => 'up',
+                '↓' => 'down',
+                'enter' => $this->options->getSelectedOptions() === []
+                    ? 'skip'
+                    : 'confirm',
+                'ctrl+c' => 'cancel',
+            ];
+        }

--- a/crates/formatter/tests/cases/preserve_breaking_conditional_expression/settings.inc
+++ b/crates/formatter/tests/cases/preserve_breaking_conditional_expression/settings.inc
@@ -1,0 +1,4 @@
+FormatSettings {
+  preserve_breaking_conditional_expression: true,
+  ..Default::default()
+}

--- a/crates/formatter/tests/cases/preserve_breaking_conditional_expression_disabled/after.php
+++ b/crates/formatter/tests/cases/preserve_breaking_conditional_expression_disabled/after.php
@@ -1,0 +1,34 @@
+<?php
+
+$options = $this->multiple ? ($this->search)($query) : [self::CANCEL, self::SEARCH_AGAIN, ...($this->search)($query)];
+
+$this->now =
+    ($now instanceof DateTimeInterface) ? DateTimeImmutable::createFromInterface($now) : new DateTimeImmutable($now);
+
+function getControls(): array
+{
+    return [
+        ...(
+            $this->bufferEnabled
+                ? [
+                    'esc' => 'select',
+                ] : [
+                    '/' => 'filter',
+                    'space' => 'select',
+                ]
+        ),
+        ...(
+            $this->bufferEnabled
+                ? ['esc' => 'select']
+                : [
+                    '/' => 'filter',
+                    'space' => 'select',
+                ]
+        ),
+        ...($this->bufferEnabled ? ['esc' => 'select'] : ['/' => 'filter', 'space' => 'select']),
+        '↑' => 'up',
+        '↓' => 'down',
+        'enter' => $this->options->getSelectedOptions() === [] ? 'skip' : 'confirm',
+        'ctrl+c' => 'cancel',
+    ];
+}

--- a/crates/formatter/tests/cases/preserve_breaking_conditional_expression_disabled/before.php
+++ b/crates/formatter/tests/cases/preserve_breaking_conditional_expression_disabled/before.php
@@ -1,0 +1,37 @@
+<?php
+
+$options = $this->multiple
+    ? ($this->search)($query)
+    : [self::CANCEL, self::SEARCH_AGAIN, ...($this->search)($query)];
+
+    $this->now = $now instanceof DateTimeInterface
+        ? DateTimeImmutable::createFromInterface($now)
+        : new DateTimeImmutable($now);
+
+         function getControls(): array
+        {
+            return [
+                ...($this->bufferEnabled ? [
+                    'esc' => 'select',
+                ] : [
+                    '/' => 'filter',
+                    'space' => 'select',
+                ]),
+                ...(
+      $this->bufferEnabled
+          ? ['esc' => 'select'] : [
+              '/' => 'filter',
+              'space' => 'select',
+          ]
+      ),
+      ...(
+          $this->bufferEnabled ? ['esc' => 'select'] : ['/' => 'filter', 'space' => 'select']
+      ),
+                '↑' => 'up',
+                '↓' => 'down',
+                'enter' => $this->options->getSelectedOptions() === []
+                    ? 'skip'
+                    : 'confirm',
+                'ctrl+c' => 'cancel',
+            ];
+        }

--- a/crates/formatter/tests/cases/preserve_breaking_conditional_expression_disabled/settings.inc
+++ b/crates/formatter/tests/cases/preserve_breaking_conditional_expression_disabled/settings.inc
@@ -1,0 +1,4 @@
+FormatSettings {
+  preserve_breaking_conditional_expression: false,
+  ..Default::default()
+}

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -122,6 +122,8 @@ test_case!(preserve_breaking_parameter_list);
 test_case!(preserve_breaking_parameter_list_disabled);
 test_case!(preserve_breaking_attribute_list);
 test_case!(preserve_breaking_attribute_list_disabled);
+test_case!(preserve_breaking_conditional_expression);
+test_case!(preserve_breaking_conditional_expression_disabled);
 test_case!(hooks_always_break);
 
 // GitHub issue test cases

--- a/docs/formatter/settings.md
+++ b/docs/formatter/settings.md
@@ -533,3 +533,19 @@ If enabled, the formatter will not attempt to collapse attribute lists onto a si
   ```toml
   preserve_breaking_attribute_list = true
   ```
+
+### `preserve_breaking_conditional_expression`
+
+Controls whether to preserve line breaks in conditional ( ternary ) expressions, even if they could fit on a single line.
+
+If enabled, the formatter will not attempt to collapse conditional expressions onto a single line if they
+were originally written with line breaks. This can be useful for preserving the original formatting
+of complex or lengthy conditional expressions.
+
+- Default: `false`
+- Type: `boolean`
+- Example:
+
+  ```toml
+  preserve_breaking_conditional_expression = true
+  ```


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR adds a new configuration option to the formatter, `preserve_breaking_conditional_expression`.

## 🔍 Context & Motivation

This new option allows users to control the formatting of conditional (ternary) expressions. By enabling this option, users can preserve line breaks in conditional expressions, ensuring that their original formatting is maintained even if the expression could technically fit on a single line. This is particularly useful for improving the readability of complex or lengthy conditional expressions.

## 🛠️ Summary of Changes

- **Feature:** Added preserve_breaking_conditional_expression option to preserve line breaks in conditional expressions.
- **Docs:** Updated the formatter documentation to include the new option.
- **Tests:** Added test cases to ensure the new option works as expected.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Closes #130 

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
