### PR TITLE
fix(syntax): CRLF heredoc parsing (#225)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 * text=auto eol=lf
+crates/formatter/tests/cases/issue_225/before.php -text eol=crlf
+crates/formatter/tests/cases/issue_225/after.php -text eol=crlf
 stubs/** linguist-vendored

--- a/crates/formatter/tests/cases/issue_225/after.php
+++ b/crates/formatter/tests/cases/issue_225/after.php
@@ -1,0 +1,5 @@
+<?php
+
+$string = <<<'ERROR'
+foo
+ERROR;

--- a/crates/formatter/tests/cases/issue_225/before.php
+++ b/crates/formatter/tests/cases/issue_225/before.php
@@ -1,0 +1,5 @@
+<?php
+
+$string = <<<'ERROR'
+foo
+ERROR;

--- a/crates/formatter/tests/cases/issue_225/settings.inc
+++ b/crates/formatter/tests/cases/issue_225/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings::default()

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -176,3 +176,4 @@ test_case!(issue_221);
 test_case!(issue_223);
 test_case!(issue_241);
 test_case!(issue_246);
+test_case!(issue_225);

--- a/crates/syntax/src/lexer/mod.rs
+++ b/crates/syntax/src/lexer/mod.rs
@@ -829,8 +829,13 @@ impl<'a, 'i> Lexer<'a, 'i> {
                     let mut only_whitespaces = true;
 
                     loop {
-                        match self.input.peek(length, 1) {
-                            [b'\n', ..] => {
+                        match self.input.peek(length, 2) {
+                            [b'\r', b'\n'] => {
+                                length += 2;
+
+                                break;
+                            }
+                            [b'\n', ..] | [b'\r', ..] => {
                                 length += 1;
 
                                 break;

--- a/crates/syntax/src/lexer/mod.rs
+++ b/crates/syntax/src/lexer/mod.rs
@@ -742,7 +742,12 @@ impl<'a, 'i> Lexer<'a, 'i> {
                         let mut token_kind = TokenKind::StringPart;
                         loop {
                             match self.input.peek(length, 2) {
-                                [b'\n', ..] => {
+                                [b'\r', b'\n'] => {
+                                    length += 2;
+
+                                    break;
+                                }
+                                [b'\n', ..] | [b'\r', ..] => {
                                     length += 1;
 
                                     break;
@@ -1003,8 +1008,12 @@ fn matches_start_of_heredoc_document(input: &Input) -> bool {
             return false; // Unexpected EOF
         }
 
-        if *input.read_at(pos) == b'\n' {
+        let byte = *input.read_at(pos);
+        if byte == b'\n' {
             return true; // Newline found: valid heredoc opener.
+        } else if byte == b'\r' {
+            // Handle CRLF: treat '\r' followed by '\n' as a newline as well.
+            return pos + 1 < total && *input.read_at(pos + 1) == b'\n';
         } else if is_part_of_identifier(input.read_at(pos)) {
             length += 1;
         } else {
@@ -1047,6 +1056,9 @@ fn matches_start_of_double_quote_heredoc_document(input: &Input) -> bool {
         if *byte == b'\n' {
             // End of line: valid only if a closing double quote was encountered.
             return terminated;
+        } else if *byte == b'\r' {
+            // Handle CRLF sequences.
+            return terminated && pos + 1 < total && *input.read_at(pos + 1) == b'\n';
         } else if !terminated && is_part_of_identifier(byte) {
             length += 1;
         } else if !terminated && *byte == b'"' {
@@ -1091,6 +1103,8 @@ fn matches_start_of_nowdoc_document(input: &Input) -> bool {
         let byte = *input.read_at(pos);
         if byte == b'\n' {
             return terminated;
+        } else if byte == b'\r' {
+            return terminated && pos + 1 < total && *input.read_at(pos + 1) == b'\n';
         } else if !terminated && is_part_of_identifier(&byte) {
             length += 1;
         } else if !terminated && byte == b'\'' {
@@ -1172,6 +1186,14 @@ fn read_start_of_heredoc_document(input: &Input, double_quoted: bool) -> (usize,
             // Newline ends the label.
             length += 1;
             return (length, whitespaces, label_length);
+        } else if byte == b'\r' {
+            // Handle CRLF sequences
+            if pos + 1 < total && *input.read_at(pos + 1) == b'\n' {
+                length += 2;
+            } else {
+                length += 1;
+            }
+            return (length, whitespaces, label_length);
         } else if is_part_of_identifier(&byte) && (!double_quoted || !terminated) {
             // For both unquoted and double-quoted (before the closing quote) heredoc,
             // a valid identifier character is part of the label.
@@ -1217,6 +1239,14 @@ fn read_start_of_nowdoc_document(input: &Input) -> (usize, usize, usize) {
         if byte == b'\n' {
             // A newline indicates the end of the label.
             length += 1;
+            return (length, whitespaces, label_length);
+        } else if byte == b'\r' {
+            // Handle CRLF sequences
+            if pos + 1 < total && *input.read_at(pos + 1) == b'\n' {
+                length += 2;
+            } else {
+                length += 1;
+            }
             return (length, whitespaces, label_length);
         } else if is_part_of_identifier(&byte) && !terminated {
             // For nowdoc, identifier characters contribute to the label until terminated.


### PR DESCRIPTION
## 📌 What Does This PR Do?
Fix CRLF parsing inside heredocs.

## 🔍 Context & Motivation

Found an issue under Windows, when a .php file is uses CRLF line endings and has a heredoc.

## 🛠️ Summary of Changes

- reproduce heredoc parsing failure when file uses CRLF line endings
- preserve CRLF in test fixture via `.gitattributes`
- fix lexer to accept `\r\n` line endings in heredoc/nowdoc openers

### Further fixups after OpenAI Codex attempt:

* fix .gitattributes & issue_225 test fixture to crlf
* Fix peeking inside DocumentKind::Heredoc
 
### Testing
- `cargo test issue_225 --package mago-formatter -- --nocapture`
- `cargo test --workspace`

## 📂 Affected Areas

- [x] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Closes #225

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
