### PR TITLE
feat(linter): implement `--mimimum-level` to lint command (#174)

### DIFF
--- a/crates/reporting/src/lib.rs
+++ b/crates/reporting/src/lib.rs
@@ -61,7 +61,7 @@ impl FromStr for Level {
             "help" => Ok(Self::Help),
             "warning" => Ok(Self::Warning),
             "error" => Ok(Self::Error),
-            _ => todo!("Recheck what we want to do here ? A `const &str` ?"),
+            _ => Err(()),
         }
     }
 }

--- a/crates/reporting/src/lib.rs
+++ b/crates/reporting/src/lib.rs
@@ -1,11 +1,13 @@
 use std::cmp::Ordering;
 use std::collections::hash_map::Entry;
 use std::iter::Once;
+use std::str::FromStr;
 
 use ahash::HashMap;
 use serde::Deserialize;
 use serde::Serialize;
 use strum::Display;
+use strum::VariantNames;
 
 use mago_fixer::FixPlan;
 use mago_source::SourceIdentifier;
@@ -37,7 +39,8 @@ pub struct Annotation {
 }
 
 /// Represents the severity level of an issue.
-#[derive(Debug, PartialEq, Eq, Ord, Copy, Clone, Hash, PartialOrd, Deserialize, Serialize, Display)]
+#[derive(Debug, PartialEq, Eq, Ord, Copy, Clone, Hash, PartialOrd, Deserialize, Serialize, Display, VariantNames)]
+#[strum(serialize_all = "lowercase")]
 pub enum Level {
     /// A note, providing additional information or context.
     Note,
@@ -47,6 +50,20 @@ pub enum Level {
     Warning,
     /// An error, indicating a problem that prevents the code from functioning correctly.
     Error,
+}
+
+impl FromStr for Level {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "note" => Ok(Self::Note),
+            "help" => Ok(Self::Help),
+            "warning" => Ok(Self::Warning),
+            "error" => Ok(Self::Error),
+            _ => todo!("Recheck what we want to do here ? A `const &str` ?"),
+        }
+    }
 }
 
 /// Represents an issue identified in the code.

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -203,6 +203,19 @@ pub struct LintCommand {
         conflicts_with = "fix",
     )]
     pub reporting_format: ReportingFormat,
+
+    /// Choose the failling threshold level for reported issues.
+    #[arg(
+        long,
+        short = 'm',
+        help = "Choose the failling threshold level for reported issues",
+        default_value_t = Level::Error,
+        value_parser = enum_variants!(Level),
+        conflicts_with = "explain",
+        conflicts_with = "list_rules",
+        conflicts_with = "fix",
+    )]
+    pub minimum_level: Level,
 }
 
 impl LintCommand {
@@ -296,7 +309,7 @@ pub async fn execute(command: LintCommand, mut configuration: Configuration) -> 
         });
     }
 
-    let issues_contain_errors = issues.has_minimum_level(Level::Error);
+    let issues_contain_errors = issues.has_minimum_level(command.minimum_level);
 
     let reporter = Reporter::new(interner, source_manager, command.reporting_target);
 


### PR DESCRIPTION
## 📌 What Does This PR Do?

Implement the `--minimum-level` flag in the `mago lint` command

## 🔍 Context & Motivation

Currently, we hardcode the failling threshold to `Level::Error`, and the logic for failling if at least one issue is found is already implemented, so the feature is pretty trivial to add :+1:

## 🛠️ Summary of Changes

- **Feature:** `mago lint --minimum-level`

## 📂 Affected Areas

- [x] Linter
- [ ] Formatter
- [x] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

#174 

## 📝 Notes for Reviewers
Still unsure about what type to use to represent `Level::FromStr::Err`. I think a simple `&'static str` should do the trick but I'd rather have some opinions first :+1:

Also not sure about the wording for the help message