### PR TITLE
feat(codex): add support for `#[\Deprecated]` on traits

### DIFF
--- a/crates/analyzer/tests/cases/use_inheritance_error_path.php
+++ b/crates/analyzer/tests/cases/use_inheritance_error_path.php
@@ -1,5 +1,16 @@
 <?php
 
+namespace {
+    class Attribute
+    {
+    }
+
+    #[Attribute]
+    class Deprecated
+    {
+    }
+}
+
 namespace Fixture {
     class NotATrait
     {
@@ -11,6 +22,11 @@ namespace Fixture {
 
     /** @deprecated */
     trait DeprecatedTrait
+    {
+    }
+
+    #[\Deprecated]
+    trait DeprecatedTraitFromAttribute
     {
     }
 
@@ -91,6 +107,18 @@ namespace UsesDeprecated {
     class UsesDeprecated
     {
         use DeprecatedTrait;
+    }
+}
+
+/**
+ * @mago-expect analysis:deprecated-trait
+ */
+namespace UsesDeprecatedFromAttribute {
+    use Fixture\DeprecatedTraitFromAttribute;
+
+    class UsesDeprecatedFromAttribute
+    {
+        use DeprecatedTraitFromAttribute;
     }
 }
 

--- a/crates/codex/src/scanner/class_like.rs
+++ b/crates/codex/src/scanner/class_like.rs
@@ -320,6 +320,10 @@ fn scan_class_like<'ctx, 'arena>(
             codebase.symbols.add_enum_name(name);
         }
         SymbolKind::Trait => {
+            if class_like_metadata.attributes.iter().any(|attr| attr.name.eq_ignore_ascii_case("Deprecated")) {
+                class_like_metadata.flags |= MetadataFlags::DEPRECATED;
+            }
+
             codebase.symbols.add_trait_name(name);
         }
         SymbolKind::Interface => {


### PR DESCRIPTION
## 📌 What Does This PR Do?

Add support for `#[\Deprecated]` on traits, see https://wiki.php.net/rfc/deprecated_traits
<!-- Briefly describe what this PR introduces or fixes. -->

## 🔍 Context & Motivation

PHP 8.5 adds support for using the `#[\Deprecated]` attribute on traits. When the attribute is present, PHP will emit deprecation warnings when the trait gets used. Since mago emits deprecation warnings when a trait documented with `@deprecated` is used, it seems sensible to also emit warnings when the deprecation is indicated via attribute.

## 🛠️ Summary of Changes

- **Feature:** Expanded existing `analysis:deprecated-trait` warnings

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Scanner

## 🔗 Related Issues or PRs

Related to php/php-src#19045
<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->