### PR TITLE
add public properties to DateInterval stubs

### DIFF
--- a/stubs/extensions/date.php
+++ b/stubs/extensions/date.php
@@ -722,6 +722,19 @@ class DateTimeZone
 
 class DateInterval
 {
+    public readonly int $y;
+    public readonly int $m;
+    public readonly int $d;
+    public readonly int $h;
+    public readonly int $i;
+    public readonly int $s;
+    public readonly float $f;
+    /** @var int<0, 1> */
+    public readonly int $invert;
+    public readonly int|false $days;
+    public readonly bool $from_string;
+    public readonly string $date_string;
+
     public function __construct(string $duration) {}
 
     public static function createFromDateString(string $datetime): DateInterval


### PR DESCRIPTION
## 📌 What Does This PR Do?

Adds readonly DateInterval properties to stubs as described here:
https://www.php.net/manual/en/class.dateinterval.php#dateinterval.props.y

## 🔍 Context & Motivation

Eliminate false positives when using the analyzer.

## 🛠️ Summary of Changes

- **Bug Fix:** Fix some false positives regarding to DateInterval by adding its public properties to stubs

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Analyzer
