### PR TITLE
fix(docs): remove `mago fix` reference

### DIFF
--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -26,16 +26,6 @@ The `lint` command is used to analyze PHP files in your project and report any i
   - `--reporting-format`: Specify the output format for issue reports (e.g., `rich`, `github`, `json`, `checkstyle`, ...).
   - `--reporting-target`: Specify the target for issue reports (e.g., `stdout`, `stderr` ).
 
-### `mago fix`
-
-The `fix` command is used to automatically fix issues identified during linting.
-
-- Usage: `mago fix [OPTIONS]`
-- Options:
-  - `--dry-run`: Preview changes without applying them.
-  - `--unsafe`: Apply unsafe fixes.
-  - `--potentially-unsafe`: Apply potentially unsafe fixes.
-
 ### `mago help`
 
 The `help` command provides information about available commands and their usage.


### PR DESCRIPTION

## 📌 What Does This PR Do?

Removed about obsolete `mago fix` .


## 🔍 Context & Motivation

<!-- Why is this change needed? Is it fixing a bug, adding a feature, or refactoring? -->

Update doc.

## 🛠️ Summary of Changes

- **Docs:** Updated installation guide.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [x] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

fix #282

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
