### PR TITLE
fix(stubs): refine end() return type annotation

### DIFF
--- a/crates/prelude/assets/extensions/standard.php
+++ b/crates/prelude/assets/extensions/standard.php
@@ -5185,7 +5185,7 @@ function count(Countable|array $value, int $mode = COUNT_NORMAL): int
  *
  * @param object|array<T> $array
  *
- * @return T|false
+ * @return ($array is non-empty-array|non-empty-list ? T : false)
  */
 function end(object|array &$array): mixed
 {


### PR DESCRIPTION
Update the `@return` docblock for the `end` function to be more precise, distinguishing between the return value for empty and non-empty arrays.

## 📌 What Does This PR Do?

Fixes the following false positive

```php
<?php

/**
 * @param non-empty-list<int> $test
 */
function x(array $test): int
{
    $item = end($test);

    return $item;
}

echo x([1]);
```

## 🛠️ Summary of Changes

- **Bug Fix:** Updated the `@return` docblock for the `end` function to be more precise, distinguishing between the return value for empty and non-empty arrays. This results in a better and more precise analysis.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Stubs, analyzer

