### PR TITLE
fix: spelling/capitalization

### DIFF
--- a/crates/linter/src/plugin/redundancy/rules/redundant_parentheses.rs
+++ b/crates/linter/src/plugin/redundancy/rules/redundant_parentheses.rs
@@ -139,7 +139,7 @@ impl Rule for RedundantParenthesesRule {
         let issue = Issue::new(context.level(), "Redundant parentheses around expression.")
             .with_annotation(
                 Annotation::primary(parenthesized.expression.span())
-                    .with_message("expression does not need to be parenthesized."),
+                    .with_message("Expression does not need to be parenthesized."),
             )
             .with_help("Remove the redundant inner parentheses.");
 

--- a/crates/linter/src/plugin/safety/rules/no_eval.rs
+++ b/crates/linter/src/plugin/safety/rules/no_eval.rs
@@ -36,8 +36,8 @@ impl Rule for NoEvalRule {
 
         context.report(
             Issue::new(context.level(), "Unsafe use of `eval` construct.")
-                .with_annotation(Annotation::primary(eval_construct.eval.span).with_message("this `eval` construct is unsafe."))
-                .with_annotation(Annotation::secondary(eval_construct.value.span()).with_message("the evaluated code is here."))
+                .with_annotation(Annotation::primary(eval_construct.eval.span).with_message("This `eval` construct is unsafe."))
+                .with_annotation(Annotation::secondary(eval_construct.value.span()).with_message("The evaluated code is here."))
                 .with_note("The `eval` construct executes arbitrary code, which can be a major security risk if not used carefully.")
                 .with_note("It can potentially lead to remote code execution vulnerabilities if the evaluated code is not properly sanitized.")
                 .with_note("Consider using safer alternatives whenever possible.")

--- a/crates/linter/src/plugin/strictness/rules/no_empty_construct.rs
+++ b/crates/linter/src/plugin/strictness/rules/no_empty_construct.rs
@@ -42,10 +42,10 @@ impl Rule for NoEmptyConstruct {
 
         let issue = Issue::new(context.level(), "Use of the `empty` construct.")
             .with_annotation(
-                Annotation::primary(construct.span()).with_message("Ambigous check due to `empty()` loose semantic."),
+                Annotation::primary(construct.span()).with_message("Ambiguous check due to `empty()` loose semantic."),
             )
             .with_note("`empty()` exhibits unexpected behavior on specific value.")
-            .with_note("It is unclear what codition is being treated with `empty()`.")
+            .with_note("It is unclear what condition is being treated with `empty()`.")
             .with_help("Use strict comparison or specific predicate function to clearly convey your intent.");
 
         context.report(issue);

--- a/crates/linter/src/plugin/strictness/rules/no_shorthand_ternary.rs
+++ b/crates/linter/src/plugin/strictness/rules/no_shorthand_ternary.rs
@@ -43,11 +43,11 @@ impl Rule for NoShorthandTernary {
         let issue = match node {
             Node::BinaryOperator(BinaryOperator::Elvis(_)) => Issue::new(context.level(), "Use of the elvis operator.")
                 .with_annotation(
-                    Annotation::primary(node.span()).with_message("Ambigous check due to `?:` loose comparison."),
+                    Annotation::primary(node.span()).with_message("Ambiguous check due to `?:` loose comparison."),
                 ),
             Node::Conditional(Conditional { then: None, .. }) => {
                 Issue::new(context.level(), "Use of the shorthand ternary operator.").with_annotation(
-                    Annotation::primary(node.span()).with_message("Ambigous check due to `? :` loose comparison."),
+                    Annotation::primary(node.span()).with_message("Ambiguous check due to `? :` loose comparison."),
                 )
             }
             _ => return LintDirective::default(),


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes spelling mistakes and makes sure messages start with a capital letter (to match the rest)

## 🔍 Context & Motivation

General improvement of message readability.

## 🛠️ Summary of Changes

Fixed spelling mistakes and added missing capital letter at start of some messages.

## 📂 Affected Areas

- [x] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
