### PR TITLE
feat(formatter): Add settings to inline empty braces

### DIFF
--- a/crates/formatter/src/internal/format/class_like.rs
+++ b/crates/formatter/src/internal/format/class_like.rs
@@ -4,60 +4,95 @@ use mago_span::Span;
 
 use crate::document::Document;
 use crate::document::Group;
+use crate::document::IfBreak;
 use crate::document::Line;
+use crate::document::group::GroupIdentifier;
 use crate::internal::FormatterState;
 use crate::internal::format::Format;
 use crate::settings::BraceStyle;
+
+use super::block::block_is_empty;
 
 pub fn print_class_like_body<'a>(
     f: &mut FormatterState<'a>,
     left_brace: &'a Span,
     class_like_members: &'a Sequence<ClassLikeMember>,
     right_brace: &'a Span,
+    anonymous_class_signature_id: Option<GroupIdentifier>,
 ) -> Document<'a> {
-    let inline_empty = match f.settings.classlike_brace_style {
-        BraceStyle::SameLine => true,
-        BraceStyle::NextLine => false,
-    };
+    let is_body_empty = block_is_empty(f, left_brace, right_brace);
+    let should_inline = is_body_empty
+        && if anonymous_class_signature_id.is_some() {
+            f.settings.inline_empty_anonymous_class_braces
+        } else {
+            f.settings.inline_empty_classlike_braces
+        };
 
     let length = class_like_members.len();
-    let mut contents = vec![Document::String("{")];
-    if let Some(c) = f.print_trailing_comments(*left_brace) {
-        contents.push(c);
-    }
+    let class_like_members = {
+        let mut contents = vec![];
+        contents.push(Document::String("{"));
+        if let Some(c) = f.print_trailing_comments(*left_brace) {
+            contents.push(c);
+        }
 
-    if length != 0 {
-        let mut members = vec![Document::Line(Line::hard())];
-        for (i, item) in class_like_members.iter().enumerate() {
-            members.push(item.format(f));
+        if length != 0 {
+            let mut members = vec![Document::Line(Line::hard())];
+            for (i, item) in class_like_members.iter().enumerate() {
+                members.push(item.format(f));
 
-            if i < (length - 1) {
-                members.push(Document::Line(Line::hard()));
-                if should_add_empty_line_after(f, item) || f.is_next_line_empty(item.span()) {
+                if i < (length - 1) {
                     members.push(Document::Line(Line::hard()));
+                    if should_add_empty_line_after(f, item) || f.is_next_line_empty(item.span()) {
+                        members.push(Document::Line(Line::hard()));
+                    }
                 }
             }
+
+            contents.push(Document::Indent(members));
         }
 
-        contents.push(Document::Indent(members));
-    }
+        if let Some(comments) = f.print_dangling_comments(left_brace.join(*right_brace), true) {
+            if length > 0 && f.settings.empty_line_before_dangling_comments {
+                contents.push(Document::Line(Line::soft()));
+            }
 
-    if let Some(comments) = f.print_dangling_comments(left_brace.join(*right_brace), true) {
-        if length > 0 && f.settings.empty_line_before_dangling_comments {
-            contents.push(Document::Line(Line::soft()));
+            contents.push(comments);
+        } else if length > 0 || !should_inline {
+            contents.push(Document::Line(Line::hard()));
         }
 
-        contents.push(comments);
-    } else if length > 0 || !inline_empty {
-        contents.push(Document::Line(Line::hard()));
-    }
+        contents.push(Document::String("}"));
+        if let Some(comments) = f.print_trailing_comments(*right_brace) {
+            contents.push(comments);
+        }
 
-    contents.push(Document::String("}"));
-    if let Some(comments) = f.print_trailing_comments(*right_brace) {
-        contents.push(comments);
-    }
+        Document::Group(Group::new(contents))
+    };
 
-    Document::Group(Group::new(contents))
+    Document::Group(Group::new(vec![
+        if should_inline {
+            Document::space()
+        } else {
+            match anonymous_class_signature_id {
+                Some(signature_id) => match f.settings.closure_brace_style {
+                    BraceStyle::SameLine => Document::space(),
+                    BraceStyle::NextLine => Document::IfBreak(
+                        IfBreak::new(
+                            Document::space(),
+                            Document::Array(vec![Document::Line(Line::hard()), Document::BreakParent]),
+                        )
+                        .with_id(signature_id),
+                    ),
+                },
+                None => match f.settings.classlike_brace_style {
+                    BraceStyle::SameLine => Document::space(),
+                    BraceStyle::NextLine => Document::Array(vec![Document::Line(Line::hard()), Document::BreakParent]),
+                },
+            }
+        },
+        class_like_members,
+    ]))
 }
 
 #[inline(always)]

--- a/crates/formatter/src/internal/format/control_structure.rs
+++ b/crates/formatter/src/internal/format/control_structure.rs
@@ -328,7 +328,13 @@ impl<'a> Format<'a> for SwitchBody {
                 SwitchBody::BraceDelimited(b) => Document::Array(vec![
                     match f.settings.control_brace_style {
                         BraceStyle::SameLine => Document::space(),
-                        BraceStyle::NextLine => Document::Line(Line::hard()),
+                        BraceStyle::NextLine => {
+                            if b.cases.is_empty() && f.settings.inline_empty_control_braces {
+                                Document::space()
+                            } else {
+                                Document::Line(Line::hard())
+                            }
+                        }
                     },
                     b.format(f),
                 ]),
@@ -363,7 +369,13 @@ impl<'a> Format<'a> for SwitchColonDelimitedBody {
 impl<'a> Format<'a> for SwitchBraceDelimitedBody {
     fn format(&'a self, f: &mut FormatterState<'a>) -> Document<'a> {
         wrap!(f, self, SwitchBraceDelimitedBody, {
-            print_block_of_nodes(f, &self.left_brace, &self.cases, &self.right_brace, false)
+            print_block_of_nodes(
+                f,
+                &self.left_brace,
+                &self.cases,
+                &self.right_brace,
+                f.settings.inline_empty_control_braces,
+            )
         })
     }
 }

--- a/crates/formatter/src/internal/format/expression.rs
+++ b/crates/formatter/src/internal/format/expression.rs
@@ -1232,7 +1232,7 @@ impl<'a> Format<'a> for AnonymousClass {
     fn format(&'a self, f: &mut FormatterState<'a>) -> Document<'a> {
         wrap!(f, self, AnonymousClass, {
             let initialization = {
-                let mut contents = vec![Document::BreakParent, self.new.format(f)];
+                let mut contents = vec![self.new.format(f)];
                 if let Some(attributes) = misc::print_attribute_list_sequence(f, &self.attribute_lists) {
                     contents.push(Document::Line(Line::default()));
                     contents.push(attributes);
@@ -1267,22 +1267,11 @@ impl<'a> Format<'a> for AnonymousClass {
             let signature_id = f.next_id();
             let signature = Document::Group(Group::new(signature).with_id(signature_id));
 
-            let body = Document::Group(Group::new(vec![
-                // we follow the same brace style as closures, not classes
-                match f.settings.closure_brace_style {
-                    BraceStyle::SameLine => Document::space(),
-                    BraceStyle::NextLine => Document::IfBreak(
-                        IfBreak::new(
-                            Document::space(),
-                            Document::Array(vec![Document::Line(Line::hard()), Document::BreakParent]),
-                        )
-                        .with_id(signature_id),
-                    ),
-                },
-                print_class_like_body(f, &self.left_brace, &self.members, &self.right_brace),
-            ]));
-
-            Document::Group(Group::new(vec![initialization, signature, body]))
+            Document::Group(Group::new(vec![
+                initialization,
+                signature,
+                print_class_like_body(f, &self.left_brace, &self.members, &self.right_brace, Some(signature_id)),
+            ]))
         })
     }
 }

--- a/crates/formatter/src/settings.rs
+++ b/crates/formatter/src/settings.rs
@@ -168,6 +168,142 @@ pub struct FormatSettings {
     #[serde(default = "BraceStyle::next_line")]
     pub classlike_brace_style: BraceStyle,
 
+    /// Place empty control structure bodies on the same line.
+    ///
+    /// Example with `false`:
+    /// ```php
+    /// if ($expr)
+    /// {
+    /// }
+    /// ```
+    ///
+    /// Example with `true`:
+    /// ```php
+    /// if ($expr) {}
+    /// ```
+    ///
+    /// Default: false
+    #[serde(default = "default_false")]
+    pub inline_empty_control_braces: bool,
+
+    /// Place empty closure bodies on the same line.
+    ///
+    /// Example with `false`:
+    /// ```php
+    /// $closure = function()
+    /// {
+    /// };
+    /// ```
+    ///
+    /// Example with `true`:
+    /// ```php
+    /// $closure = function() {};
+    /// ```
+    ///
+    /// Default: true
+    #[serde(default = "default_true")]
+    pub inline_empty_closure_braces: bool,
+
+    /// Place empty function bodies on the same line.
+    ///
+    /// Example with `false`:
+    /// ```php
+    /// function foo()
+    /// {
+    /// }
+    /// ```
+    ///
+    /// Example with `true`:
+    /// ```php
+    /// function foo() {}
+    /// ```
+    ///
+    /// Default: false
+    #[serde(default = "default_false")]
+    pub inline_empty_function_braces: bool,
+
+    /// Place empty method bodies on the same line.
+    ///
+    /// Example with `false`:
+    /// ```php
+    /// class Foo
+    /// {
+    ///     public function bar()
+    ///     {
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// Example with `true`:
+    /// ```php
+    /// class Foo
+    /// {
+    ///     public function bar() {}
+    /// }
+    /// ```
+    ///
+    /// Default: false
+    #[serde(default = "default_false")]
+    pub inline_empty_method_braces: bool,
+
+    /// Place empty constructor bodies on the same line.
+    ///
+    /// Example with `false`:
+    /// ```php
+    /// class Foo {
+    ///     public function __construct()
+    ///     {
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// Example with `true`:
+    /// ```php
+    /// class Foo {
+    ///     public function __construct() {}
+    /// }
+    /// ```
+    ///
+    /// Default: true
+    #[serde(default = "default_true")]
+    pub inline_empty_constructor_braces: bool,
+
+    /// Place empty class-like bodies on the same line.
+    ///
+    /// Example with `false`:
+    /// ```php
+    /// class Foo
+    /// {
+    /// }
+    /// ```
+    ///
+    /// Example with `true`:
+    /// ```php
+    /// class Foo {}
+    /// ```
+    ///
+    /// Default: false
+    #[serde(default = "default_false")]
+    pub inline_empty_classlike_braces: bool,
+
+    /// Place empty anonymous class bodies on the same line.
+    ///
+    /// Example with `false`:
+    /// ```php
+    /// $anon = new class
+    /// {
+    /// };
+    /// ```
+    ///
+    /// Example with `true`:
+    /// ```php
+    /// $anon = new class {};
+    /// ```
+    ///
+    /// Default: true
+    #[serde(default = "default_true")]
+    pub inline_empty_anonymous_class_braces: bool,
+
     /// How to format broken method/property chains.
     ///
     /// When `next_line`, the first method/property starts on a new line:
@@ -1197,6 +1333,13 @@ impl Default for FormatSettings {
             method_brace_style: BraceStyle::NextLine,
             classlike_brace_style: BraceStyle::NextLine,
             control_brace_style: BraceStyle::SameLine,
+            inline_empty_control_braces: false,
+            inline_empty_closure_braces: true,
+            inline_empty_function_braces: false,
+            inline_empty_method_braces: false,
+            inline_empty_constructor_braces: true,
+            inline_empty_classlike_braces: false,
+            inline_empty_anonymous_class_braces: true,
             static_before_visibility: false,
             null_type_hint: NullTypeHint::default(),
             break_promoted_properties_list: true,

--- a/crates/formatter/tests/cases/inline_empty_braces_default/after.php
+++ b/crates/formatter/tests/cases/inline_empty_braces_default/after.php
@@ -1,0 +1,37 @@
+<?php
+
+if ($condition) {
+}
+
+function empty_function()
+{
+}
+
+$closure = function () {};
+
+class EmptyClass
+{
+}
+
+trait EmptyTrait
+{
+}
+
+interface EmptyInterface
+{
+}
+
+enum EmptyEnum
+{
+}
+
+class Example
+{
+    public function __construct() {}
+
+    public function emptyMethod()
+    {
+    }
+}
+
+$anon = new class {};

--- a/crates/formatter/tests/cases/inline_empty_braces_default/before.php
+++ b/crates/formatter/tests/cases/inline_empty_braces_default/before.php
@@ -1,0 +1,25 @@
+<?php
+
+if ($condition) {}
+
+function empty_function() {}
+
+$closure = function () {};
+
+class EmptyClass {}
+
+trait EmptyTrait {}
+
+interface EmptyInterface {}
+
+enum EmptyEnum {}
+
+class Example
+{
+    public function __construct() {}
+
+    public function emptyMethod() {}
+}
+
+$anon = new class {};
+

--- a/crates/formatter/tests/cases/inline_empty_braces_default/settings.inc
+++ b/crates/formatter/tests/cases/inline_empty_braces_default/settings.inc
@@ -1,0 +1,3 @@
+FormatSettings {
+  ..Default::default()
+}

--- a/crates/formatter/tests/cases/inline_empty_braces_disabled/after.php
+++ b/crates/formatter/tests/cases/inline_empty_braces_disabled/after.php
@@ -1,0 +1,41 @@
+<?php
+
+if ($condition) {
+}
+
+function empty_function()
+{
+}
+
+$closure = function () {
+};
+
+class EmptyClass
+{
+}
+
+trait EmptyTrait
+{
+}
+
+interface EmptyInterface
+{
+}
+
+enum EmptyEnum
+{
+}
+
+class Example
+{
+    public function __construct()
+    {
+    }
+
+    public function emptyMethod()
+    {
+    }
+}
+
+$anon = new class {
+};

--- a/crates/formatter/tests/cases/inline_empty_braces_disabled/before.php
+++ b/crates/formatter/tests/cases/inline_empty_braces_disabled/before.php
@@ -1,0 +1,25 @@
+<?php
+
+if ($condition) {}
+
+function empty_function() {}
+
+$closure = function () {};
+
+class EmptyClass {}
+
+trait EmptyTrait {}
+
+interface EmptyInterface {}
+
+enum EmptyEnum {}
+
+class Example
+{
+    public function __construct() {}
+
+    public function emptyMethod() {}
+}
+
+$anon = new class {};
+

--- a/crates/formatter/tests/cases/inline_empty_braces_disabled/settings.inc
+++ b/crates/formatter/tests/cases/inline_empty_braces_disabled/settings.inc
@@ -1,0 +1,10 @@
+FormatSettings {
+  inline_empty_control_braces: false,
+  inline_empty_closure_braces: false,
+  inline_empty_function_braces: false,
+  inline_empty_method_braces: false,
+  inline_empty_constructor_braces: false,
+  inline_empty_classlike_braces: false,
+  inline_empty_anonymous_class_braces: false,
+  ..Default::default()
+}

--- a/crates/formatter/tests/cases/inline_empty_braces_enabled/after.php
+++ b/crates/formatter/tests/cases/inline_empty_braces_enabled/after.php
@@ -1,0 +1,24 @@
+<?php
+
+if ($condition) {}
+
+function empty_function() {}
+
+$closure = function () {};
+
+class EmptyClass {}
+
+trait EmptyTrait {}
+
+interface EmptyInterface {}
+
+enum EmptyEnum {}
+
+class Example
+{
+    public function __construct() {}
+
+    public function emptyMethod() {}
+}
+
+$anon = new class {};

--- a/crates/formatter/tests/cases/inline_empty_braces_enabled/before.php
+++ b/crates/formatter/tests/cases/inline_empty_braces_enabled/before.php
@@ -1,0 +1,25 @@
+<?php
+
+if ($condition) {}
+
+function empty_function() {}
+
+$closure = function () {};
+
+class EmptyClass {}
+
+trait EmptyTrait {}
+
+interface EmptyInterface {}
+
+enum EmptyEnum {}
+
+class Example
+{
+    public function __construct() {}
+
+    public function emptyMethod() {}
+}
+
+$anon = new class {};
+

--- a/crates/formatter/tests/cases/inline_empty_braces_enabled/settings.inc
+++ b/crates/formatter/tests/cases/inline_empty_braces_enabled/settings.inc
@@ -1,0 +1,10 @@
+FormatSettings {
+  inline_empty_control_braces: true,
+  inline_empty_closure_braces: true,
+  inline_empty_function_braces: true,
+  inline_empty_method_braces: true,
+  inline_empty_constructor_braces: true,
+  inline_empty_classlike_braces: true,
+  inline_empty_anonymous_class_braces: true,
+  ..Default::default()
+}

--- a/crates/formatter/tests/cases/inline_empty_braces_swapped/after.php
+++ b/crates/formatter/tests/cases/inline_empty_braces_swapped/after.php
@@ -1,0 +1,28 @@
+<?php
+
+if ($condition) {}
+
+function empty_function() {}
+
+$closure = function () {
+};
+
+class EmptyClass {}
+
+trait EmptyTrait {}
+
+interface EmptyInterface {}
+
+enum EmptyEnum {}
+
+class Example
+{
+    public function __construct()
+    {
+    }
+
+    public function emptyMethod() {}
+}
+
+$anon = new class {
+};

--- a/crates/formatter/tests/cases/inline_empty_braces_swapped/before.php
+++ b/crates/formatter/tests/cases/inline_empty_braces_swapped/before.php
@@ -1,0 +1,25 @@
+<?php
+
+if ($condition) {}
+
+function empty_function() {}
+
+$closure = function () {};
+
+class EmptyClass {}
+
+trait EmptyTrait {}
+
+interface EmptyInterface {}
+
+enum EmptyEnum {}
+
+class Example
+{
+    public function __construct() {}
+
+    public function emptyMethod() {}
+}
+
+$anon = new class {};
+

--- a/crates/formatter/tests/cases/inline_empty_braces_swapped/settings.inc
+++ b/crates/formatter/tests/cases/inline_empty_braces_swapped/settings.inc
@@ -1,0 +1,10 @@
+FormatSettings {
+  inline_empty_control_braces: true,
+  inline_empty_closure_braces: false,
+  inline_empty_function_braces: true,
+  inline_empty_method_braces: true,
+  inline_empty_constructor_braces: false,
+  inline_empty_classlike_braces: true,
+  inline_empty_anonymous_class_braces: false,
+  ..Default::default()
+}

--- a/crates/formatter/tests/cases/issue_166/after.php
+++ b/crates/formatter/tests/cases/issue_166/after.php
@@ -2,9 +2,7 @@
 
 final class Issue166FirstCase
 {
-    public function __construct(#[Eager] public BWithEager $b)
-    {
-    }
+    public function __construct(#[Eager] public BWithEager $b) {}
 
     #[ConsoleCommand]
     public function test(
@@ -26,8 +24,7 @@ final class Issue166SecondCase
     public function __construct(
         #[Eager]
         public BWithEager $b,
-    ) {
-    }
+    ) {}
 
     #[ConsoleCommand]
     public function test(

--- a/crates/formatter/tests/cases/parameter_attributes/after.php
+++ b/crates/formatter/tests/cases/parameter_attributes/after.php
@@ -11,6 +11,5 @@ class Foo
         private Qux $qux,
         #[QuuxAttr(['type' => Quux::class])]
         private Quux $quux,
-    ) {
-    }
+    ) {}
 }

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -137,6 +137,10 @@ test_case!(line_options_all_off);
 test_case!(whitespace_in_heredoc);
 test_case!(shell_style_comments);
 test_case!(double_slash_comments);
+test_case!(inline_empty_braces_enabled);
+test_case!(inline_empty_braces_disabled);
+test_case!(inline_empty_braces_default);
+test_case!(inline_empty_braces_swapped);
 
 // A special test case for regressions in the Psl codebase
 test_case!(psl_regressions);


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR introduces new settings to control the inlining of empty braces for various language constructs (control structures, closures, functions, methods, constructors, class-like structures, and anonymous classes). It also adds a utility function to determine if a block is empty and refactors the code to consistently apply these settings.

## 🔍 Context & Motivation

Currently, the formatter lacks granular control over the placement of empty braces. This change addresses the need for more customization, allowing users to specify whether empty blocks should be inlined or placed on a new line based on the context. This enhances code readability and allows for better adherence to specific coding styles.

## 🛠️ Summary of Changes

- **Feature**: Added `inline_empty_control_braces` setting.
- **Feature**: Added `inline_empty_closure_braces` setting.
- **Feature**: Added `inline_empty_function_braces` setting.
- **Feature**: Added `inline_empty_method_braces` setting.
- **Feature**: Added `inline_empty_constructor_braces` setting.
- **Feature**: Added `inline_empty_classlike_braces` setting.
- **Feature**: Added `inline_empty_anonymous_class_braces` setting.
- **Tests**: Added new test cases to verify the new settings.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Closes #167 

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
