### PR TITLE
docs: polish casing and minor readability and presentation improvements

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,6 +1,5 @@
 import { defineConfig } from "vitepress";
 
-// A placeholder for your site's domain
 const site = "https://mago.carthage.software";
 
 export default defineConfig({
@@ -61,7 +60,7 @@ export default defineConfig({
         text: "📖 Guide",
         collapsed: false,
         items: [
-          { text: "Getting Started", link: "/guide/getting-started" },
+          { text: "Getting started", link: "/guide/getting-started" },
           { text: "Installation", link: "/guide/installation" },
           { text: "Initialization", link: "/guide/initialization" },
           { text: "Updating Mago", link: "/guide/self-update" },
@@ -82,11 +81,11 @@ export default defineConfig({
               { text: "Overview", link: "/tools/formatter/overview" },
               { text: "Usage", link: "/tools/formatter/usage" },
               {
-                text: "Configuration Reference",
+                text: "Configuration reference",
                 link: "/tools/formatter/configuration-reference",
               },
               {
-                text: "Command Reference",
+                text: "Command reference",
                 link: "/tools/formatter/command-reference",
               },
             ],
@@ -137,12 +136,12 @@ export default defineConfig({
               },
               { text: "Integrations", link: "/tools/linter/integrations" },
               {
-                text: "Command Reference",
-                link: "/tools/linter/command-reference",
+                text: "Configuration reference",
+                link: "/tools/linter/configuration-reference",
               },
               {
-                text: "Configuration Reference",
-                link: "/tools/linter/configuration-reference",
+                text: "Command reference",
+                link: "/tools/linter/command-reference",
               },
             ],
           },
@@ -153,23 +152,23 @@ export default defineConfig({
               { text: "Overview", link: "/tools/analyzer/overview" },
               { text: "Usage", link: "/tools/analyzer/usage" },
               {
-                text: "Configuration Reference",
+                text: "Configuration reference",
                 link: "/tools/analyzer/configuration-reference",
               },
               {
-                text: "Command Reference",
+                text: "Command reference",
                 link: "/tools/analyzer/command-reference",
               },
             ],
           },
           {
-            text: "Lexer & Parser",
+            text: "Lexer & parser",
             collapsed: true,
             items: [
               { text: "Overview", link: "/tools/lexer-parser/overview" },
               { text: "Usage", link: "/tools/lexer-parser/usage" },
               {
-                text: "Command Reference",
+                text: "Command reference",
                 link: "/tools/lexer-parser/command-reference",
               },
             ],
@@ -188,7 +187,7 @@ export default defineConfig({
       },
       { text: "🤝 Contributing", link: "/contributing" },
       { text: "⚡️ Benchmarks", link: "/benchmarks" },
-      { text: "⭐ Projects Using Mago", link: "/projects-using-mago" },
+      { text: "⭐ Projects using Mago", link: "/projects-using-mago" },
     ],
 
     socialLinks: [

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -54,10 +54,15 @@
     font-size: 1.25em;
     padding-bottom: 0.3rem;
     text-decoration: underline;
+    text-underline-offset: 6px;
     text-decoration-thickness: 2px;
     text-decoration-color: var(--heading-underline-color);
     margin-top: 2.5rem;
     margin-bottom: 1.25rem;
+}
+
+.VPDoc h3 a {
+  text-decoration: none;
 }
 
 .VPDoc h4 {
@@ -79,6 +84,9 @@
 .dark {
     --heading-text-color: #47a467;
     --heading-underline-color: #1aa0d2;
+
+    --vp-code-bg: #494a4b29;
+    --vp-c-brand-1: #5fbb7f;
 }
 
 @keyframes float {
@@ -128,4 +136,12 @@
 
 .consulting-container p.description {
     margin: 0 auto 1rem auto;
+}
+
+.custom-block {
+  padding: 12px 16px 3px;
+
+  & .custom-block-title + p {
+    margin-top: 2%px;
+  }
 }

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -8,7 +8,7 @@ Performance is a core feature of **Mago**. Every component, from the parser to t
 
 We regularly benchmark Mago against other popular tools in the PHP ecosystem to ensure it remains the fastest toolchain available. The benchmarks below were run against the full `wordpress-develop` codebase.
 
-## Our Performance Promise
+## Our performance promise
 
 At its core, Mago is built on a simple philosophy: **it must be the fastest.**
 
@@ -25,7 +25,7 @@ This benchmark measures the time it takes to check the formatting of an entire c
 | **Mago**   | **362.3ms ± 4.6ms** | **1x**         |
 | Pretty PHP | 35.62s ± 0.06s      | 98.32x slower  |
 
-### Resource Usage
+### Resource usage
 
 | Tool       | Peak Memory (RSS) | CPU Cycles       |
 | :--------- | :---------------- | :--------------- |
@@ -44,7 +44,7 @@ This benchmark measures the time it takes to lint an entire codebase.
 | Pint         | 34.23s ± 0.05s      | 45.89x slower  |
 | PHP-CS-Fixer | 41.81s ± 0.13s      | 56.07x slower  |
 
-### Resource Usage
+### Resource usage
 
 | Tool         | Peak Memory (RSS) | CPU Cycles       |
 | :----------- | :---------------- | :--------------- |
@@ -64,7 +64,7 @@ This benchmark measures the time it takes to perform a full static analysis.
 | Psalm    | 45.42s ± 1.16s    | 11.77x slower  |
 | PHPStan  | 111.43s ± 0.45s   | 28.88x slower  |
 
-### Resource Usage
+### Resource usage
 
 | Tool     | Peak Memory (RSS) | CPU Cycles       |
 | :------- | :---------------- | :--------------- |
@@ -78,7 +78,7 @@ This benchmark measures the time it takes to perform a full static analysis.
 - **Hardware:** MacBook Pro (Apple M1 Pro, 32GB RAM)
 - **PHP:** 8.4.11 (Zend v4.4.11, Zend OPcache v8.4.11)
 
-## A Note on Memory Usage
+## A note on memory usage
 
 You might notice that Mago sometimes uses more memory than other tools, especially on large codebases. This is a
 deliberate and fundamental design choice.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -6,32 +6,32 @@ Thank you for your interest in contributing to **Mago**! We're excited to build 
 
 ---
 
-## Getting Started
+## Getting started
 
 Contributing to open-source can be intimidating, but don't worry! We're here to help you get started. Here is a small checklist to get you going:
 
-1.  **Discuss First:** Before you start coding, please open an issue or comment on an existing one to discuss the changes you plan to make. This helps ensure your work aligns with the project's goals.
+1.  **Discuss first**. Before you start coding, please open an issue or comment on an existing one to discuss the changes you plan to make. This helps ensure your work aligns with the project's goals.
 
-2.  **Fork & Clone:** Fork the repository to your own GitHub account and clone it to your local machine:
+2.  **Fork & clone**. Fork the repository to your own GitHub account and clone it to your local machine:
 
     ```bash
     git clone https://github.com/<your-username>/mago.git
     ```
 
-3.  **Set Up Your Environment:**
+3.  **Set up your environment:**
     - Install [Rust](https://www.rust-lang.org/tools/install)
     - Install [Just](https://github.com/casey/just)
     - Run `just build` to set up the project and install dependencies.
 
-4.  **Create a Branch:** Create a new branch with a descriptive name:
+4.  **Create a branch**. Create a new branch with a descriptive name:
 
     ```bash
     git checkout -b feature/my-awesome-change
     ```
 
-5.  **Make Your Changes:** Implement your changes and follow the coding guidelines.
+5.  **Make your changes**. Implement your changes and follow the coding guidelines.
 
-6.  **Verify Your Changes:** Run the tests and linter to make sure everything is correct and follows our coding standards:
+6.  **Verify your changes**. Run the tests and linter to make sure everything is correct and follows our coding standards:
 
     ```bash
     # Run all tests
@@ -41,19 +41,21 @@ Contributing to open-source can be intimidating, but don't worry! We're here to 
     just lint
     ```
 
-7.  **Commit and Push:** Commit your changes with a descriptive message and push them to your fork:
+7.  **Commit and push**. Commit your changes with a descriptive message and push them to your fork:
 
     ```bash
     git commit -m "feat: add my awesome change"
     git push origin feature/my-awesome-change
     ```
 
-8.  **Submit a Pull Request:** Go to the main [Mago repository](https://github.com/carthage-software/mago) and open a new Pull Request with your changes.
+8.  **Submit a pull request**. Go to the main [Mago repository](https://github.com/carthage-software/mago) and open a new pull request with your changes.
 
 ---
 
-## Submitting Pull Requests
+## Submitting pull requests
 
-- **Tests:** If you're fixing a bug, please add a test case that reproduces it. If you're adding a new feature, ensure it has comprehensive test coverage.
-- **License:** By contributing, you agree that your contributions will be licensed under the dual MIT/Apache-2.0 license.
-- **Security:** To report a security vulnerability, please follow the instructions in our [Security Policy](https://github.com/carthage-software/mago/security/policy).
+If you're fixing a bug, please add a test case that reproduces it. If you're adding a new feature, ensure it has comprehensive test coverage.
+
+By contributing, you agree that your contributions will be licensed under the dual MIT/Apache-2.0 license.
+
+To report a security vulnerability, please follow the instructions in our [Security Policy](https://github.com/carthage-software/mago/security/policy).

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,22 +1,22 @@
 ---
-title: Getting Started
+title: Getting started
 ---
 
-# Getting Started 🚀
+# Getting started 🚀
 
 Welcome to **Mago**! You're about to experience a new level of speed and precision in PHP development tooling.
 
 **Mago** is a complete toolchain for PHP, written in Rust, designed from the ground up for maximum performance. It includes:
 
-- **A Blazing-Fast Formatter:** Automatically formats your code according to PSR-12, ending style debates forever.
-- **An Intelligent Linter:** Catches stylistic issues, inconsistencies, and code smells before they become problems.
-- **A Powerful Static Analyzer:** Finds type errors and logical bugs in your code without you ever having to run it.
+- **A blazing-fast [formatter](../tools/formatter/overview.md)** that automatically formats your code according to PSR-12, ending style debates forever.
+- **An intelligent [linter](../tools/linter/overview.md)** that catches stylistic issues, inconsistencies, and code smells before they become problems.
+- **A powerful static [analyzer](../tools/analyzer/overview.md)** that finds type errors and logical bugs in your code without you ever having to run it.
 
 This guide will walk you through installing Mago and setting it up for your project in just a few minutes.
 
-### Next Steps
+### Next steps
 
 Ready to dive in? Here's where to go next:
 
-- **[Installation](./installation.md)**: Get Mago installed on your system.
-- **[Initialization](./initialization.md)**: Set up a new project with our interactive guide.
+- **[Installation](./installation.md)**: get Mago installed on your system.
+- **[Initialization](./initialization.md)**: set up a new project with our interactive guide.

--- a/docs/guide/initialization.md
+++ b/docs/guide/initialization.md
@@ -1,5 +1,6 @@
 ---
 title: Initialization
+outline: deep
 ---
 
 # Initialization
@@ -12,20 +13,20 @@ When you run it, Mago will guide you through a series of steps:
 mago init
 ```
 
-### Configuration Paths
+## Configuration paths
 
-1.  **Auto-detection (`composer.json`):** If a `composer.json` file is present, Mago will offer to automatically configure your project paths, PHP version, and linter integrations based on its contents. This is the recommended approach for most projects.
+1.  If a `composer.json` file is present, Mago will offer to automatically configure your project paths, PHP version, and linter integrations based on its contents. This is the recommended approach for most projects.
 
-2.  **Manual Setup:** If no `composer.json` is found, or if you prefer to set things up manually, the command will prompt you for:
+2.  If no `composer.json` is found, or if you prefer to set things up manually, the command will prompt you for:
     - Source code paths (`src`, `tests`, etc.)
     - Dependency paths (`vendor`)
     - Paths to exclude
     - PHP version
     - Linter integrations (Symfony, Laravel, etc.)
 
-### Interactive Walkthrough
+## Interactive walkthrough
 
-The command also includes an interactive setup for the Formatter and Analyzer, allowing you to enable powerful features and customize settings right from the start.
+The command also includes an interactive setup for the formatter and analyzer, allowing you to enable powerful features and customize settings right from the start.
 
 Here's an example of what the process looks like:
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,12 +1,13 @@
 ---
 title: Installation
+outline: deep
 ---
 
 # Installation
 
 Installing **Mago** is a quick process with several options to suit your environment and preferences.
 
-## Shell Installer (macOS & Linux)
+## Shell installer (macOS & Linux)
 
 This is the **recommended method** for most macOS and Linux users. Our script automatically downloads the correct binary for your system and adds it to your path.
 
@@ -22,20 +23,20 @@ curl --proto '=https' --tlsv1.2 -sSf https://carthage.software/mago.sh | bash
 wget -qO- https://carthage.software/mago.sh | bash
 ```
 
-## Manual Download
+## Manual download
 
 You can always download a pre-compiled binary directly from our GitHub Releases page. This is the **recommended method for Windows** and a reliable fallback for other systems.
 
-1.  Navigate to the **[Mago Releases Page](https://github.com/carthage-software/mago/releases)**.
+1.  Navigate to the **[Mago releases page](https://github.com/carthage-software/mago/releases)**.
 2.  Download the appropriate archive for your operating system (e.g., `mago-x86_64-pc-windows-msvc.zip` for Windows).
 3.  Unzip the archive.
 4.  Place the `mago.exe` (or `mago`) executable in a directory that is part of your system's `PATH` environment variable.
 
-## Alternative Methods (Package Managers)
+## Package managers
 
-These methods are convenient but may be managed by the community or experience slight publishing delays. If you use Homebrew or Cargo, it is **crucial to run `mago self-update`** immediately after installation.
+These methods are convenient but may be managed by the community or experience slight publishing delays. If you use Homebrew or Cargo, it is **crucial to run [`mago self-update`](./self-update.md)** immediately after installation.
 
-### Composer (PHP Project)
+### Composer (PHP project)
 
 To add Mago as a development dependency to your PHP project via Composer:
 
@@ -45,7 +46,9 @@ composer require --dev carthage-software/mago:1.0.0-beta.3
 
 ### Homebrew (macOS)
 
-> **Warning:** The Homebrew formula for Mago is community-managed and often lags significantly behind official releases. This method is **not recommended** unless you follow it with a self-update.
+:::warning
+ The Homebrew formula for Mago is community-managed and often lags significantly behind official releases. This method is **not recommended** unless you follow it with a [self-update](./self-update.md).
+:::
 
 1.  Install the potentially outdated version from Homebrew:
     ```sh
@@ -58,18 +61,20 @@ composer require --dev carthage-software/mago:1.0.0-beta.3
 
 ### Cargo (Rust)
 
-> **Note:** Publishing to crates.io can sometimes be delayed after a new release.
+:::info
+Publishing to crates.io can sometimes be delayed after a new release.
+:::
 
 1.  Install from Crates.io:
     ```sh
     cargo install mago
     ```
-2.  **Run `mago self-update`** to ensure you have the absolute latest version:
+2.  Run [`mago self-update`](./self-update.md) to ensure you have the absolute latest version:
     ```sh
     mago self-update
     ```
 
-## Verify Installation
+## Verify installation
 
 Once installed, you can verify that Mago is working correctly by checking its version:
 

--- a/docs/guide/self-update.md
+++ b/docs/guide/self-update.md
@@ -6,7 +6,7 @@ title: Updating Mago
 
 Keeping **Mago** up-to-date is simple. We provide a built-in command to handle the entire update process for you, ensuring you always have the latest features and performance improvements.
 
-## Recommended Method (`self-update`)
+## Recommended method
 
 If you installed Mago using the shell script, `brew`, `cargo`, or by manually downloading the binary, the easiest way to update is with the built-in `self-update` command.
 
@@ -34,7 +34,7 @@ composer update carthage-software/mago
 
 This ensures that your project's `composer.lock` file is updated correctly.
 
-## Verifying the Update
+## Checking the current version
 
 After the update process completes, you can verify that you have the latest version by running:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ hero:
     id: mago-logo
   actions:
     - theme: brand
-      text: Get Started
+      text: Get started
       link: /guide/getting-started
     - theme: alt
       text: View on GitHub
@@ -18,18 +18,18 @@ hero:
 
 features:
   - icon: ⚡️
-    title: The Fastest Toolchain
+    title: The fastest toolchain
     details: Mago is engineered from the ground up for maximum performance, leveraging Rust and a parallel pipeline to analyze and format code faster than any other tool.
   - icon: 🛠️
-    title: All-in-One Solution
+    title: All-in-one solution
     details: Get a powerful static analyzer, a configurable linter with auto-fixing, and an opinionated code formatter in a single, cohesive binary.
   - icon: 🎨
-    title: Smart & Opinionated
+    title: Smart & opinionated
     details: With a focus on correctness and modern PHP standards, Mago provides intelligent feedback and consistent formatting to eliminate style debates and prevent bugs.
 ---
 
 <div class="consulting-container">
-  <h2>Professional Consulting</h2>
+  <h2>Professional consulting</h2>
   <p class="description">
     Need expert help with high-performance and high-load PHP applications?
   </p>
@@ -39,6 +39,6 @@ features:
 </div>
 
 <div class="sponsor-container">
-  <h2>Sponsored By</h2>
+  <h2>Sponsored by</h2>
   <p>Your logo here? <a href="https://github.com/sponsors/azjezz" target="_blank" rel="noopener">Become a sponsor!</a></p>
 </div>

--- a/docs/projects-using-mago.md
+++ b/docs/projects-using-mago.md
@@ -1,17 +1,13 @@
 ---
-title: Projects Using Mago
+title: Projects using Mago
 ---
 
 **Mago** is proud to be used by innovative projects in the PHP ecosystem. Here are a few of them:
 
-- **[Tempest PHP Framework](https://github.com/tempestphp/tempest-framework/)**
-  The PHP framework that gets out of your way.
+- **[Tempest](https://github.com/tempestphp/tempest-framework/)** — a PHP framework designed to get out of your way. Its core philosophy is to help you focus on your application code, without being bothered hand-holding the framework.
 
-- **[PHP Standard Library (PSL)](https://github.com/azjezz/psl/)**
-  A modern, consistent, centralized, well-typed, non-blocking set of APIs for PHP programmers.
+- **[PHP Standard Library (PSL)](https://github.com/azjezz/psl/)** — a modern, consistent, centralized, well-typed, non-blocking set of APIs for PHP programmers.
 
----
+## Add your project
 
-## Add Your Project!
-
-Are you using Mago in your project? We'd love to feature you here! Please open a [Pull Request](https://github.com/carthage-software/mago/pulls) to add your project to this list.
+Are you using Mago in your project? We'd love to feature you here! Please open a [pull request](https://github.com/carthage-software/mago/pulls) to add your project to this list.

--- a/docs/recipes/github-actions.md
+++ b/docs/recipes/github-actions.md
@@ -1,12 +1,12 @@
 ---
-title: GitHub Actions Recipe
+title: GitHub Actions recipe
 ---
 
-# 🧩 GitHub Actions Recipe
+# 🧩 GitHub Actions recipe
 
 Automate your code quality checks by running **Mago** directly in your GitHub workflow. This setup will check for formatting and linting errors on every push and pull request, providing direct feedback within GitHub.
 
-## Quick Setup
+## Quick setup
 
 Create a new file at `.github/workflows/mago.yml` and add the following content:
 

--- a/docs/recipes/helix.md
+++ b/docs/recipes/helix.md
@@ -1,8 +1,8 @@
 ---
-title: Helix Editor Recipe
+title: Helix Editor recipe
 ---
 
-# 🧩 Helix Editor Recipe
+# 🧩 Helix editor recipe
 
 Integrate Mago directly with the [Helix editor](https://helix-editor.com/) for fast, reliable, and automatic code formatting.
 

--- a/docs/recipes/vscode.md
+++ b/docs/recipes/vscode.md
@@ -1,8 +1,8 @@
 ---
-title: Visual Studio Code Recipe
+title: Visual Studio Code recipe
 ---
 
-# 🧩 Visual Studio Code Recipe
+# 🧩 Visual Studio Code recipe
 
 Integrate Mago directly into Visual Studio Code for powerful, automatic PHP code formatting.
 
@@ -15,7 +15,7 @@ This guide uses the [Custom Local Formatters](https://marketplace.visualstudio.c
 
 ## Configuration
 
-### Step 1: Install the Extension
+### Install the extension
 
 First, you need to install the bridge extension that allows VS Code to run Mago as a formatter.
 
@@ -23,7 +23,7 @@ First, you need to install the bridge extension that allows VS Code to run Mago 
 2.  Search for `Custom Local Formatters`.
 3.  Install the extension created by **`jkillian`**.
 
-### Step 2: Configure `settings.json`
+### Configure `settings.json`
 
 Next, you'll configure the extension to use Mago and tell VS Code to use it for PHP files.
 
@@ -59,4 +59,4 @@ Next, you'll configure the extension to use Mago and tell VS Code to use it for 
 Your setup is now complete.
 
 - With `editor.formatOnSave` enabled, your PHP files will be automatically formatted by Mago every time you save.
-- You can also manually format a file at any time by opening the Command Palette (`Ctrl+Shift+P`) and running the **Format Document** command.
+- You can also manually format a file at any time by opening the command palette (`Ctrl+Shift+P`) and running the **Format document** command.

--- a/docs/recipes/zed.md
+++ b/docs/recipes/zed.md
@@ -1,8 +1,8 @@
 ---
-title: Zed Editor Recipe
+title: Zed editor recipe
 ---
 
-# 🧩 Zed Editor Recipe
+# 🧩 Zed editor recipe
 
 Integrate Mago directly into the [Zed editor](https://zed.dev) for seamless, high-performance code formatting on save.
 

--- a/docs/tools/analyzer/command-reference.md
+++ b/docs/tools/analyzer/command-reference.md
@@ -1,16 +1,19 @@
 ---
-title: Command Reference
+title: Analyzer command reference
+outline: deep
 ---
 
-# Command Reference
+# Command reference
 
 The `mago analyze` command is the entry point for running Mago's static type checker.
-
-> **Note:** `mago analyse` is a convenient alias for `mago analyze`. Both can be used interchangeably.
 
 ```sh
 Usage: mago analyze [OPTIONS] [PATHS]...
 ```
+
+:::tip
+`mago analyse` is a convenient alias for `mago analyze`. Both can be used interchangeably.
+:::
 
 ## Arguments
 

--- a/docs/tools/analyzer/configuration-reference.md
+++ b/docs/tools/analyzer/configuration-reference.md
@@ -1,10 +1,10 @@
 ---
-title: Configuration Reference
+title: Analyzer configuration Reference
 ---
 
-# Configuration Reference
+# Configuration reference
 
-The **Mago** Analyzer is highly configurable, allowing you to tailor the analysis to your project's specific needs. All settings go under the `[analyzer]` table in your `mago.toml` file.
+**Mago**'s analyzer is highly configurable, allowing you to tailor the analysis to your project's specific needs. All settings go under the `[analyzer]` table in your `mago.toml` file.
 
 ```toml
 [analyzer]
@@ -15,14 +15,14 @@ redundancy-issues = false
 ignore = ["mixed-argument"]
 ```
 
-## General Options
+## General options
 
 | Option     | Type       | Default | Description                                        |
 | :--------- | :--------- | :------ | :------------------------------------------------- |
 | `excludes` | `string[]` | `[]`    | A list of glob patterns to exclude from analysis.  |
 | `ignore`   | `string[]` | `[]`    | A list of specific issue codes to ignore globally. |
 
-## Issue Categories
+## Issue categories
 
 You can enable or disable entire categories of issues. All categories are enabled by default.
 
@@ -48,7 +48,7 @@ You can enable or disable entire categories of issues. All categories are enable
 | `method-issues`        | `true`  | Report issues related to methods and their usage.             |
 | `iterator-issues`      | `true`  | Report issues related to iterators and their usage.           |
 
-## Feature Flags
+## Feature flags
 
 These flags control specific, powerful analysis capabilities.
 

--- a/docs/tools/analyzer/overview.md
+++ b/docs/tools/analyzer/overview.md
@@ -25,7 +25,7 @@ If your code were an essay, the **linter** would be the grammar and style checke
 - **Comprehensive checks** — Catches a wide range of issues, from simple null pointer risks to complex logical errors.
 - **Heuristic engine** — Provides advice on code quality issues that aren't strict errors but could indicate potential bugs.
 
-## Dive Iin
+## Dive in
 
 - **[Usage](./usage.md)**: learn how to run the analyzer.
 - **[Configuration reference](./configuration-reference.md)**: see all the available options to customize the analysis.

--- a/docs/tools/analyzer/overview.md
+++ b/docs/tools/analyzer/overview.md
@@ -1,30 +1,32 @@
 ---
-title: The Mago Analyzer
+title: The analyzer
 ---
 
-# The Mago Analyzer 🔬
+# Mago's analyzer 🔬
 
-The **Mago** Analyzer is a powerful static analysis engine that finds logical errors, type mismatches, and potential bugs in your code _before_ you run it. It's the core of Mago's ability to ensure your code is not just well-styled, but also correct and robust.
+**Mago**'s analyzer is a powerful static analysis engine that finds logical errors, type mismatches, and potential bugs in your code _before_ you run it. It's the core of Mago's ability to ensure your code is not just well-styled, but also correct and robust.
 
-## Analyzer vs. Linter: What's the Difference?
+## Analyzer vs. linter: what's the difference?
 
-While they both find issues, the Analyzer and the Linter operate at different levels of understanding.
+While they both find issues, the analyzer and the linter operate at different levels of understanding.
 
-- **The Linter is a Style Editor:** It looks at the _structure_ of your code. It checks for stylistic issues, inconsistencies, and code smells (e.g., "this `if` statement has no `else`"). It doesn't know what your code _does_.
+- **The linter is a style editor**. It looks at the _structure_ of your code. It checks for stylistic issues, inconsistencies, and code smells (e.g., "this `if` statement has no `else`"). It doesn't know what your code _does_.
 
-- **The Analyzer is a Fact-Checker:** It builds a deep, semantic understanding of your entire codebase. It knows what types your functions return, what properties your classes have, and what exceptions can be thrown. It finds logical impossibilities (e.g., "you're calling a method that doesn't exist on this object").
+- **The analyzer is a fact-checker**. It builds a deep, semantic understanding of your entire codebase. It knows what types your functions return, what properties your classes have, and what exceptions can be thrown. It finds logical impossibilities (e.g., "you're calling a method that doesn't exist on this object").
 
-> **Analogy:** If your code were an essay, the **Linter** would be the grammar and style checker, while the **Analyzer** would be the editor who checks your facts and ensures your arguments are logical.
+:::tip Analogy
+If your code were an essay, the **linter** would be the grammar and style checker, while the **analyzer** would be the editor who checks your facts and ensures your arguments are logical.
+:::
 
-## Key Features
+## Key features
 
-- **🚀 Blazing Fast:** Written in Rust and highly parallelized to analyze large codebases in seconds.
-- **Deep Type Inference:** Understands your code's types, even without full type hinting.
-- **Comprehensive Checks:** Catches a wide range of issues, from simple null pointer risks to complex logical errors.
-- **Heuristic Engine:** Provides advice on code quality issues that aren't strict errors but could indicate potential bugs.
+- **🚀 Blazing fast** — Written in Rust and highly parallelized to analyze large codebases in seconds.
+- **Deep type inference** — Understands your code's types, even without full type hinting.
+- **Comprehensive checks** — Catches a wide range of issues, from simple null pointer risks to complex logical errors.
+- **Heuristic engine** — Provides advice on code quality issues that aren't strict errors but could indicate potential bugs.
 
-## Dive In
+## Dive Iin
 
-- **[Usage](./usage.md)**: Learn how to run the analyzer.
-- **[Configuration Reference](./configuration-reference.md)**: See all the available options to customize the analysis.
-- **[Command Reference](./command-reference.md)**: A detailed guide to the `mago analyze` command and its flags.
+- **[Usage](./usage.md)**: learn how to run the analyzer.
+- **[Configuration reference](./configuration-reference.md)**: see all the available options to customize the analysis.
+- **[Command reference](./command-reference.md)**: a detailed guide to the `mago analyze` command and its flags.

--- a/docs/tools/analyzer/usage.md
+++ b/docs/tools/analyzer/usage.md
@@ -1,12 +1,12 @@
 ---
-title: Usage
+title: Analyzer usage
 ---
 
-# Using the Mago Analyzer
+# Using the analyzer
 
 The `mago analyze` command is your primary tool for running a deep, type-level analysis on your project.
 
-## Analyzing Your Project
+## Analyzing your project
 
 To analyze all the source files defined in your `mago.toml` configuration, simply run:
 
@@ -16,7 +16,7 @@ mago analyze
 
 Mago will first compile a model of your entire codebase (including dependencies and stubs) and then analyze your source files in parallel, reporting any issues it finds.
 
-## Analyzing Specific Files
+## Analyzing specific files
 
 You can also analyze specific files or directories by passing them as arguments. This will override the `paths` in your configuration for this run.
 
@@ -28,7 +28,7 @@ mago analyze src/Services/UserService.php
 mago analyze src/Controller/
 ```
 
-## Working with a Baseline
+## Working with a baseline
 
 When introducing Mago to an existing project, you might have a large number of pre-existing issues. A "baseline" allows you to ignore these for now and focus only on new issues in new code.
 
@@ -46,7 +46,7 @@ To use a baseline, simply run the analyzer as usual. Mago will automatically det
 mago analyze --baseline /path/to/your/baseline.php
 ```
 
-## Disabling Stubs
+## Disabling stubs
 
 By default, Mago loads a "prelude" of stubs for PHP's built-in functions and classes. If you wish to disable this for any reason, you can use the `--no-stubs` flag. Note that this may lead to a large number of "symbol not found" errors if your code uses standard PHP features.
 

--- a/docs/tools/formatter/command-reference.md
+++ b/docs/tools/formatter/command-reference.md
@@ -1,20 +1,23 @@
 ---
-title: Command Reference
+title: Formatter command reference
+outline: deep
 ---
 
-# Command Reference
+# Command reference
 
 The `mago format` command is the entry point for all formatting-related tasks.
-
-> **Note:** `mago fmt` is a convenient alias for `mago format`. Both can be used interchangeably.
 
 ```sh
 Usage: mago format [OPTIONS] [PATH]...
 ```
 
-### Arguments
+:::info
+`mago fmt` is a convenient alias for `mago format`. Both can be used interchangeably.
+:::
 
-##### `[PATH]...`
+## Arguments
+
+#### `[PATH]...`
 
 Optional. A list of specific files or directories to format. If you provide paths here, they will be used instead
 of the `paths` defined in your `mago.toml` configuration.
@@ -24,13 +27,13 @@ of the `paths` defined in your `mago.toml` configuration.
 mago fmt src/index.php tests/
 ```
 
-### Options
+## Options
 
-#### `-d`, `--dry-run`
+### `-d`, `--dry-run`
 
 Perform a "dry run". This will calculate and print a diff of all changes that would be made to your files without actually modifying them.
 
-#### `-c`, `--check`
+### `-c`, `--check`
 
 Check if the source files are formatted correctly. This is the ideal flag for CI environments. The command will:
 
@@ -39,7 +42,7 @@ Check if the source files are formatted correctly. This is the ideal flag for CI
 
 It does not modify any files or print any output to `stdout` on success.
 
-#### `-i`, `--stdin-input`
+### `-i`, `--stdin-input`
 
 Read source code from `stdin`, format it, and print the result to `stdout`. This is useful for editor integrations.
 
@@ -47,6 +50,6 @@ Read source code from `stdin`, format it, and print the result to `stdout`. This
 echo "<?php\necho 'hello world';" | mago fmt --stdin-input
 ```
 
-#### `-h`, `--help`
+### `-h`, `--help`
 
 Display help information about the `mago format` command.

--- a/docs/tools/formatter/configuration-reference.md
+++ b/docs/tools/formatter/configuration-reference.md
@@ -1,10 +1,10 @@
 ---
-title: Configuration Reference
+title: Formatter configuration reference
 ---
 
-# Configuration Reference
+# Configuration reference
 
-While the **Mago** Formatter is opinionated and works great out of the box with its PSR-12 compliant defaults, you can customize its behavior in your `mago.toml` file.
+While **Mago**'s formatter is opinionated and works great out-of-the-box with its PSR-12 compliant defaults, you can customize its behavior in your `mago.toml` file.
 
 All settings go under the `[formatter]` table.
 
@@ -14,7 +14,7 @@ print-width = 100
 use-tabs = true
 ```
 
-## Configuration Options
+## Configuration options
 
 | Option | Type | Default | Description |
 | :--- | :--- | :--- | :--- |

--- a/docs/tools/formatter/overview.md
+++ b/docs/tools/formatter/overview.md
@@ -1,14 +1,14 @@
 ---
-title: The Mago Formatter
+title: The formatter
 ---
 
-# The Mago Formatter ✨
+# Mago's formatter ✨
 
-The **Mago** Formatter is a powerful, opinionated code formatter for PHP that ensures your entire codebase adheres to a single, consistent style.
+**Mago**'s formatter is a powerful, opinionated code formatter for PHP that ensures your entire codebase adheres to a single, consistent style.
 
 Its primary goal is to end debates over code style. By automating the formatting process, it allows you and your team to stop worrying about whitespace and focus on what truly matters: building great software.
 
-## How It Works
+## How it works
 
 Mago takes a "parse-and-reprint" approach, inspired by modern formatters like Prettier and `rustfmt`.
 
@@ -18,14 +18,14 @@ Mago takes a "parse-and-reprint" approach, inspired by modern formatters like Pr
 
 This process guarantees that the output is always 100% consistent, regardless of the input style. Most importantly, it does this without ever changing the behavior of your code.
 
-## Key Features
+## Key features
 
-- **🚀 Blazing Fast:** Written in Rust for maximum performance, making it one of the fastest PHP formatters available.
-- **Opinionated & Consistent:** Ends style debates by enforcing a single, unified coding style across your entire project.
-- **PSR-12 Compliant:** Follows the widely accepted PSR-12 coding standard.
-- **Safe:** The formatter is designed to never alter the runtime behavior of your code.
+- **Blazing fast** — Written in Rust for maximum performance, making it one of the fastest PHP formatters available.
+- **Opinionated & consistent** — Ends style debates by enforcing a single, unified coding style across your entire project.
+- **PSR-12 compliant** — Follows the widely accepted PSR-12 coding standard.
+- **Safe** — The formatter is designed to never alter the runtime behavior of your code.
 
-## Dive In
+## Dive in
 
-- **[Usage](./usage.md)**: Learn how to run the formatter from the command line.
-- **[Configuration Reference](./configuration-reference.md)**: See all the available options to customize the formatter's behavior.
+- **[Usage](./usage.md)**: learn how to run the formatter from the command line.
+- **[Configuration reference](./configuration-reference.md)**: see all the available options to customize the formatter's behavior.

--- a/docs/tools/formatter/usage.md
+++ b/docs/tools/formatter/usage.md
@@ -1,12 +1,12 @@
 ---
-title: Usage
+title: Formatter usage
 ---
 
-# Using the Mago Formatter
+# Using the formatter
 
-The **Mago** Formatter is designed to be simple to run. You can format your entire project, specific directories, or even code piped from `stdin`.
+**Mago**'s formatter is designed to be simple to run. You can format your entire project, specific directories, or even code piped from `stdin`.
 
-## Formatting Your Project
+## Formatting your project
 
 To format all the source files defined in your `mago.toml` configuration, simply run:
 
@@ -16,9 +16,9 @@ mago fmt
 
 This command will find all relevant files and overwrite them in place with the formatted version.
 
-## Checking for Formatting Issues
+## Checking for formatting issues
 
-In a Continuous Integration (CI) environment, you'll want to check if files are formatted correctly
+In a continuous integration environment, you'll want to check if files are formatted correctly
 without actually changing them. The `--check` flag is perfect for this.
 
 ```sh
@@ -29,7 +29,7 @@ This command will exit with a success code (`0`) if all files are correctly form
 and a failure code (`1`) if any files would be changed. No output is printed on success, making it ideal
 for scripts.
 
-## Previewing Changes
+## Previewing changes
 
 If you want to see what changes the formatter would make without modifying any files,
 use the `--dry-run` flag.
@@ -40,7 +40,7 @@ mago fmt --dry-run
 
 This will print a diff of all proposed changes to your console.
 
-## Formatting Specific Directories or Files
+## Formatting specific directories or files
 
 You can also format specific files or directories by passing them as arguments:
 

--- a/docs/tools/lexer-parser/command-reference.md
+++ b/docs/tools/lexer-parser/command-reference.md
@@ -1,8 +1,9 @@
 ---
-title: Command Reference
+title: Lexer and parser command reference
+outline: deep
 ---
 
-# Command Reference
+# Command reference
 
 The `mago ast` command is a powerful inspection tool that tokenizes and parses a single PHP file, giving you insight into its lexical and syntactical structure.
 

--- a/docs/tools/lexer-parser/overview.md
+++ b/docs/tools/lexer-parser/overview.md
@@ -1,13 +1,13 @@
 ---
-title: Lexer & Parser 🧠
+title: The lexer & parser
 ---
 
-# The Mago Lexer & Parser 🧠
+# Mago's lexer and parser 🧠
 
-At the heart of **Mago** lies its high-performance, resilient Lexer and Parser. These are the foundational components that turn your raw PHP source code into a structured representation that all of Mago's other tools can understand.
+At the heart of **Mago** lies its high-performance, resilient lexer and parser. These are the foundational components that turn your raw PHP source code into a structured representation that all of Mago's other tools can understand.
 
-- **The Lexer (Tokenizer):** Scans your code and breaks it down into a stream of individual "tokens" (e.g., `OpenTag`, `LiteralString`, `Whitespace`).
-- **The Parser:** Takes the stream of tokens from the lexer and assembles them into a hierarchical **Abstract Syntax Tree (AST)** that represents the code's structure.
+- **The lexer (tokenizer)** scans your code and breaks it down into a stream of individual "tokens" (e.g., `OpenTag`, `LiteralString`, `Whitespace`).
+- **The parser** takes the stream of tokens from the lexer and assembles them into a hierarchical **Abstract Syntax Tree (AST)** that represents the code's structure.
 
 While these components are mostly used internally, Mago exposes them through the `mago ast` command. This is an incredibly powerful tool for:
 
@@ -15,9 +15,9 @@ While these components are mostly used internally, Mago exposes them through the
 - Understanding exactly how PHP interprets a piece of syntax.
 - Integrating with other tools that need a robust PHP parser, delegating the hard work to Mago.
 
-## For Rust Developers
+## For Rust developers
 
 If you're building your own tools in Rust and need a high-performance PHP parser, you can use Mago's core crates directly:
 
-- **[`mago-syntax`](https://crates.io/crates/mago-syntax):** The crate containing the Lexer, Parser, and all AST node definitions, along with utilities for working with the AST.
-- **[`mago-names`](https://crates.io/crates/mago-names):** The crate for resolving symbol names (e.g., turning a local class name into its fully qualified name).
+- **[`mago-syntax`](https://crates.io/crates/mago-syntax):** the crate containing the lexer, parser, and all AST node definitions, along with utilities for working with the AST.
+- **[`mago-names`](https://crates.io/crates/mago-names):** the crate for resolving symbol names (e.g., turning a local class name into its fully qualified name).

--- a/docs/tools/lexer-parser/usage.md
+++ b/docs/tools/lexer-parser/usage.md
@@ -1,8 +1,8 @@
 ---
-title: Usage
+title: Lexer and parser usage
 ---
 
-# Using Mago's Lexer and Parser
+# Using Mago's lexer and parser
 
 The primary way to interact with Mago's parser is through the `mago ast` command. It takes a single PHP file and can output its structure in several different formats.
 
@@ -14,7 +14,7 @@ Let's consider a simple file, `example.php`:
 echo 'Hello, World!';
 ```
 
-### Default Tree View
+### Default tree view
 
 By default, `mago ast` prints a human-readable tree that visualizes the Abstract Syntax Tree (AST).
 
@@ -38,7 +38,7 @@ Program
         └── Terminator ;
 ```
 
-### Token View
+### Token view
 
 To see the raw token stream from the lexer, use the `--tokens` flag. This is useful for debugging low-level syntax issues.
 
@@ -60,7 +60,7 @@ This will output a table of all tokens found in the file:
   Whitespace                "\n"                                               [29..29]
 ```
 
-### JSON Output
+### JSON output
 
 For machine-readable output, you can combine the `--json` flag with either the default AST view or the `--tokens` view. This is perfect for scripting or for other tools to consume Mago's output.
 

--- a/docs/tools/linter/command-reference.md
+++ b/docs/tools/linter/command-reference.md
@@ -1,8 +1,9 @@
 ---
-title: Command Reference
+title: Linter command reference
+outline: deep
 ---
 
-# Command Reference
+# Command reference
 
 The `mago lint` command is the entry point for all linting-related tasks.
 
@@ -38,13 +39,15 @@ Run only a specific, comma-separated list of rules, overriding the configuration
 
 Enable all linter rules for the most exhaustive analysis possible. This overrides your configuration, ignores PHP version constraints, and enables rules that are disabled by default.
 
-> **Warning:** This mode is extremely noisy, not recommended for general use.
+:::warning
+This mode is extremely noisy, not recommended for general use.
+:::
 
 ### `-s`, `--semantics`
 
 Perform only the parsing and basic semantic checks without running any lint rules.
 
-### Auto-Fixing
+### Auto-fixing
 
 | Flag | Description |
 | :--- | :--- |

--- a/docs/tools/linter/configuration-reference.md
+++ b/docs/tools/linter/configuration-reference.md
@@ -1,10 +1,10 @@
 ---
-title: Configuration Reference
+title: Linter configuration reference
 ---
 
-# Configuration Reference
+# Configuration reference
 
-The **Mago** Linter is configured in your `mago.toml` file under the `[linter]` and `[linter.rules]` tables.
+**Mago**'s linter is configured in your `mago.toml` file under the `[linter]` and `[linter.rules]` tables.
 
 ```toml
 # Example linter configuration
@@ -23,26 +23,25 @@ no-else-clause = { level = "warning" }
 cyclomatic-complexity = { threshold = 20 }
 ```
 
-## `[linter]` Table
+## `[linter]`
 
 | Option         | Type       | Default | Description                                                                  |
 | :------------- | :--------- | :------ | :--------------------------------------------------------------------------- |
 | `excludes`     | `string[]` | `[]`    | A list of glob patterns to exclude from linting.                             |
 | `integrations` | `string[]` | `[]`    | A list of framework integrations to enable (e.g., `"symfony"`, `"laravel"`). |
 
-## `[linter.rules]` Table
+## `[linter.rules]`
 
 This table allows you to configure individual lint rules. Each key is the rule's code (in `kebab-case`).
 
-### Common Rule Options
+### Common rule options
 
 All rules accept two common options:
 
 - `enabled`: A boolean (`true` or `false`) to enable or disable the rule.
 - `level`: A string to set the issue severity. Options are `"error"`, `"warning"`, `"help"`, and `"note"`.
 
-### Rule-Specific Options
-
+### Rule-specific options
 Some rules have additional configuration options. For example, `cyclomatic-complexity` has a `threshold`:
 
 ```toml

--- a/docs/tools/linter/integrations.md
+++ b/docs/tools/linter/integrations.md
@@ -1,18 +1,24 @@
 ---
-title: Integrations
+title: Linter integrations
 ---
 
 # Integrations
 
-**Mago** includes specialized sets of linting rules designed for popular PHP frameworks and libraries. These "integrations" allow Mago to provide more intelligent and context-aware feedback for your specific stack.
+**Mago** includes specialized sets of linting rules designed for popular PHP frameworks and libraries. These integrations allow Mago to provide more intelligent and context-aware feedback for your specific stack.
 
 When an integration is enabled, Mago will automatically activate all the rules associated with it. You can still configure or disable individual rules from an integration in your `[linter.rules]` table if needed.
 
-## Available Integrations
+## Available integrations
 
-Mago is built with the broader PHP ecosystem in mind and includes support for a wide range of tools.
+Mago is built with the broader PHP ecosystem in mind and includes support for a wide range of tools. Currently, the linter has rules dedicated to:
+- Laravel
+- PHPUnit
+- PSL
+- Symfony
 
-> **Note:** While many integrations are listed below for future support, only **Laravel**, **PHPUnit**, **PSL**, and **Symfony** currently have specialized rules. Rules for other integrations are planned for future releases.
+## Future integrations
+
+The following integrations are planned for future releases:
 
 ### Frameworks
 
@@ -34,7 +40,7 @@ Mago is built with the broader PHP ecosystem in mind and includes support for a 
 - PSL (PHP Standard Library)
 - ReactPHP
 
-### Testing Frameworks
+### Testing frameworks
 
 - Behat
 - Codeception
@@ -53,7 +59,7 @@ Mago is built with the broader PHP ecosystem in mind and includes support for a 
 - Cycle
 - Doctrine
 
-## Enabling Integrations
+## Enabling integrations
 
 You can enable integrations in your `mago.toml` file under the `[linter]` table.
 

--- a/docs/tools/linter/overview.md
+++ b/docs/tools/linter/overview.md
@@ -1,28 +1,30 @@
 ---
-title: The Mago Linter
+title: The linter
 ---
 
-# The Mago Linter 🔎
+# Mago's linter 🔎
 
-The **Mago** Linter is a blazing-fast tool for finding and fixing stylistic issues, inconsistencies, and code smells in your PHP code. It helps you maintain a clean, readable, and consistent codebase with minimal effort.
+**Mago**'s linter is a blazing-fast tool for finding and fixing stylistic issues, inconsistencies, and code smells in your PHP code. It helps you maintain a clean, readable, and consistent codebase with minimal effort.
 
-## Linter vs. Analyzer
+## Linter vs. analyzer
 
-While they both find issues, the Analyzer and the Linter operate at different levels of understanding.
+While they both find issues, the analyzer and the linter operate at different levels of understanding.
 
-- **The Linter is a Style Editor:** It looks at the _structure_ of your code. It enforces your team's coding standards, flags redundant code, and suggests more modern syntax. It doesn't know what your code _does_, only what it _looks like_.
+- **The linter is a style editor**. It looks at the _structure_ of your code. It enforces your team's coding standards, flags redundant code, and suggests more modern syntax. It doesn't know what your code _does_, only what it _looks like_.
 
-- **The Analyzer is a Fact-Checker:** It builds a deep, semantic understanding of your entire codebase. It knows what types your functions return, what properties your classes have, and what exceptions can be thrown. It finds logical impossibilities (e.g., "you're calling a method that doesn't exist on this object").
+- **The analyzer is a fact-checker.** It builds a deep, semantic understanding of your entire codebase. It knows what types your functions return, what properties your classes have, and what exceptions can be thrown. It finds logical impossibilities (e.g., "you're calling a method that doesn't exist on this object").
 
-> **Analogy:** If your code were an essay, the **Linter** would be the grammar and style checker, while the **Analyzer** would be the editor who checks your facts and ensures your arguments are logical.
+:::info Analogy
+If your code were an essay, the **linter** would be the grammar and style checker, while the **analyzer** would be the editor who checks your facts and ensures your arguments are logical.
+:::
 
-## The Semantic Checker
+## The semantic checker
 
-Mago processes files in three stages: **Parse** -> **Semantic Check** -> **Lint**.
+Mago processes files in three stages: **Parse** -> **Semantic check** -> **Lint**.
 
-The Mago parser is intentionally tolerant—it can parse syntax that the standard PHP compiler would reject, like features from a future PHP version.
+Mago's parser is intentionally tolerant—it can parse syntax that the standard PHP compiler would reject, like features from a future PHP version.
 
-The **Semantic Checker** is the crucial second step. Its job is to find syntax errors that Mago's parser allows but PHP would consider fatal. This includes things like:
+The **semantic checker** is the crucial second step. Its job is to find syntax errors that Mago's parser allows but PHP would consider fatal. This includes things like:
 
 - Invalid enum backing types (`enum Foo: array {}`)
 - Using features not available in your configured PHP version (e.g., property hooks in PHP 8.1).
@@ -35,17 +37,17 @@ mago lint -s
 
 This makes it a faster and more powerful replacement for `php -l`, allowing you to quickly validate the basic correctness of your files. It's a great way to start introducing Mago to your codebase incrementally.
 
-## Key Features
+## Key features
 
-- **🚀 Blazing Fast:** Written in Rust and built on a high-performance arena allocator, making it **_the fastest_** PHP linter available.
-- **Highly Configurable:** Every rule can be enabled, disabled, or have its severity level adjusted.
-- **Auto-Fixing:** Many rules provide automatic fixes that can be applied with the `--fix` flag.
-- **Framework Integrations:** Includes specialized rules for frameworks like Symfony, Laravel, and PHPUnit.
+- **Blazing fast** — Written in Rust and built on a high-performance arena allocator, making it **_the fastest_** PHP linter available.
+- **Highly configurable** — Every rule can be enabled, disabled, or have its severity level adjusted.
+- **Auto-fixing** — Many rules provide automatic fixes that can be applied with the `--fix` flag.
+- **Framework integrations** — Includes specialized rules for frameworks like Symfony, Laravel, and PHPUnit.
 
 ## Dive In
 
-- **[Usage](./usage.md)**: Learn how to run the linter from the command line.
-- **[Integrations](./integrations.md)**: Enable framework-specific checks.
-- **[Rules & Categories](./rules-and-categories.md)**: Discover all available rules.
-- **[Configuration Reference](./configuration-reference.md)**: See all the available settings.
-- **[Command Reference](./command-reference.md)**: A detailed guide to the `mago lint` command.
+- **[Usage](./usage.md)**: learn how to run the linter from the command line.
+- **[Integrations](./integrations.md)**: enable framework-specific checks.
+- **[Rules & categories](./rules-and-categories.md)**: discover all available rules.
+- **[Configuration reference](./configuration-reference.md)**: see all the available settings.
+- **[Command reference](./command-reference.md)**: a detailed guide to the `mago lint` command.

--- a/docs/tools/linter/rules-and-categories.md
+++ b/docs/tools/linter/rules-and-categories.md
@@ -1,13 +1,13 @@
 ---
 sidebar_position: 3
-title: Rules & Categories
+title: Rules & categories
 ---
 
-# Rules & Categories
+# Rules & categories
 
-The **Mago** Linter comes with a wide variety of rules, each designed to catch a specific type of issue.
+**Mago**'s linter comes with a wide variety of rules, each designed to catch a specific type of issue.
 
-## Rule Categories
+## Rule categories
 
 - [BestPractices](./rules/best-practices)
 - [Clarity](./rules/clarity)
@@ -19,7 +19,7 @@ The **Mago** Linter comes with a wide variety of rules, each designed to catch a
 - [Safety](./rules/safety)
 - [Security](./rules/security)
 
-## Integration-Specific Rules
+## Integration-specific rules
 
 
 ### Laravel

--- a/docs/tools/linter/rules/best-practices.md
+++ b/docs/tools/linter/rules/best-practices.md
@@ -1,12 +1,11 @@
 ---
-title: BestPractices Rules
+title: BestPractices rules
+outline: [2, 3]
 ---
 
-# BestPractices Rules
+# BestPractices rules
 
 This document details the rules available in the `BestPractices` category.
-
-## Available Rules
 
 | Rule | Code |
 | :--- | :---------- |
@@ -30,7 +29,6 @@ This document details the rules available in the `BestPractices` category.
 | Psl String Functions | [`psl-string-functions`](#psl-string-functions) |
 | Use Compound Assignment | [`use-compound-assignment`](#use-compound-assignment) |
 
----
 
 ## <a id="combine-consecutive-issets"></a>`combine-consecutive-issets`
 
@@ -51,7 +49,7 @@ the rule will still warn, but it will not attempt an automated fix.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -61,7 +59,7 @@ if (isset($a, $b)) {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -89,7 +87,7 @@ since they give the impression of iteration but never actually do so.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -102,7 +100,7 @@ for ($i = 0; $i < 3; $i++) {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -133,7 +131,7 @@ Middlewares should be applied in the routes file, not in the controller.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -142,7 +140,7 @@ Middlewares should be applied in the routes file, not in the controller.
 Route::get('/user', 'UserController@index')->middleware('auth');
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -179,7 +177,7 @@ harder to see at a glance.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -188,7 +186,7 @@ $name = 'World';
 $greeting = sprintf('Hello, %s!', $name);
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -218,7 +216,7 @@ making them the recommended approach for migrations.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -243,7 +241,7 @@ return new class extends Migration {
 };
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -282,7 +280,7 @@ This improves readability by reducing boilerplate code.
 
 ### Requirements
 
-- **PHP Version:** PHP `>= 8.1.0`
+- **PHP version:** PHP `>= 8.1.0`
 
 ### Configuration
 
@@ -293,7 +291,7 @@ This improves readability by reducing boilerplate code.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -302,7 +300,7 @@ $names = ['Alice', 'Bob', 'Charlie'];
 $uppercased_names = array_map(strtoupper(...), $names);
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -330,7 +328,7 @@ Detects when an implementation class is used instead of the interface.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -346,7 +344,7 @@ class UserController
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -384,7 +382,7 @@ Using the array parameter directly is more concise and readable.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -395,7 +393,7 @@ return view('user.profile', [
 ]);
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -423,7 +421,7 @@ initializations or increments. This can make the code more readable and concise.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -435,7 +433,7 @@ while ($i < 10) {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -467,7 +465,7 @@ Psl array functions are preferred because they are type-safe and provide more co
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -475,7 +473,7 @@ Psl array functions are preferred because they are type-safe and provide more co
 $filtered = Psl\Vec\filter($xs, fn($x) => $x > 2);
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -504,7 +502,7 @@ Psl data structures are preferred because they are type-safe and provide more co
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -516,7 +514,7 @@ use Psl\DataStructure\Stack;
 $stack = new Stack();
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -547,7 +545,7 @@ Psl DateTime classes and functions are preferred because they are type-safe and 
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -555,7 +553,7 @@ Psl DateTime classes and functions are preferred because they are type-safe and 
 $dateTime = new Psl\DateTime\DateTime();
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -583,7 +581,7 @@ Psl math functions are preferred because they are type-safe and provide more con
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -591,7 +589,7 @@ Psl math functions are preferred because they are type-safe and provide more con
 $abs = Psl\Math\abs($number);
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -619,7 +617,7 @@ Psl output functions are preferred because they are type-safe and provide more c
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -627,7 +625,7 @@ Psl output functions are preferred because they are type-safe and provide more c
 Psl\IO\write_line("Hello, world!");
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -656,7 +654,7 @@ Psl randomness functions are preferred because they are type-safe and provide mo
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -664,7 +662,7 @@ Psl randomness functions are preferred because they are type-safe and provide mo
 $randomInt = Psl\SecureRandom\int(0, 10);
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -693,7 +691,7 @@ Psl regex functions are preferred because they are type-safe and provide more co
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -701,7 +699,7 @@ Psl regex functions are preferred because they are type-safe and provide more co
 $result = Psl\Regex\matches('Hello, World!', '/\w+/');
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -731,7 +729,7 @@ and allow other tasks within the event loop to continue executing while the curr
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -742,7 +740,7 @@ use Psl\DateTime;
 Async\sleep(DateTime\Duration::seconds(1));
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -771,7 +769,7 @@ Psl string functions are preferred because they are type-safe and provide more c
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -779,7 +777,7 @@ Psl string functions are preferred because they are type-safe and provide more c
 $capitalized = Psl\Str\capitalize($string);
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -808,7 +806,7 @@ creating an intermediate copy of the string.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -817,7 +815,7 @@ $count += 1;
 $message .= ' Hello';
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php

--- a/docs/tools/linter/rules/clarity.md
+++ b/docs/tools/linter/rules/clarity.md
@@ -1,12 +1,11 @@
 ---
-title: Clarity Rules
+title: Clarity rules
+outline: [2, 3]
 ---
 
-# Clarity Rules
+# Clarity rules
 
 This document details the rules available in the `Clarity` category.
-
-## Available Rules
 
 | Rule | Code |
 | :--- | :---------- |
@@ -22,7 +21,6 @@ This document details the rules available in the `Clarity` category.
 | Tagged TODO | [`tagged-todo`](#tagged-todo) |
 | Valid Docblock | [`valid-docblock`](#valid-docblock) |
 
----
 
 ## <a id="explicit-octal"></a>`explicit-octal`
 
@@ -31,7 +29,7 @@ Detects implicit octal numeral notation and suggests replacing it with explicit 
 
 ### Requirements
 
-- **PHP Version:** PHP `>= 8.1.0`
+- **PHP version:** PHP `>= 8.1.0`
 
 ### Configuration
 
@@ -42,7 +40,7 @@ Detects implicit octal numeral notation and suggests replacing it with explicit 
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -50,7 +48,7 @@ Detects implicit octal numeral notation and suggests replacing it with explicit 
 $a = 0o123;
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -71,7 +69,7 @@ where the intent is often ambiguous without the parameter name.
 
 ### Requirements
 
-- **PHP Version:** PHP `>= 8.0.0`
+- **PHP version:** PHP `>= 8.0.0`
 
 ### Configuration
 
@@ -82,7 +80,7 @@ where the intent is often ambiguous without the parameter name.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -92,7 +90,7 @@ function set_option(string $key, bool $enable_feature) {}
 set_option(key: 'feature_x', enable_feature: true); // ✅ clear intent
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -122,7 +120,7 @@ developer's intent or expectation, making it preferable to use explicit checks.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -132,7 +130,7 @@ if ($myArray === []) {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -162,7 +160,7 @@ tools that expect the normal ASCII `#` symbol.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -173,7 +171,7 @@ tools that expect the normal ASCII `#` symbol.
 class Foo {}
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -201,7 +199,7 @@ confusion and unexpected behavior, and is generally considered poor practice.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -210,7 +208,7 @@ $b = 0;
 $a = $b;
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -236,7 +234,7 @@ Both shorthand ternary operator (`$a ? : $b`) and elvis operator (`$a ?: $b`) re
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -245,7 +243,7 @@ $value = $foo ?? $default;
 $value = $foo ? $foo : $default;
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -262,7 +260,7 @@ for improved readability and intent clarity.
 
 ### Requirements
 
-- **PHP Version:** PHP `>= 8.0.0`
+- **PHP version:** PHP `>= 8.0.0`
 
 ### Configuration
 
@@ -273,7 +271,7 @@ for improved readability and intent clarity.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -286,7 +284,7 @@ if (str_contains($a, $b)) {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -308,7 +306,7 @@ for improved readability and intent clarity.
 
 ### Requirements
 
-- **PHP Version:** PHP `>= 8.0.0`
+- **PHP version:** PHP `>= 8.0.0`
 
 ### Configuration
 
@@ -319,7 +317,7 @@ for improved readability and intent clarity.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -331,7 +329,7 @@ if (str_starts_with($a, $b)) {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -361,7 +359,7 @@ issue reference ensures that the issue is tracked and resolved.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -371,7 +369,7 @@ issue reference ensures that the issue is tracked and resolved.
 // FIXME(#123) This is a valid FIXME comment.
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -397,7 +395,7 @@ makes it easier to track progress and ensures that tasks are not forgotten.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -407,7 +405,7 @@ makes it easier to track progress and ensures that tasks are not forgotten.
 // TODO(#123) This is a valid TODO comment.
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -432,7 +430,7 @@ it can be noisy and may not be relevant to all codebases.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -446,7 +444,7 @@ function foo($a) {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php

--- a/docs/tools/linter/rules/consistency.md
+++ b/docs/tools/linter/rules/consistency.md
@@ -1,12 +1,11 @@
 ---
-title: Consistency Rules
+title: Consistency rules
+outline: [2, 3]
 ---
 
-# Consistency Rules
+# Consistency rules
 
 This document details the rules available in the `Consistency` category.
-
-## Available Rules
 
 | Rule | Code |
 | :--- | :---------- |
@@ -28,7 +27,6 @@ This document details the rules available in the `Consistency` category.
 | No Trailing Space | [`no-trailing-space`](#no-trailing-space) |
 | Trait Name | [`trait-name`](#trait-name) |
 
----
 
 ## <a id="ambiguous-function-call"></a>`ambiguous-function-call`
 
@@ -53,7 +51,7 @@ performance gains in some cases.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -72,7 +70,7 @@ $length2 = \strlen("hello");
 $value = namespace\my_function();
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -102,7 +100,7 @@ is the preferred way to define arrays in PHP.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -111,7 +109,7 @@ is the preferred way to define arrays in PHP.
 $arr = [1, 2, 3];
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -144,7 +142,7 @@ This rule can be configured to enforce the preferred style.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -158,7 +156,7 @@ final class SomeTest extends TestCase
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -192,7 +190,7 @@ This improves readability and prevents potential errors when adding new statemen
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -206,7 +204,7 @@ for ($i = 0; $i < 10; $i++) {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -237,7 +235,7 @@ especially when variables are followed by alphanumeric characters. This rule pro
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -248,7 +246,7 @@ $c = "Hello, {$$name}!";
 $d = "Hello, {${$object->getMethod()}}!";
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -278,7 +276,7 @@ Class names should be in class case, also known as PascalCase.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -286,7 +284,7 @@ Class names should be in class case, also known as PascalCase.
 class MyClass {}
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -316,7 +314,7 @@ Constant names should be in constant case, also known as UPPER_SNAKE_CASE.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -328,7 +326,7 @@ class MyClass {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -362,7 +360,7 @@ Enum names should be in class case, also known as PascalCase.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -370,7 +368,7 @@ Enum names should be in class case, also known as PascalCase.
 enum MyEnum {}
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -400,7 +398,7 @@ Function names should be in camel case or snake case, depending on the configura
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -408,7 +406,7 @@ Function names should be in camel case or snake case, depending on the configura
 function my_function() {}
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -437,7 +435,7 @@ Interface names should be in class case and suffixed with `Interface`, depending
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -445,7 +443,7 @@ Interface names should be in class case and suffixed with `Interface`, depending
 interface MyInterface {}
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -472,7 +470,7 @@ in lowercase. Using uppercase or mixed case is discouraged for consistency and r
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -484,7 +482,7 @@ if (true) {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?PHP
@@ -514,7 +512,7 @@ and readability.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -524,7 +522,7 @@ function example(int $param): void {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -552,7 +550,7 @@ This is primarily for consistency and clarity.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -561,7 +559,7 @@ This is primarily for consistency and clarity.
 $freeSpace = disk_free_space("/");
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -587,7 +585,7 @@ in PHP, as they are more consistent with the language's syntax and are easier to
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -595,7 +593,7 @@ in PHP, as they are more consistent with the language's syntax and are easier to
 // This is a good comment.
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -620,7 +618,7 @@ Discourages the use of `?><?php` as a statement terminator. Recommends using a s
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -628,7 +626,7 @@ Discourages the use of `?><?php` as a statement terminator. Recommends using a s
 echo "Hello World";
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -653,7 +651,7 @@ diffs and formatting issues, so it is recommended to remove it.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -661,7 +659,7 @@ diffs and formatting issues, so it is recommended to remove it.
 // This is a good comment.
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -687,7 +685,7 @@ Trait names should be in class case and suffixed with `Trait`, depending on the 
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -695,7 +693,7 @@ Trait names should be in class case and suffixed with `Trait`, depending on the 
 trait MyTrait {}
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php

--- a/docs/tools/linter/rules/correctness.md
+++ b/docs/tools/linter/rules/correctness.md
@@ -1,12 +1,11 @@
 ---
-title: Correctness Rules
+title: Correctness rules
+outline: [2, 3]
 ---
 
-# Correctness Rules
+# Correctness rules
 
 This document details the rules available in the `Correctness` category.
-
-## Available Rules
 
 | Rule | Code |
 | :--- | :---------- |
@@ -24,7 +23,6 @@ This document details the rules available in the `Correctness` category.
 | Strict Behavior | [`strict-behavior`](#strict-behavior) |
 | Strict Types | [`strict-types`](#strict-types) |
 
----
 
 ## <a id="assert-description"></a>`assert-description`
 
@@ -43,7 +41,7 @@ Assert functions should have a description to make it easier to understand the p
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -51,7 +49,7 @@ Assert functions should have a description to make it easier to understand the p
 assert($user->isActivated(), 'User MUST be activated at this point.');
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -67,7 +65,7 @@ Detects class constants that are missing a type hint.
 
 ### Requirements
 
-- **PHP Version:** PHP `>= 8.3.0`
+- **PHP version:** PHP `>= 8.3.0`
 
 ### Configuration
 
@@ -78,7 +76,7 @@ Detects class constants that are missing a type hint.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -100,7 +98,7 @@ class ResourceHandle implements IO\CloseSeekReadWriteStreamHandleInterface {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -138,7 +136,7 @@ Detects equality and inequality comparisons that should use identity comparison 
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -148,7 +146,7 @@ if ($a === $b) {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -179,7 +177,7 @@ behavior and potential security vulnerabilities.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -187,7 +185,7 @@ behavior and potential security vulnerabilities.
 echo 'Hello, world!';
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <php?
@@ -212,7 +210,7 @@ to read and understand.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -223,7 +221,7 @@ if ($x == 1) {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -253,7 +251,7 @@ For example, `if ($x === true)` is equivalent to the more concise `if ($x)`, and
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -262,7 +260,7 @@ if ($x) { /* ... */ }
 if (!$y) { /* ... */ }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -291,7 +289,7 @@ potentially hiding errors that should be addressed. This practice, known as
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -304,7 +302,7 @@ try {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -324,7 +322,7 @@ Detects parameters that are missing a type hint.
 
 ### Requirements
 
-- **PHP Version:** PHP `>= 7.0.0`
+- **PHP version:** PHP `>= 7.0.0`
 
 ### Configuration
 
@@ -337,7 +335,7 @@ Detects parameters that are missing a type hint.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -348,7 +346,7 @@ function foo(string $bar): void
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -367,7 +365,7 @@ Detects class-like properties that are missing a type hint.
 
 ### Requirements
 
-- **PHP Version:** PHP `>= 7.4.0`
+- **PHP version:** PHP `>= 7.4.0`
 
 ### Configuration
 
@@ -378,7 +376,7 @@ Detects class-like properties that are missing a type hint.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -389,7 +387,7 @@ class Foo
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -408,7 +406,7 @@ Detects functions, methods, closures, and arrow functions that are missing a ret
 
 ### Requirements
 
-- **PHP Version:** PHP `>= 7.0.0`
+- **PHP version:** PHP `>= 7.0.0`
 
 ### Configuration
 
@@ -421,7 +419,7 @@ Detects functions, methods, closures, and arrow functions that are missing a ret
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -431,7 +429,7 @@ function foo(): int {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -462,7 +460,7 @@ instead of `assertEquals` or `assertNotEquals`.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -480,7 +478,7 @@ final class SomeTest extends TestCase
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -507,7 +505,7 @@ The use of loose comparison for these functions may lead to hard-to-debug, unexp
 
 ### Requirements
 
-- **PHP Version:** PHP `>= 7.0.0`
+- **PHP version:** PHP `>= 7.0.0`
 
 ### Configuration
 
@@ -519,7 +517,7 @@ The use of loose comparison for these functions may lead to hard-to-debug, unexp
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -527,7 +525,7 @@ The use of loose comparison for these functions may lead to hard-to-debug, unexp
 in_array(1, ['foo', 'bar', 'baz'], strict: true);
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -543,7 +541,7 @@ Detects missing `declare(strict_types=1);` statement at the beginning of the fil
 
 ### Requirements
 
-- **PHP Version:** PHP `>= 7.0.0`
+- **PHP version:** PHP `>= 7.0.0`
 
 ### Configuration
 
@@ -555,7 +553,7 @@ Detects missing `declare(strict_types=1);` statement at the beginning of the fil
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -565,7 +563,7 @@ declare(strict_types=1);
 echo "Hello, World!";
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php

--- a/docs/tools/linter/rules/deprecation.md
+++ b/docs/tools/linter/rules/deprecation.md
@@ -1,12 +1,11 @@
 ---
-title: Deprecation Rules
+title: Deprecation rules
+outline: [2, 3]
 ---
 
-# Deprecation Rules
+# Deprecation rules
 
 This document details the rules available in the `Deprecation` category.
-
-## Available Rules
 
 | Rule | Code |
 | :--- | :---------- |
@@ -15,7 +14,6 @@ This document details the rules available in the `Deprecation` category.
 | No Void Reference Return | [`no-void-reference-return`](#no-void-reference-return) |
 | Optional Parameter Before Required | [`optional-param-order`](#optional-param-order) |
 
----
 
 ## <a id="explicit-nullable-param"></a>`explicit-nullable-param`
 
@@ -26,7 +24,7 @@ Such parameters are considered deprecated; an explicit nullable type hint is rec
 
 ### Requirements
 
-- **PHP Version:** PHP `>= 8.4.0`
+- **PHP version:** PHP `>= 8.4.0`
 
 ### Configuration
 
@@ -37,7 +35,7 @@ Such parameters are considered deprecated; an explicit nullable type hint is rec
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -49,7 +47,7 @@ function bar(null|string $param) {}
 function baz(null|object $param = null) {}
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -71,7 +69,7 @@ Such names are considered deprecated; a more descriptive identifier is recommend
 
 ### Requirements
 
-- **PHP Version:** PHP `>= 8.4.0`
+- **PHP version:** PHP `>= 8.4.0`
 
 ### Configuration
 
@@ -82,7 +80,7 @@ Such names are considered deprecated; a more descriptive identifier is recommend
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -90,7 +88,7 @@ Such names are considered deprecated; a more descriptive identifier is recommend
 class MyService {}
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -107,7 +105,7 @@ Such functions are considered deprecated; returning by reference from a void fun
 
 ### Requirements
 
-- **PHP Version:** PHP `>= 8.2.0`
+- **PHP version:** PHP `>= 8.2.0`
 
 ### Configuration
 
@@ -118,7 +116,7 @@ Such functions are considered deprecated; returning by reference from a void fun
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -128,7 +126,7 @@ function &foo(): string {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -147,7 +145,7 @@ Such parameter order is considered deprecated; required parameters should preced
 
 ### Requirements
 
-- **PHP Version:** PHP `>= 8.0.0`
+- **PHP version:** PHP `>= 8.0.0`
 
 ### Configuration
 
@@ -158,7 +156,7 @@ Such parameter order is considered deprecated; required parameters should preced
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -166,7 +164,7 @@ Such parameter order is considered deprecated; required parameters should preced
 function foo(string $required, ?string $optional = null): void {}
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php

--- a/docs/tools/linter/rules/maintainability.md
+++ b/docs/tools/linter/rules/maintainability.md
@@ -1,12 +1,11 @@
 ---
-title: Maintainability Rules
+title: Maintainability rules
+outline: [2, 3]
 ---
 
-# Maintainability Rules
+# Maintainability rules
 
 This document details the rules available in the `Maintainability` category.
-
-## Available Rules
 
 | Rule | Code |
 | :--- | :---------- |
@@ -22,7 +21,6 @@ This document details the rules available in the `Maintainability` category.
 | Too Many Methods | [`too-many-methods`](#too-many-methods) |
 | Too Many Properties | [`too-many-properties`](#too-many-properties) |
 
----
 
 ## <a id="cyclomatic-complexity"></a>`cyclomatic-complexity`
 
@@ -62,7 +60,7 @@ Consider refactoring to use early returns, helper methods, or clearer control fl
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -74,7 +72,7 @@ if ($condition) {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -183,7 +181,7 @@ Refactor by extracting the flag logic into its own class or method.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -197,7 +195,7 @@ function get_difference_case_insensitive(string $a, string $b): string {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -227,7 +225,7 @@ the code easier to read and maintain by reducing its cyclomatic complexity.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -242,7 +240,7 @@ function process($user) {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -276,7 +274,7 @@ and make it difficult to follow the flow of execution.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -290,7 +288,7 @@ while ($i < 10) {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -325,7 +323,7 @@ This rule checks the number of cases in enums. If the number of cases exceeds a 
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 enum SimpleEnum {
@@ -335,7 +333,7 @@ enum SimpleEnum {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 enum LargeEnum {
@@ -385,7 +383,7 @@ If the number of methods exceeds a configurable threshold, an issue is reported.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 class SimpleClass {
@@ -395,7 +393,7 @@ class SimpleClass {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 class ComplexClass {
@@ -443,7 +441,7 @@ If the number of properties exceeds a configurable threshold, an issue is report
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 class SimpleClass {
@@ -452,7 +450,7 @@ class SimpleClass {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 class ComplexClass {

--- a/docs/tools/linter/rules/redundancy.md
+++ b/docs/tools/linter/rules/redundancy.md
@@ -1,12 +1,11 @@
 ---
-title: Redundancy Rules
+title: Redundancy rules
+outline: [2, 3]
 ---
 
-# Redundancy Rules
+# Redundancy rules
 
 This document details the rules available in the `Redundancy` category.
-
-## Available Rules
 
 | Rule | Code |
 | :--- | :---------- |
@@ -27,7 +26,6 @@ This document details the rules available in the `Redundancy` category.
 | No Redundant String Concat | [`no-redundant-string-concat`](#no-redundant-string-concat) |
 | No Redundant Write Visibility | [`no-redundant-write-visibility`](#no-redundant-write-visibility) |
 
----
 
 ## <a id="constant-condition"></a>`constant-condition`
 
@@ -49,7 +47,7 @@ and can be removed or refactored.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -58,7 +56,7 @@ if ($variable > 10) {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -87,7 +85,7 @@ Detects redundant closing tags ( `?>` ) at the end of a file.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -95,7 +93,7 @@ Detects redundant closing tags ( `?>` ) at the end of a file.
 echo "Hello, world!";
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -123,7 +121,7 @@ to keep the codebase clean and maintainable.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -135,7 +133,7 @@ to keep the codebase clean and maintainable.
  */
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -162,7 +160,7 @@ loop body does not perform any actions and is likely a mistake or redundant code
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -172,7 +170,7 @@ foreach ($items as $item) {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -198,7 +196,7 @@ Detects redundant `noop` statements.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -206,7 +204,7 @@ Detects redundant `noop` statements.
 echo "Hello, world!";
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -230,7 +228,7 @@ Detects redundant blocks around statements.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -238,7 +236,7 @@ Detects redundant blocks around statements.
 echo "Hello, world!";
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -264,7 +262,7 @@ Detects redundant `continue` statements in loops.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -274,7 +272,7 @@ while (true) {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -301,7 +299,7 @@ Detects redundant files that contain no executable code or declarations.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -313,7 +311,7 @@ function foo(): void {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -338,7 +336,7 @@ Detects redundant `final` modifiers on methods in final classes or enum methods.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -350,7 +348,7 @@ final class Foo {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -378,7 +376,7 @@ Detects redundant `goto` labels that are declared but not used.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -388,7 +386,7 @@ echo "Hello, world!";
 end:
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -414,7 +412,7 @@ Includes operations like multiplying by 1/-1, adding 0, modulo 1/-1, etc.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -425,7 +423,7 @@ $difference = $value - 1;
 $remainder = $x % 2;
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -453,7 +451,7 @@ Detects methods that override a parent method but only call the parent method wi
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -477,7 +475,7 @@ class Child extends Parent
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -522,7 +520,7 @@ making the `?->` operator superfluous and the code unnecessarily verbose.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -534,7 +532,7 @@ if (isset($user->profile)) {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -562,7 +560,7 @@ Detects redundant parentheses around expressions.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -570,7 +568,7 @@ Detects redundant parentheses around expressions.
 $foo = 42;
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -594,7 +592,7 @@ Detects redundant string concatenation expressions.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -602,7 +600,7 @@ Detects redundant string concatenation expressions.
 $foo = "Hello World";
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -626,7 +624,7 @@ Detects redundant write visibility modifiers on properties.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -637,7 +635,7 @@ final class User
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php

--- a/docs/tools/linter/rules/safety.md
+++ b/docs/tools/linter/rules/safety.md
@@ -1,12 +1,11 @@
 ---
-title: Safety Rules
+title: Safety rules
+outline: [2, 3]
 ---
 
-# Safety Rules
+# Safety rules
 
 This document details the rules available in the `Safety` category.
-
-## Available Rules
 
 | Rule | Code |
 | :--- | :---------- |
@@ -19,7 +18,6 @@ This document details the rules available in the `Safety` category.
 | No Shell Execute String | [`no-shell-execute-string`](#no-shell-execute-string) |
 | No Unsafe Finally | [`no-unsafe-finally`](#no-unsafe-finally) |
 
----
 
 ## <a id="no-error-control-operator"></a>`no-error-control-operator`
 
@@ -38,7 +36,7 @@ The error control operator suppresses errors and makes debugging more difficult.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -50,7 +48,7 @@ try {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -75,7 +73,7 @@ The `eval` construct executes arbitrary code, which can be a major security risk
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -84,7 +82,7 @@ The `eval` construct executes arbitrary code, which can be a major security risk
 $result = json_decode($jsonString);
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -113,7 +111,7 @@ If you are confident in your use of FFI and understand the risks, you can disabl
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -123,7 +121,7 @@ $data = 'some data';
 $hash = hash('sha256', $data);
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -152,7 +150,7 @@ The `global` keyword introduces global state into your function, making it harde
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -162,7 +160,7 @@ function foo(string $bar): void {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -195,7 +193,7 @@ It is recommended to use `$request->only([...])` to specify the inputs you need 
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -219,7 +217,7 @@ class UserController extends Controller
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -261,7 +259,7 @@ Use `$_GET`, `$_POST`, or `$_COOKIE` instead for better clarity.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -269,7 +267,7 @@ Use `$_GET`, `$_POST`, or `$_COOKIE` instead for better clarity.
 $identifier = $_GET['id'];
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -293,7 +291,7 @@ Detects the use of shell execute strings (`...`) in PHP code.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -301,7 +299,7 @@ Detects the use of shell execute strings (`...`) in PHP code.
 $output = shell_exec('ls -l');
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -328,7 +326,7 @@ leading to unexpected behavior.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -342,7 +340,7 @@ function example(): int {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php

--- a/docs/tools/linter/rules/security.md
+++ b/docs/tools/linter/rules/security.md
@@ -1,12 +1,11 @@
 ---
-title: Security Rules
+title: Security rules
+outline: [2, 3]
 ---
 
-# Security Rules
+# Security rules
 
 This document details the rules available in the `Security` category.
-
-## Available Rules
 
 | Rule | Code |
 | :--- | :---------- |
@@ -17,7 +16,6 @@ This document details the rules available in the `Security` category.
 | No Short Opening Tag | [`no-short-opening-tag`](#no-short-opening-tag) |
 | Tainted Data to Sink | [`tainted-data-to-sink`](#tainted-data-to-sink) |
 
----
 
 ## <a id="disallowed-functions"></a>`disallowed-functions`
 
@@ -40,7 +38,7 @@ security restrictions, or the usage of preferred alternatives.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -52,7 +50,7 @@ function allowed_function(): void {
 allowed_function(); // Not flagged
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -80,7 +78,7 @@ intended for production environments.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -89,7 +87,7 @@ intended for production environments.
 error_log('Processing user request.');
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -119,7 +117,7 @@ Instead, use `hash_equals` for comparing strings or `password_verify` for valida
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -129,7 +127,7 @@ if (hash_equals($storedToken, $userToken)) {
 }
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -157,7 +155,7 @@ and should be avoided. Use environment variables or secure configuration managem
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -165,7 +163,7 @@ and should be avoided. Use environment variables or secure configuration managem
 $password = getenv('DB_PASSWORD');
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php
@@ -195,7 +193,7 @@ interpreted correctly.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -203,7 +201,7 @@ interpreted correctly.
 echo "Hello, World!";
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?
@@ -231,7 +229,7 @@ or other injection attacks.
 
 ### Examples
 
-#### Correct Code
+#### Correct code
 
 ```php
 <?php
@@ -240,7 +238,7 @@ or other injection attacks.
 echo htmlspecialchars($_GET['name'] ?? '', ENT_QUOTES, 'UTF-8');
 ```
 
-#### Incorrect Code
+#### Incorrect code
 
 ```php
 <?php

--- a/docs/tools/linter/usage.md
+++ b/docs/tools/linter/usage.md
@@ -1,12 +1,12 @@
 ---
-title: Usage
+title: Linter usage
 ---
 
 # Usage
 
 The `mago lint` command is the entry point for running the linter.
 
-## Linting Your Project
+## Linting your project
 
 To lint all the source files defined in your `mago.toml` configuration, simply run:
 
@@ -16,7 +16,7 @@ mago lint
 
 Mago will scan your project in parallel and report any issues it finds.
 
-## Auto-Fixing Issues
+## Auto-fixing issues
 
 Many lint rules provide automatic fixes. To apply them, use the `--fix` flag:
 
@@ -30,7 +30,7 @@ This will modify your files in place. To see what changes would be made without 
 mago lint --fix --dry-run
 ```
 
-## Running Specific Rules
+## Running specific rules
 
 If you want to run only a specific set of rules, use the `--only` flag. This is great for incrementally introducing new rules to a project.
 

--- a/docs/tools/overview.md
+++ b/docs/tools/overview.md
@@ -1,8 +1,9 @@
 ---
-title: Tools Overview
+title: Tools overview
+outline: deep
 ---
 
-# Tools Overview
+# Tools overview
 
 **Mago** is a comprehensive toolchain, not just a single utility. It's composed of several powerful, high-performance components that work together to improve your PHP code.
 
@@ -10,16 +11,16 @@ This section provides a detailed guide for each tool.
 
 ### [Formatter](./formatter/overview.md)
 
-The **Formatter** is an opinionated code formatter that ensures your entire codebase adheres to a single, consistent style based on PSR-12. It's designed to end debates over code style forever.
+The **formatter** is an opinionated code formatter that ensures your entire codebase adheres to a single, consistent style based on PSR-12. It's designed to end debates over code style forever.
 
 ### [Linter](./linter/overview.md)
 
-The **Linter** is a blazing-fast tool for finding stylistic issues, inconsistencies, and code smells. It helps you maintain a clean and readable codebase with minimal effort.
+The **linter** is a blazing-fast tool for finding stylistic issues, inconsistencies, and code smells. It helps you maintain a clean and readable codebase with minimal effort.
 
 ### [Analyzer](./analyzer/overview.md)
 
-The **Analyzer** is a powerful static analysis engine that finds logical errors, type mismatches, and potential bugs in your code _before_ you run it. It's the core of Mago's ability to ensure your code is correct and robust.
+The **analyzer** is a powerful static analysis engine that finds logical errors, type mismatches, and potential bugs in your code _before_ you run it. It's the core of Mago's ability to ensure your code is correct and robust.
 
-### [Lexer & Parser](./lexer-parser/overview.md)
+### [Lexer & parser](./lexer-parser/overview.md)
 
 At the heart of Mago lies its high-performance Lexer and Parser. These components turn your raw PHP source code into a structured Abstract Syntax Tree (AST). The `mago ast` command provides a powerful way to inspect this structure for debugging and learning.

--- a/scripts/linter-rules-docs.php
+++ b/scripts/linter-rules-docs.php
@@ -317,14 +317,14 @@ function generate_overview_page(string $docs_dir, array $rules_by_category, arra
     $overviewPagePath = $docs_dir . '/tools/linter/rules-and-categories.md';
     writeln('✍️ ', 'Generating main overview page: %s', $overviewPagePath);
 
-    $overviewContent = "---\nsidebar_position: 3\ntitle: Rules & Categories\n---\n\n# Rules & Categories\n\n";
-    $overviewContent .= "The **Mago** Linter comes with a wide variety of rules, each designed to catch a specific type of issue.\n\n";
-    $overviewContent .= "## Rule Categories\n\n";
+    $overviewContent = "---\nsidebar_position: 3\ntitle: Rules & categories\n---\n\n# Rules & categories\n\n";
+    $overviewContent .= "**Mago**'s linter comes with a wide variety of rules, each designed to catch a specific type of issue.\n\n";
+    $overviewContent .= "## Rule categories\n\n";
     foreach ($rules_by_category as $categoryName => $data) {
         $overviewContent .= "- [{$categoryName}](./rules/{$data['kebab']})\n";
     }
 
-    $overviewContent .= "\n## Integration-Specific Rules\n\n";
+    $overviewContent .= "\n## Integration-specific rules\n\n";
     if ([] === $rules_by_integration) {
         $overviewContent .= "There are currently no rules that require a specific integration.\n";
     } else {
@@ -362,14 +362,13 @@ function create_category_markdown_content(string $category_name, array $rules, a
 
     $content = <<<MD
     ---
-    title: {$category_name} Rules
+    title: {$category_name} rules
+    outline: [2, 3]
     ---
 
-    # {$category_name} Rules
+    # {$category_name} rules
 
     This document details the rules available in the `{$category_name}` category.
-
-    ## Available Rules
 
     | Rule | Code |
     | :--- | :---------- |
@@ -379,7 +378,7 @@ function create_category_markdown_content(string $category_name, array $rules, a
         $content .= "\n| {$rule['name']} | [`{$rule['code']}`](#{$rule['code']}) |";
     }
 
-    $content .= "\n\n---\n";
+    $content .= "\n\n";
 
     foreach ($rules as $rule) {
         $rule_config = $linter_config['rules'][$rule['code']] ?? ['enabled' => true, 'level' => 'error'];
@@ -438,7 +437,7 @@ function generate_rule_docs_section(array $rule, array $config): string
     }
 
     if ($phpVersion) {
-        $requirements_items[] = "- **PHP Version:** {$phpVersion}";
+        $requirements_items[] = "- **PHP version:** {$phpVersion}";
     }
     if ([] !== $requiredIntegrations) {
         $plural = count($requiredIntegrations) > 1 ? 's' : '';
@@ -466,10 +465,10 @@ function generate_rule_docs_section(array $rule, array $config): string
     if ('' !== $good_example || '' !== $bad_example) {
         $examples_section .= "### Examples\n\n";
         if ('' !== $good_example) {
-            $examples_section .= "#### Correct Code\n\n```php\n{$good_example}\n```\n\n";
+            $examples_section .= "#### Correct code\n\n```php\n{$good_example}\n```\n\n";
         }
         if ('' !== $bad_example) {
-            $examples_section .= "#### Incorrect Code\n\n```php\n{$bad_example}\n```\n\n";
+            $examples_section .= "#### Incorrect code\n\n```php\n{$bad_example}\n```\n\n";
         }
     }
 


### PR DESCRIPTION
This pull request polishes the documentation by using sentence casing for a more professional/polished feel, along with other minor changes:
- Added hyperlinks here and there for better navigation
- Added padding between `h3` and their underline for readability
- Fixed double underline on `a` anchors within `h3`
- Improved `<code>` contrast (green on light gray → slightly lighter green on slightly darker gray)
- Fixed ordering of config and command reference in sidebar
- Made the table of content deeper on some page where it makes sense
- Fixed some formatting, like multiple `<hr />`
- Used VitePress custom blocks instead of quote blocks

I would also recommend removing the underline on `h3` titles. It hinders readability (a bit less since I increased the padding). I didn't remove them though, because I'm assuming it was a conscious stylistic choice.