### PR TITLE
fix(analyzer): add HasArrayKey assertion for array_key_exists function call

### DIFF
--- a/crates/analyzer/tests/cases/issue_391.php
+++ b/crates/analyzer/tests/cases/issue_391.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @pure
+ */
+function array_key_exists(string|int|float|bool|null $key, array $array): bool {}
+
+namespace Psl\Iter {
+    /**
+     * Returns true if the given iterable contains the key.
+     *
+     * @template Tk
+     * @template Tv
+     *
+     * @param iterable<Tk, Tv> $iterable
+     * @param Tk $key
+     */
+    function contains_key(iterable $iterable, mixed $key): bool {}
+}
+
+
+/**
+ * @param array<string, int> $test
+ */
+function x(array $test): void
+{
+    if (\array_key_exists('test', $test)) {
+        echo $test['test'];
+    }
+}
+
+/**
+ * @param array<string, int> $test
+ */
+function y(array $test): void
+{
+    if (Psl\Iter\contains_key($test, 'test')) {
+        echo $test['test'];
+    }
+}

--- a/crates/analyzer/tests/framework.rs
+++ b/crates/analyzer/tests/framework.rs
@@ -54,7 +54,12 @@ fn run_test_case_inner(config: TestCase) {
         &source_file,
         &resolved_names,
         &codebase,
-        Settings { find_unused_expressions: true, check_throws: true, ..Default::default() },
+        Settings {
+            find_unused_expressions: true,
+            check_throws: true,
+            allow_possibly_undefined_array_keys: false,
+            ..Default::default()
+        },
     );
 
     let analysis_run_result = analyzer.analyze(program, &mut analysis_result);

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -160,3 +160,4 @@ test_case!(iterator_to_array);
 // Github Issues
 test_case!(issue_306);
 test_case!(issue_359);
+test_case!(issue_391);


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR fixes a bug where `array_key_exists` and `key_exists` functions did not add the key to the type definition.
These functions now behave the same as isset() when used on an array.

fixes #391 

## 🛠️ Summary of Changes

- **Bug Fix:** Make `array_key_exists`, `key_exists` and `Psl\Iter\contains_key` functions behave the same as isset when used on an array.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): analyzer

## 🔗 Related Issues or PRs

fixes #391 