### PR TITLE
feat: support yaml config file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ pretty_assertions = { version = "1.4.1" }
 either = { version = "1.13.0" }
 codespan-reporting = { version = "0.12.0", features = ["serde", "serialization"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-config = { version = "0.15.4", features = ["toml"] }
+config = { version = "0.15.4", features = ["toml", "yaml"] }
 toml = "0.9.2"
 num_cpus = "1.16.0"
 regex = "1.11.0"

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -19,7 +19,7 @@ use mago_php_version::PHPVersion;
 
 use crate::config::Configuration;
 use crate::consts::COMPOSER_JSON_FILE;
-use crate::consts::CONFIGURATION_FILE;
+use crate::consts::CONFIGURATION_FILE_NAME;
 use crate::consts::DEFAULT_PHP_VERSION;
 use crate::error::Error;
 use crate::utils::version::extract_minimum_php_version;
@@ -71,7 +71,7 @@ pub fn execute(
     };
 
     let configuration_file =
-        configuration_file.unwrap_or_else(|| configuration.source.workspace.join(CONFIGURATION_FILE));
+        configuration_file.unwrap_or_else(|| configuration.source.workspace.join(CONFIGURATION_FILE_NAME));
 
     print_welcome_banner();
     if configuration_file.exists() {

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -37,7 +37,7 @@ pub const ISSUE_URL: &str = "https://github.com/carthage-software/mago/issues/ne
 pub const ENVIRONMENT_PREFIX: &str = "MAGO";
 
 /// The name of the configuration file for mago.
-pub const CONFIGURATION_FILE: &str = "mago.toml";
+pub const CONFIGURATION_FILE_NAME: &str = "mago";
 
 /// The name of `composer.json` file.
 pub const COMPOSER_JSON_FILE: &str = "composer.json";


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR allows mago to read yaml configs by using `config::File::with_name` instead of `config::File::from`, which makes the config crate resolve the format based on the file extension.

This is sort of like a proof of concept, and since I don't know any rust this is probably subpar.

If this is something you're interested in having in mago, I'd happily work on this some more ☺️

## 🔍 Context & Motivation

#350 

In my opinion it is way more readable:

```yaml
php-version: "8.4.0"

source:
  paths:
    - "src"
    - "tests"
    - "workbench/app/"
    - "workbench/database/factories/"
    - "workbench/database/seeders/"
  includes:
    - "vendor"
  excludes: []

formatter:
  print-width: 120
  tab-width: 4
  use-tabs: false
  null-type-hint: "question"

linter:
  integrations:
    - "laravel"
  rules:
    ambiguous-function-call:
      enabled: false
    literal-named-argument:
      enabled: false
    halstead:
      effort-threshold: 7000
```

## 🛠️ Summary of Changes

- **Feature:** Added support for reading config from `mago.yaml`.

## 📂 Affected Areas

Everything?

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

<!-- Fixes #350, related to #__ -->

## 📝 Notes for Reviewers

I think the description sums it up :)
