### PR TITLE
fix(stubs): sizeof return type should be the same as count

### DIFF
--- a/crates/prelude/assets/extensions/standard.php
+++ b/crates/prelude/assets/extensions/standard.php
@@ -4805,7 +4805,7 @@ function pos(object|array $array): mixed
 }
 
 /**
- * @return int<0, max>
+ * @return ($value is non-empty-array|non-empty-list ? int<1, max> : int<0, max>)
  *
  * @pure
  */


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR fixes return type of the sizeof function, which is an alias of the count function => they should return the same thing.

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed `sizeof` function not having the same return type as `count` on non-empty-arrays.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Stubs, analyzer

