### PR TITLE
fix(analyzer): incorrect behavior with allow-possibly-undefined-array-keys

### DIFF
--- a/crates/analyzer/src/utils/expression/array.rs
+++ b/crates/analyzer/src/utils/expression/array.rs
@@ -616,7 +616,7 @@ pub(crate) fn handle_array_access_on_keyed_array<'ctx, 'arena>(
             }
 
             if !in_assignment {
-                if has_value_parameter {
+                if context.settings.allow_possibly_undefined_array_keys && has_value_parameter {
                     *has_possibly_undefined = true;
 
                     return value_parameter.into_owned();

--- a/crates/analyzer/tests/cases/issue_390.php
+++ b/crates/analyzer/tests/cases/issue_390.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @param array<string, int> $test
+ *
+ * @mago-expect analysis:mixed-argument
+ * @mago-expect analysis:undefined-string-array-index
+ */
+function x(array $test): void
+{
+    if (isset($test['test'])) {
+        echo $test['asdf'];
+    }
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -160,4 +160,5 @@ test_case!(iterator_to_array);
 // Github Issues
 test_case!(issue_306);
 test_case!(issue_359);
+test_case!(issue_390);
 test_case!(issue_391);


### PR DESCRIPTION


## 📌 What Does This PR Do?

This PR fixes an issue when checking for an array key presence, and then accessing a different one. Mago will now properly report an error.

fixes #390 

## 🛠️ Summary of Changes

- **Bug Fix:** The analyzer will now properly report error when checking for a key presence and accessing a different one later.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Analyzer

## 🔗 Related Issues or PRs

fixes #390 
