### PR TITLE
refactor(docblock): add variable struct

### DIFF
--- a/crates/analyzer/src/utils/docblock.rs
+++ b/crates/analyzer/src/utils/docblock.rs
@@ -144,7 +144,7 @@ pub fn get_docblock_variables<'ctx, 'arena>(
             let tag_content = tag.description;
 
             let var_tag = parse_var_tag(tag_content, tag.description_span)?;
-            let variable_name = var_tag.variable_name;
+            let variable_name = var_tag.variable.map(|v| v.raw_name());
             let type_string = var_tag.type_string;
 
             match get_type_from_string(

--- a/crates/analyzer/src/utils/docblock.rs
+++ b/crates/analyzer/src/utils/docblock.rs
@@ -144,7 +144,7 @@ pub fn get_docblock_variables<'ctx, 'arena>(
             let tag_content = tag.description;
 
             let var_tag = parse_var_tag(tag_content, tag.description_span)?;
-            let variable_name = var_tag.variable.map(|v| v.raw_name());
+            let variable_name = var_tag.variable.map(|v| v.to_string());
             let type_string = var_tag.type_string;
 
             match get_type_from_string(

--- a/crates/codex/src/scanner/function_like.rs
+++ b/crates/codex/src/scanner/function_like.rs
@@ -369,7 +369,7 @@ fn scan_function_like_docblock<'ctx, 'arena>(
                     .with_code(ScanningIssueKind::InvalidParamTag)
                     .with_annotation(Annotation::primary(parameter_tag.span).with_message(format!(
                         "Parameter `{}` is not defined in this function",
-                        parameter_tag.variable.raw_name()
+                        parameter_tag.variable
                     )))
                     .with_note(
                         "Each `@param` tag in a docblock must correspond to a parameter in the function's signature.",
@@ -440,10 +440,8 @@ fn scan_function_like_docblock<'ctx, 'arena>(
                 Issue::error("@param-out tag references an unknown parameter.")
                     .with_code(ScanningIssueKind::InvalidParamOutTag)
                     .with_annotation(
-                        Annotation::primary(param_out.span).with_message(format!(
-                            "Parameter `{}` does not exist",
-                            param_out.variable.raw_name()
-                        )),
+                        Annotation::primary(param_out.span)
+                            .with_message(format!("Parameter `{}` does not exist", param_out.variable)),
                     )
                     .with_note("The `@param-out` tag specifies the type of a by-reference parameter after the function has executed.")
                     .with_help("Check for typos or ensure this parameter exists in the function signature."),

--- a/crates/codex/src/scanner/function_like.rs
+++ b/crates/codex/src/scanner/function_like.rs
@@ -359,27 +359,18 @@ fn scan_function_like_docblock<'ctx, 'arena>(
     }
 
     for parameter_tag in docblock.parameters {
-        let parameter_name;
-        let parameter_name_str;
-        let is_variadic = parameter_tag.name.starts_with("...");
-        if is_variadic {
-            parameter_name_str = &parameter_tag.name[3..];
-            parameter_name = atom(parameter_name_str);
-        } else {
-            parameter_name_str = &parameter_tag.name;
-            parameter_name = atom(parameter_name_str);
-        }
-
+        let parameter_name = atom(&parameter_tag.variable.name);
         let param_type_string = &parameter_tag.type_string;
+        let is_variadic = parameter_tag.variable.is_variadic;
 
         let Some(parameter_metadata) = metadata.get_parameter_mut(parameter_name) else {
             metadata.issues.push(
                 Issue::error("The @param tag references an unknown parameter.")
                     .with_code(ScanningIssueKind::InvalidParamTag)
-                    .with_annotation(
-                        Annotation::primary(parameter_tag.span)
-                            .with_message(format!("Parameter `{parameter_name_str}` is not defined in this function")),
-                    )
+                    .with_annotation(Annotation::primary(parameter_tag.span).with_message(format!(
+                        "Parameter `{}` is not defined in this function",
+                        parameter_tag.variable.raw_name()
+                    )))
                     .with_note(
                         "Each `@param` tag in a docblock must correspond to a parameter in the function's signature.",
                     )
@@ -442,15 +433,17 @@ fn scan_function_like_docblock<'ctx, 'arena>(
     }
 
     for param_out in docblock.parameters_out {
-        let param_name = atom(&param_out.name);
+        let param_name = atom(&param_out.variable.name);
 
         let Some(parameter_metadata) = metadata.get_parameter_mut(param_name) else {
             metadata.issues.push(
                 Issue::error("@param-out tag references an unknown parameter.")
                     .with_code(ScanningIssueKind::InvalidParamOutTag)
                     .with_annotation(
-                        Annotation::primary(param_out.span)
-                            .with_message(format!("Parameter `{}` does not exist", param_out.name)),
+                        Annotation::primary(param_out.span).with_message(format!(
+                            "Parameter `{}` does not exist",
+                            param_out.variable.raw_name()
+                        )),
                     )
                     .with_note("The `@param-out` tag specifies the type of a by-reference parameter after the function has executed.")
                     .with_help("Check for typos or ensure this parameter exists in the function signature."),
@@ -576,7 +569,7 @@ fn scan_function_like_docblock<'ctx, 'arena>(
     }
 
     for assertion_tag in docblock.assertions {
-        let assertion_param_name = atom(&assertion_tag.parameter_name);
+        let assertion_param_name = atom(&assertion_tag.variable.name);
 
         let assertions = parse_assertion_string(assertion_tag.type_string, classname, &type_context, scope, metadata);
 
@@ -586,7 +579,7 @@ fn scan_function_like_docblock<'ctx, 'arena>(
     }
 
     for assertion_tag in docblock.if_true_assertions {
-        let assertion_param_name = atom(&assertion_tag.parameter_name);
+        let assertion_param_name = atom(&assertion_tag.variable.name);
 
         let assertions = parse_assertion_string(assertion_tag.type_string, classname, &type_context, scope, metadata);
 
@@ -596,7 +589,7 @@ fn scan_function_like_docblock<'ctx, 'arena>(
     }
 
     for assertion_tag in docblock.if_false_assertions {
-        let assertion_param_name = atom(&assertion_tag.parameter_name);
+        let assertion_param_name = atom(&assertion_tag.variable.name);
 
         let assertions = parse_assertion_string(assertion_tag.type_string, classname, &type_context, scope, metadata);
 

--- a/crates/docblock/src/tag.rs
+++ b/crates/docblock/src/tag.rs
@@ -1,16 +1,13 @@
 use mago_span::Span;
-use std::fmt;
 use serde::Deserialize;
 use serde::Serialize;
+use std::fmt;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
 pub struct Variable {
     pub name: String,          // normalized: includes `$`, excludes `...` and `&`
     pub is_variadic: bool,     // true if `...` was present
     pub is_by_reference: bool, // true if `&` was present
-}
-
-impl Variable {
 }
 
 impl fmt::Display for Variable {
@@ -775,13 +772,7 @@ mod tests {
 
     #[test]
     fn test_variable_display_and_raw() {
-        let cases = vec![
-            ("$x", "$x"),
-            ("&$x", "&$x"),
-            ("...$x", "...$x"),
-            ("...$x)", "...$x"),
-            ("...$x,", "...$x"),
-        ];
+        let cases = vec![("$x", "$x"), ("&$x", "&$x"), ("...$x", "...$x"), ("...$x)", "...$x"), ("...$x,", "...$x")];
 
         for (input, expected_raw) in cases {
             let v = parse_var_ident(input).expect("should parse variable");

--- a/crates/docblock/src/tag.rs
+++ b/crates/docblock/src/tag.rs
@@ -1,7 +1,28 @@
+use mago_span::Span;
 use serde::Deserialize;
 use serde::Serialize;
 
-use mago_span::Span;
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
+pub struct Variable {
+    pub name: String,          // normalized: includes `$`, excludes `...` and `&`
+    pub is_variadic: bool,     // true if `...` was present
+    pub is_by_reference: bool, // true if `&` was present
+}
+
+impl Variable {
+    #[inline]
+    pub fn raw_name(&self) -> String {
+        let mut raw_name = String::with_capacity(self.name.len() + 4);
+        if self.is_by_reference {
+            raw_name.push('&');
+        }
+        if self.is_variadic {
+            raw_name.push_str("...");
+        }
+        raw_name.push_str(&self.name);
+        raw_name
+    }
+}
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
 pub struct TypeString {
@@ -34,7 +55,7 @@ pub struct ImportTypeTag {
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
 pub struct ParameterTag {
     pub span: Span,
-    pub name: String,
+    pub variable: Variable,
     pub type_string: TypeString,
     pub description: String,
 }
@@ -42,7 +63,7 @@ pub struct ParameterTag {
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
 pub struct ParameterOutTag {
     pub span: Span,
-    pub name: String,
+    pub variable: Variable,
     pub type_string: TypeString,
 }
 
@@ -100,54 +121,40 @@ pub struct WhereTag {
 pub struct AssertionTag {
     pub span: Span,
     pub type_string: TypeString,
-    pub parameter_name: String,
+    pub variable: Variable,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
 pub struct VarTag {
     pub span: Span,
     pub type_string: TypeString,
-    pub variable_name: Option<String>,
+    pub variable: Option<Variable>,
 }
 
-/// Parses a PHPDoc var and returns the identifier token.
+/// Parses a PHPDoc variable token and returns a structured `Variable`.
 ///
-/// Accepts `$name`, `...$name` and `&$name`
-/// ASCII character after the name (e.g., `,`, `)`, whitespace), so trailing
+/// Supports `$name`, `...$name`, and `&$name`. The returned `Variable`
+/// preserves the `$` and optional `...` prefix in `name`, and sets flags
+/// for `is_variadic` and `is_by_reference` for downstream consumers.
 ///
-/// ## Examples
-///
-/// - `"$foo"`        → `Some("$foo")`
-/// - `"&$foo"`       → `Some("$foo")`
-/// - `"...$ids)"`    → `Some("...$ids")`
-/// - `"$bar,"`       → `Some("$bar")`
-/// - `"$"`           → `None`
-/// - `"...$"`        → `None`
-/// - `"$1x"`         → `None`
-///
-/// # Arguments
-///
-/// * `raw` - Raw token starting at the variable position.
-///
-/// # Returns
-///
-/// `Some(&str)` with a subslice contains the `$`/`...$` prefix
-/// and the identifier, or `None` if the token does not start with `$`/`...$`
-///
-/// # Notes
-///
-/// - Identifier rules are ASCII-only: `[_A-Za-z][_A-Za-z0-9]*`.
-/// - The returned slice length can be used to anchor any trailing description.
+/// Examples:
+/// - "$foo"       → Some(Variable { name: "$foo", is_variadic: false, is_by_reference: false })
+/// - "&$foo"      → Some(Variable { name: "$foo", is_variadic: false, is_by_reference: true })
+/// - "...$ids)"   → Some(Variable { name: "...$ids", is_variadic: true, is_by_reference: false })
+/// - "$"          → None
+/// - "...$"       → None
+/// - "$1x"        → None
 #[inline]
-fn parse_var_ident(raw: &str) -> Option<&str> {
+fn parse_var_ident(raw: &str) -> Option<Variable> {
+    let is_by_reference = raw.starts_with('&');
     // tolerate "&$x" in docblocks
     let raw = raw.strip_prefix('&').unwrap_or(raw);
 
     // accept "$name" or "...$name"
-    let (prefix_len, rest) = if let Some(r) = raw.strip_prefix("...$") {
-        (4usize, r)
+    let (prefix_len, rest, is_variadic) = if let Some(r) = raw.strip_prefix("...$") {
+        (4usize, r, true)
     } else if let Some(r) = raw.strip_prefix('$') {
-        (1usize, r)
+        (1usize, r, false)
     } else {
         return None;
     };
@@ -170,8 +177,10 @@ fn parse_var_ident(raw: &str) -> Option<&str> {
         len += 1;
     }
 
-    // Some from ...$ OR $ until ascii
-    Some(&raw[..prefix_len + len])
+    let token = &raw[..prefix_len + len];
+    // normalized: remove variadic prefix if present, keep `$`
+    let normalized = if is_variadic { &token[3..] } else { token };
+    Some(Variable { name: normalized.to_owned(), is_variadic, is_by_reference })
 }
 
 /// Parses the content string of a `@template` or `@template-covariant` tag.
@@ -335,13 +344,12 @@ pub fn parse_param_tag(content: &str, span: Span) -> Option<ParameterTag> {
 
     let mut rest_parts = rest_slice.split_whitespace();
     let raw_name = rest_parts.next()?;
-    let name_token = parse_var_ident(raw_name)?;
-    let name = name_token.to_owned();
+    let variable = parse_var_ident(raw_name)?;
 
-    let desc_start = rest_slice.find(name_token).map_or(0, |i| i + name_token.len());
+    let desc_start = rest_slice.find(&variable.name).map_or(0, |i| i + variable.name.len());
     let description = rest_slice[desc_start..].trim_start().to_owned();
 
-    Some(ParameterTag { span, name, type_string, description })
+    Some(ParameterTag { span, variable, type_string, description })
 }
 
 /// Parses the content string of a `@param-out` tag.
@@ -370,10 +378,9 @@ pub fn parse_param_out_tag(content: &str, span: Span) -> Option<ParameterOutTag>
     }
 
     let raw_name = rest_slice.split_whitespace().next()?;
-    let name_token = parse_var_ident(raw_name)?;
-    let name = name_token.to_owned();
+    let variable = parse_var_ident(raw_name)?;
 
-    Some(ParameterOutTag { span, name, type_string })
+    Some(ParameterOutTag { span, variable, type_string })
 }
 
 /// Parses the content string of a `@return` tag.
@@ -456,11 +463,9 @@ pub fn parse_assertion_tag(content: &str, span: Span) -> Option<AssertionTag> {
     let mut rest_parts = rest_slice.split_whitespace();
 
     let raw_name = rest_parts.next()?;
-    let name_token = parse_var_ident(raw_name)?;
+    let variable = parse_var_ident(raw_name)?;
 
-    let param_name = name_token.to_owned();
-
-    Some(AssertionTag { span, parameter_name: param_name, type_string })
+    Some(AssertionTag { span, variable, type_string })
 }
 
 /// Parses the content string of a `@var` tag.
@@ -484,14 +489,14 @@ pub fn parse_var_tag(content: &str, span: Span) -> Option<VarTag> {
         return None;
     }
 
-    let variable_name = if rest_slice.is_empty() {
+    let variable = if rest_slice.is_empty() {
         None
     } else {
         let var_part = rest_slice.split_whitespace().next()?;
-        parse_var_ident(var_part).map(|s| s.to_owned())
+        parse_var_ident(var_part)
     };
 
-    Some(VarTag { span, type_string, variable_name })
+    Some(VarTag { span, type_string, variable })
 }
 
 /// Parses the content string of a `@type` tag.
@@ -736,22 +741,34 @@ mod tests {
 
     #[test]
     fn test_parse_var_ident() {
-        let cases: &[(&str, Option<&str>)] = &[
-            // valid basics
-            ("$x", Some("$x")),
-            ("&$refVar", Some("$refVar")),     // ref drop '&'
-            ("$foo,", Some("$foo")),           // trailing excluded
-            ("...$ids)", Some("...$ids")),     // variadic with trailing ')'
-            ("...$items,", Some("...$items")), // variadic with trailing ','
-            // invalid tokens
-            ("$", None),    // no identifier
-            ("...$", None), // no identifier
-            ("$1x", None),  // cannot start with digit
-            ("foo", None),  // no '$'
+        struct Expect<'a> {
+            s: &'a str,
+            variadic: bool,
+            by_ref: bool,
+        }
+        let cases: &[(&str, Option<Expect>)] = &[
+            ("$x", Some(Expect { s: "$x", variadic: false, by_ref: false })),
+            ("&$refVar", Some(Expect { s: "$refVar", variadic: false, by_ref: true })),
+            ("$foo,", Some(Expect { s: "$foo", variadic: false, by_ref: false })),
+            ("...$ids)", Some(Expect { s: "$ids", variadic: true, by_ref: false })),
+            ("...$items,", Some(Expect { s: "$items", variadic: true, by_ref: false })),
+            ("$", None),
+            ("...$", None),
+            ("$1x", None),
+            ("foo", None),
         ];
 
         for (input, expected) in cases {
-            assert_eq!(parse_var_ident(input), *expected, "input={}", input);
+            let got = parse_var_ident(input);
+            match (got, expected) {
+                (None, None) => {}
+                (Some(v), Some(e)) => {
+                    assert_eq!(v.name, e.s, "input={}", input);
+                    assert_eq!(v.is_variadic, e.variadic, "input={}", input);
+                    assert_eq!(v.is_by_reference, e.by_ref, "input={}", input);
+                }
+                _ => panic!("mismatch for input={}", input),
+            }
         }
     }
 
@@ -850,7 +867,7 @@ mod tests {
         assert_eq!(result.type_string.value, "string|int"); // Check owned string value
         assert_eq!(result.type_string.span.start.offset, offset + 1); // Span of type part
         assert_eq!(result.type_string.span.end.offset, offset + 1 + "string|int".len() as u32);
-        assert_eq!(result.name, "$myVar");
+        assert_eq!(result.variable.name, "$myVar");
         assert_eq!(result.description, "Description here");
         assert_eq!(result.span, span); // Check overall span
     }
@@ -864,7 +881,7 @@ mod tests {
         assert_eq!(result.type_string.value, "array<int, string>"); // Check owned string
         assert_eq!(result.type_string.span.start.offset, offset + 1);
         assert_eq!(result.type_string.span.end.offset, offset + 1 + "array<int, string>".len() as u32);
-        assert_eq!(result.name, "$param");
+        assert_eq!(result.variable.name, "$param");
         assert_eq!(result.description, "");
     }
 
@@ -877,7 +894,7 @@ mod tests {
         assert_eq!(result.type_string.value, "(string // comment \n | int)");
         assert_eq!(result.type_string.span.start.offset, offset + 1);
         assert_eq!(result.type_string.span.end.offset, offset + 1 + "(string // comment \n | int)".len() as u32);
-        assert_eq!(result.name, "$var");
+        assert_eq!(result.variable.name, "$var");
         assert_eq!(result.description, "desc");
     }
 
@@ -967,7 +984,7 @@ mod tests {
         let content = " string $foo, desc";
         let span = test_span_for(content);
         let result = parse_param_tag(content, span).unwrap();
-        assert_eq!(result.name, "$foo");
+        assert_eq!(result.variable.name, "$foo");
         assert_eq!(result.description, ", desc");
     }
 
@@ -976,7 +993,7 @@ mod tests {
         let content = " list<int> ...$items) rest";
         let span = test_span_for(content);
         let result = parse_param_tag(content, span).unwrap();
-        assert_eq!(result.name, "...$items");
+        assert_eq!(result.variable.name, "$items");
         assert_eq!(result.description, ") rest");
     }
 
@@ -985,7 +1002,7 @@ mod tests {
         let content = " int $out,";
         let span = test_span_for(content);
         let result = parse_param_out_tag(content, span).unwrap();
-        assert_eq!(result.name, "$out");
+        assert_eq!(result.variable.name, "$out");
     }
 
     #[test]
@@ -993,7 +1010,7 @@ mod tests {
         let content = " int $x,";
         let span = test_span_for(content);
         let result = parse_assertion_tag(content, span).unwrap();
-        assert_eq!(result.parameter_name, "$x");
+        assert_eq!(result.variable.name, "$x");
     }
 
     #[test]
@@ -1001,7 +1018,7 @@ mod tests {
         let content = " string $foo,desc";
         let span = test_span_for(content);
         let result = parse_param_tag(content, span).unwrap();
-        assert_eq!(result.name, "$foo");
+        assert_eq!(result.variable.name, "$foo");
         assert_eq!(result.description, ",desc");
     }
 
@@ -1010,7 +1027,7 @@ mod tests {
         let content = " list<int> ...$items)more";
         let span = test_span_for(content);
         let result = parse_param_tag(content, span).unwrap();
-        assert_eq!(result.name, "...$items");
+        assert_eq!(result.variable.name, "$items");
         assert_eq!(result.description, ")more");
     }
 }


### PR DESCRIPTION
## 📌 What Does This PR Do?

Refactors the docblock parsing and consumption flow by introducing a structured `Variable` type (with variadic and by‑reference flags), normalizing variable names for matching, and improving diagnostics formatting. The change reduces duplicated logic across crates and clarifies how variable tokens are handled.

## 🔍 Context & Motivation

Feedback on #376 suggested going beyond keeping raw strings and modeling variables explicitly.

## 🛠️ Summary of Changes

- Refactor(docblock): add `Variable { name, is_variadic, is_by_reference }` (name includes `$`, excludes leading `...` and `&`).
- Refactor(docblock): `parse_var_ident` returns `Option<Variable>`; `ParameterTag`/`ParameterOutTag`/`AssertionTag`/`VarTag` now carry `Variable`.
- Ergonomics: implement `Display` for `Variable` so messages render as "&...$name". Remove unused helpers.
- Refactor(codex/analyzer): consume `Variable` directly; drop manual normalization; use `Display` for user‑facing messages.
- Tests: update expectations to normalized names; add coverage for `Variable` display.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Other: docblock parser (mago-docblock), scanners (mago-codex), analyzer utils (mago-analyzer)

## 🔗 Related Issues or PRs

- https://github.com/carthage-software/mago/pull/376

## 📝 Notes for Reviewers

- Breaking change: public shapes in `mago-docblock` changed (e.g., `name: String` → `variable: Variable`), and serde payloads follow suit. Need atention
- Diagnostics now print variables using `Display` (e.g., "&...$x"). Matching logic uses normalized names only.

### ⚠️⚠️⚠️
Case that changes looks dangerous can be use deprecated like this
```rust
impl ParameterTag {
    #[deprecated(note = "use self.variable.token")]
    pub fn name(&self) -> &str { &self.variable.token }
}
```
