### PR TITLE
chore(nix): add dev flake (rustup: 1.89.0 + nightly) and docs

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /target
 /crates/*/target
 /vendor/
+.direnv

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ Here is a small checklist to get you going:
    - Install [Rust](https://www.rust-lang.org/tools/install)
    - Install [Just](https://github.com/casey/just)
    - Run `just build` to set up the project.
+   - If you use [Nix](https://nixos.org): Run `nix develop` and `just build`.
 
 5. **Create a branch**:
    Create a new branch with a descriptive name:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -22,6 +22,7 @@ Contributing to open-source can be intimidating, but don't worry! We're here to 
     - Install [Rust](https://www.rust-lang.org/tools/install)
     - Install [Just](https://github.com/casey/just)
     - Run `just build` to set up the project and install dependencies.
+    - If you use [Nix](https://nixos.org): Run `nix develop` and `just build`.
 
 4.  **Create a branch**. Create a new branch with a descriptive name:
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1756542300,
+        "narHash": "sha256-tlOn88coG5fzdyqz6R93SQL5Gpq+m/DsWpekNFhqPQk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d7600c775f877cd87b4f5a831c28aa94137377aa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Mago - devshell using rustup (stable 1.89.0 + nightly)";
+  description = "Mago - devshell using rustup (stable 1.89.0 + nightly) and php 8.4 + composer";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
@@ -11,6 +11,8 @@
       let
         pkgs = import nixpkgs { inherit system; };
         isDarwin = pkgs.stdenv.isDarwin;
+        php = pkgs.php84;
+        composer = pkgs.php84Packages.composer;
       in {
         devShells.default = pkgs.mkShell {
           buildInputs = [
@@ -20,6 +22,8 @@
             pkgs.openssl
             pkgs.just
             pkgs.wasm-pack
+            php
+            composer
           ] ++ pkgs.lib.optionals isDarwin [
             pkgs.libiconv
           ];
@@ -40,8 +44,10 @@
               rustup toolchain install nightly --profile minimal
               rustup default 1.89.0
             fi
-            echo "[mago] rustc: $(rustc --version)"
-            echo "[mago] nightly: $(rustup run nightly rustc --version)"
+            echo "[mago] rustc:     $(rustc --version)"
+            echo "[mago] nightly:   $(rustup run nightly rustc --version)"
+            echo "[mago] php:       $(php -v | head -n1)"
+            echo "[mago] composer:  $(composer --version)"
             echo "[mago] Run: just build | just test | just lint | just fix | just build-wasm"
           '';
         };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+{
+  description = "Mago - devshell using rustup (stable 1.89.0 + nightly)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        isDarwin = pkgs.stdenv.isDarwin;
+      in {
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            pkgs.rustup
+            pkgs.rust-analyzer
+            pkgs.pkg-config
+            pkgs.openssl
+            pkgs.just
+            pkgs.wasm-pack
+          ] ++ pkgs.lib.optionals isDarwin [
+            pkgs.libiconv
+          ];
+
+          NIX_LDFLAGS = pkgs.lib.optionalString isDarwin ''
+            -framework Security -framework SystemConfiguration
+          '';
+
+          OPENSSL_NO_VENDOR = 1;
+          RUSTFLAGS = "-C debuginfo=1";
+          CARGO_TERM_COLOR = "always";
+          CARGO_INCREMENTAL = "1";
+
+          shellHook = ''
+            export PATH="$HOME/.cargo/bin:$PATH"
+            if ! command -v rustc >/dev/null 2>&1; then
+              rustup toolchain install 1.89.0 --profile minimal
+              rustup toolchain install nightly --profile minimal
+              rustup default 1.89.0
+            fi
+            echo "[mago] rustc: $(rustc --version)"
+            echo "[mago] nightly: $(rustup run nightly rustc --version)"
+            echo "[mago] Run: just build | just test | just lint | just fix | just build-wasm"
+          '';
+        };
+      });
+}


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR adds a `flake.nix` to provide a reproducible development environment for contributors using Nix, and updates the CONTRIBUTING guide with optional instructions for Nix users.

## 🔍 Context & Motivation

Setting up the exact Rust toolchain and dependencies can be error-prone, especially when the project requires Rust 1.89.0 and nightly for certain tasks (`just lint` / `just fix`).  
By providing a Nix flake, contributors on Linux or macOS can quickly enter a pré configured environment and start working without manual setup.

## 🛠️ Summary of Changes

- **Feature:** Added `flake.nix` with Rust stable 1.89.0, nightly, OpenSSL, pkg-config, Just, and wasm-pack using `rustup`.
- **Docs:** Updated `CONTRIBUTING.md` with optional instructions for using `nix develop`.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [x] Documentation
- [x] Other (Development Environment)

## 🔗 Related Issues or PRs

https://github.com/carthage-software/mago/issues/371

## 📝 Notes for Reviewers

- The flake uses `rustup` to allow the existing `cargo +nightly` commands in the Justfile to work unchanged.
- No packaging (`nix build` / `nix run`) is included; this PR focuses on developer experience.
- Works on Linux and macOS with Nix installed; not limited to NixOS.