### PR TITLE
fix(formatter): correct parenthesis handling

### DIFF
--- a/crates/formatter/src/internal/format/control_structure.rs
+++ b/crates/formatter/src/internal/format/control_structure.rs
@@ -23,7 +23,9 @@ impl<'arena> Format<'arena> for If<'arena> {
                 self.r#if.format(f),
                 misc::print_condition(
                     f,
+                    self.left_parenthesis,
                     self.condition,
+                    self.right_parenthesis,
                     f.settings.space_before_if_parenthesis,
                     f.settings.space_within_if_parenthesis,
                 ),
@@ -80,7 +82,9 @@ impl<'arena> Format<'arena> for IfStatementBodyElseIfClause<'arena> {
                 self.elseif.format(f),
                 misc::print_condition(
                     f,
+                    self.left_parenthesis,
                     self.condition,
+                    self.right_parenthesis,
                     f.settings.space_before_if_parenthesis,
                     f.settings.space_within_if_parenthesis,
                 ),
@@ -145,7 +149,9 @@ impl<'arena> Format<'arena> for IfColonDelimitedBodyElseIfClause<'arena> {
 
             let condition = misc::print_condition(
                 f,
+                self.left_parenthesis,
                 self.condition,
+                self.right_parenthesis,
                 f.settings.space_before_if_parenthesis,
                 f.settings.space_within_if_parenthesis,
             );
@@ -204,7 +210,9 @@ impl<'arena> Format<'arena> for DoWhile<'arena> {
                 self.r#while.format(f),
                 misc::print_condition(
                     f,
+                    self.left_parenthesis,
                     self.condition,
+                    self.right_parenthesis,
                     f.settings.space_before_while_parenthesis,
                     f.settings.space_within_while_parenthesis,
                 ),
@@ -308,7 +316,9 @@ impl<'arena> Format<'arena> for Switch<'arena> {
                 self.switch.format(f),
                 misc::print_condition(
                     f,
+                    self.left_parenthesis,
                     self.expression,
+                    self.right_parenthesis,
                     f.settings.space_before_switch_parenthesis,
                     f.settings.space_within_switch_parenthesis,
                 ),
@@ -441,7 +451,9 @@ impl<'arena> Format<'arena> for While<'arena> {
                 self.r#while.format(f),
                 misc::print_condition(
                     f,
+                    self.left_parenthesis,
                     self.condition,
+                    self.right_parenthesis,
                     f.settings.space_before_while_parenthesis,
                     f.settings.space_within_while_parenthesis,
                 ),

--- a/crates/formatter/src/internal/format/expression.rs
+++ b/crates/formatter/src/internal/format/expression.rs
@@ -915,7 +915,9 @@ impl<'arena> Format<'arena> for Match<'arena> {
                 self.r#match.format(f),
                 print_condition(
                     f,
+                    self.left_parenthesis,
                     self.expression,
+                    self.right_parenthesis,
                     f.settings.space_before_match_parenthesis,
                     f.settings.space_within_match_parenthesis,
                 ),

--- a/crates/formatter/src/internal/format/member_access.rs
+++ b/crates/formatter/src/internal/format/member_access.rs
@@ -17,7 +17,6 @@ use crate::internal::format::call_arguments::print_argument_list;
 use crate::internal::format::misc;
 use crate::internal::format::misc::is_breaking_expression;
 use crate::internal::format::misc::is_string_word_type;
-use crate::internal::parens::instantiation_needs_parens;
 use crate::internal::utils::string_width;
 use crate::internal::utils::unwrap_parenthesized;
 
@@ -548,7 +547,7 @@ fn base_needs_parerns<'arena>(f: &FormatterState<'_, 'arena>, base: &'arena Expr
     }
 
     match base {
-        Expression::Instantiation(instantiation) => instantiation_needs_parens(f, instantiation),
+        Expression::Instantiation(instantiation) => f.instantiation_needs_parens(instantiation),
         Expression::Binary(_)
         | Expression::UnaryPrefix(_)
         | Expression::UnaryPostfix(_)

--- a/crates/formatter/src/internal/utils.rs
+++ b/crates/formatter/src/internal/utils.rs
@@ -79,7 +79,7 @@ pub fn is_at_call_like_expression(f: &FormatterState<'_, '_>) -> bool {
 }
 
 #[inline]
-pub fn unwrap_parenthesized<'arena>(mut expression: &'arena Expression<'arena>) -> &'arena Expression<'arena> {
+pub fn unwrap_parenthesized<'ast, 'arena>(mut expression: &'ast Expression<'arena>) -> &'ast Expression<'arena> {
     while let Expression::Parenthesized(parenthesized) = expression {
         expression = parenthesized.expression;
     }

--- a/crates/formatter/tests/cases/issue_279/after.php
+++ b/crates/formatter/tests/cases/issue_279/after.php
@@ -1,0 +1,31 @@
+<?php
+
+if (
+    in_array($object->getVeryLongAndInterestingObjectType(), SuperClass::VERY_LONG_AND_DESCRIPTIVE_CONSTANT_NAME) &&
+        (!$object->veryLongConditionCheckWithLotsOfText() && !$object->evenLongerConditionCheckWithEvenMoreText())
+) {
+}
+
+if (false) {
+    if (
+        in_array($object->getVeryLongAndInterestingObjectType(), SuperClass::VERY_LONG_AND_DESCRIPTIVE_CONSTANT_NAME) &&
+            (!$object->veryLongConditionCheckWithLotsOfText() && !$object->evenLongerConditionCheckWithEvenMoreText())
+    ) {
+    }
+}
+
+if (false) {
+    if (false) {
+        if (
+            in_array(
+                    $object->getVeryLongAndInterestingObjectType(),
+                    SuperClass::VERY_LONG_AND_DESCRIPTIVE_CONSTANT_NAME,
+                ) &&
+                (
+                    !$object->veryLongConditionCheckWithLotsOfText() &&
+                        !$object->evenLongerConditionCheckWithEvenMoreText()
+                )
+        ) {
+        }
+    }
+}

--- a/crates/formatter/tests/cases/issue_279/before.php
+++ b/crates/formatter/tests/cases/issue_279/before.php
@@ -1,0 +1,33 @@
+<?php
+
+            if (
+                in_array(
+                    $object->getVeryLongAndInterestingObjectType(),
+                    SuperClass::VERY_LONG_AND_DESCRIPTIVE_CONSTANT_NAME,
+                )
+                && (
+                    !$object->veryLongConditionCheckWithLotsOfText()
+                    && !$object->evenLongerConditionCheckWithEvenMoreText()
+                )
+            ) {}
+
+            if (false) {
+                
+                if (
+                    in_array($object->getVeryLongAndInterestingObjectType(), SuperClass::VERY_LONG_AND_DESCRIPTIVE_CONSTANT_NAME) &&
+                        (!$object->veryLongConditionCheckWithLotsOfText() && !$object->evenLongerConditionCheckWithEvenMoreText())
+                ) {
+                }
+
+            }
+            
+            if (false) {
+            if (false) {
+                
+                if (
+                    in_array($object->getVeryLongAndInterestingObjectType(), SuperClass::VERY_LONG_AND_DESCRIPTIVE_CONSTANT_NAME) &&
+                        (!$object->veryLongConditionCheckWithLotsOfText() && !$object->evenLongerConditionCheckWithEvenMoreText())
+                ) {
+                }
+
+            }            }

--- a/crates/formatter/tests/cases/issue_279/settings.inc
+++ b/crates/formatter/tests/cases/issue_279/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings::default()

--- a/crates/formatter/tests/cases/issue_300/after.php
+++ b/crates/formatter/tests/cases/issue_300/after.php
@@ -1,0 +1,30 @@
+<?php
+
+if (1)
+    echo '1';
+
+if (1)
+    echo '1';
+else if (2)
+    echo '2';
+
+if (1)
+    echo '1';
+else if (2) // Comment
+    echo '2';
+
+if (1)
+    echo '1';
+else if (2) // Comment
+    echo '2';
+else
+    echo '3';
+
+if (1)
+    echo '1';
+else if (2) // Comment
+    echo '2'; // Comment
+else if (3) // Comment
+    echo '3';
+else
+    echo '4';

--- a/crates/formatter/tests/cases/issue_300/before.php
+++ b/crates/formatter/tests/cases/issue_300/before.php
@@ -1,0 +1,33 @@
+<?php
+
+if (1)
+  echo '1';
+
+if (1)
+  echo '1';
+else if (2)
+  echo '2';
+
+  if (1)
+    echo '1';
+  else if (2) // Comment
+    echo '2';
+
+    
+    
+    if (1)
+      echo '1';
+    else if (2) // Comment
+      echo '2';
+    else
+      echo '3';
+      
+    if (1)
+        echo '1';
+        else if (2) // Comment
+        echo '2'; // Comment
+        else if (3) // Comment
+
+        echo '3';
+        else
+        echo '4';

--- a/crates/formatter/tests/cases/issue_300/settings.inc
+++ b/crates/formatter/tests/cases/issue_300/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings::default()

--- a/crates/formatter/tests/cases/issue_301/after.php
+++ b/crates/formatter/tests/cases/issue_301/after.php
@@ -1,0 +1,7 @@
+<?php
+
+if (
+    aLongishFunction() !== 'a longish value' ||
+        (in_array($another_val, getListOfValsToCheckAgainst()) || $another_val == 1 && !is_foo())
+) {
+}

--- a/crates/formatter/tests/cases/issue_301/before.php
+++ b/crates/formatter/tests/cases/issue_301/before.php
@@ -1,0 +1,8 @@
+<?php
+
+if (
+    aLongishFunction() !== 'a longish value'
+    || (in_array($another_val, getListOfValsToCheckAgainst())
+    || ($another_val == 1 && !is_foo()))
+) {
+}

--- a/crates/formatter/tests/cases/issue_301/settings.inc
+++ b/crates/formatter/tests/cases/issue_301/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings::default()

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -201,3 +201,6 @@ test_case!(issue_298);
 test_case!(issue_297);
 test_case!(issue_296);
 test_case!(issue_299);
+test_case!(issue_279);
+test_case!(issue_300);
+test_case!(issue_301);

--- a/crates/syntax/src/token/mod.rs
+++ b/crates/syntax/src/token/mod.rs
@@ -349,6 +349,26 @@ impl Precedence {
             _ => return None,
         })
     }
+
+    #[inline]
+    pub const fn is_associative(&self) -> bool {
+        self.associativity().is_some()
+    }
+
+    #[inline]
+    pub const fn is_right_associative(&self) -> bool {
+        matches!(self.associativity(), Some(Associativity::Right))
+    }
+
+    #[inline]
+    pub const fn is_left_associative(&self) -> bool {
+        matches!(self.associativity(), Some(Associativity::Left))
+    }
+
+    #[inline]
+    pub const fn is_non_associative(&self) -> bool {
+        matches!(self.associativity(), Some(Associativity::NonAssociative))
+    }
 }
 
 impl TokenKind {


### PR DESCRIPTION
This commit resolves several formatting bugs related to operator associativity, spacing in `else if` chains, and comment alignment in control structures.

the primary change corrects how parentheses are handled for binary expressions. The formatter now respects operator associativity rules to preserve the original AST structure.

previously, expressions like `$a || ($b || $c)` were incorrectly flattened to `$a || $b || $c`, which is parsed differently. The new logic checks if an expression is the left or right child of a parent operator with the same precedence. It then correctly adds parentheses to maintain the intended evaluation order for both left-associative (e.g., `||`, `+`) and right-associative (e.g., `**`) operators.

closes #279
closes #300
closes #301

