### PR TITLE
fix: support compiling mago-formatter to wasm32-unknown-unknown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy 0.7.35",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1820,7 +1820,6 @@ dependencies = [
 name = "mago-wasm"
 version = "0.23.0"
 dependencies = [
- "getrandom 0.2.15",
  "mago-formatter",
  "mago-interner",
  "mago-linter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ mago-php-version = { path = "crates/php-version", version = "0.23.0" }
 mago-reference = { path = "crates/reference", version = "0.23.0" }
 tracing = { version = "0.1.40" }
 ahash = { version = "0.8.11", default-features = false, features = ["std"] }
-getrandom = { version = "0.2", features = ["js"] }
 serde_json = { version = "1.0.138" }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.44.2", features = ["rt", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ mago-wasm = { path = "crates/wasm", version = "0.23.0" }
 mago-php-version = { path = "crates/php-version", version = "0.23.0" }
 mago-reference = { path = "crates/reference", version = "0.23.0" }
 tracing = { version = "0.1.40" }
-ahash = { version = "0.8.11" }
+ahash = { version = "0.8.11", default-features = false, features = ["std"] }
 getrandom = { version = "0.2", features = ["js"] }
 serde_json = { version = "1.0.138" }
 serde = { version = "1.0", features = ["derive"] }
@@ -85,7 +85,7 @@ self_update = { version = "0.42.0", features = ["archive-tar", "archive-zip", "c
 openssl = { version = "0.10", features = ["vendored"] }
 tempfile = "3.15.0"
 colored = "3.0.0"
-blake3 = "1.5.5"
+blake3 = "1.8.1"
 memchr = "2.7.4"
 parking_lot = "0.12.3"
 dialoguer = "0.11.0"

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -9,9 +9,6 @@ homepage.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
-[package.metadata.cargo-machete]
-ignored = ["getrandom"]
-
 [lints]
 workspace = true
 
@@ -29,5 +26,4 @@ mago-linter = { workspace = true }
 mago-formatter = { workspace = true }
 wasm-bindgen = { workspace = true }
 serde-wasm-bindgen = { workspace = true }
-getrandom = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
## 📌 What Does This PR Do?

Allows `mago-formatter` to compile under wasm32-unknown-unknown.

## 🔍 Context & Motivation

To allow it to be used as a dprint plugin.

## 🛠️ Summary of Changes

1. Disable `ahash` using the `getrandom` crate and instead use comptime randomness, which I believe is fine for these crates?
1. Upgrade blake3 which causes it to not use the `getrandom` crate.
1. I think we can now update the wasm crate to not require the "js" feature of getrandom and then remove it as a dependency.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

None

## 📝 Notes for Reviewers


