### PR TITLE
fix(formatter): Ensure clone binary operations are correctly parenthesized

### DIFF
--- a/crates/formatter/src/internal/parens.rs
+++ b/crates/formatter/src/internal/parens.rs
@@ -201,6 +201,9 @@ impl<'a> FormatterState<'a> {
                 // ```
                 return access.left_bracket.start.offset > node.span().start.offset;
             }
+            Some(Node::Clone(_)) => {
+                return true;
+            }
             parent => {
                 if let Some(Node::Assignment(_)) = parent
                     && operator.is_low_precedence()

--- a/crates/formatter/tests/cases/issue_241/after.php
+++ b/crates/formatter/tests/cases/issue_241/after.php
@@ -2,4 +2,5 @@
 
 clone $foo;
 clone $foo?->bar;
-clone ($foo?->bar ?? $foo?->baz);
+clone ($foo ?? $bar);
+clone $objectWithOperatorOverloading + 10;

--- a/crates/formatter/tests/cases/issue_241/after.php
+++ b/crates/formatter/tests/cases/issue_241/after.php
@@ -1,0 +1,5 @@
+<?php
+
+clone $foo;
+clone $foo?->bar;
+clone ($foo?->bar ?? $foo?->baz);

--- a/crates/formatter/tests/cases/issue_241/before.php
+++ b/crates/formatter/tests/cases/issue_241/before.php
@@ -1,5 +1,6 @@
 <?php
 
-clone $foo;
+clone ($foo);
 clone ($foo?->bar);
-clone ($foo?->bar ?? $foo?->baz);
+clone ($foo ?? $bar);
+clone $objectWithOperatorOverloading + 10;

--- a/crates/formatter/tests/cases/issue_241/before.php
+++ b/crates/formatter/tests/cases/issue_241/before.php
@@ -1,0 +1,5 @@
+<?php
+
+clone $foo;
+clone ($foo?->bar);
+clone ($foo?->bar ?? $foo?->baz);

--- a/crates/formatter/tests/cases/issue_241/settings.inc
+++ b/crates/formatter/tests/cases/issue_241/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings::default()

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -174,3 +174,4 @@ test_case!(issue_217);
 test_case!(issue_218);
 test_case!(issue_221);
 test_case!(issue_223);
+test_case!(issue_241);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Resolve #241 

## 🔍 Context & Motivation

Fixing a bug in the formatter that can cause runtime errors

## 🛠️ Summary of Changes

Ensure `clone` followed by a binary expression are correctly parenthesized

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

#241 

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
