### PR TITLE
Fix docs on concat_atom macro

### DIFF
--- a/crates/atom/src/lib.rs
+++ b/crates/atom/src/lib.rs
@@ -70,7 +70,7 @@ pub fn empty_atom() -> Atom {
 ///
 /// # Panics
 ///
-/// Panics at compile time if called with 0, 1, or more than 16 arguments.
+/// Panics at compile time if called with 0, 1, or more than 12 arguments.
 #[macro_export]
 macro_rules! concat_atom {
     ($s1:expr, $s2:expr $(,)?) => {


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes the docs of the `concat_atom` macro, which currently mentions it breaks on more than 16 arguments, but it actually breaks on more than 12.

## 🔍 Context & Motivation

The wrong docs may cause an unexpected panic.

## 🛠️ Summary of Changes

N/A

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [X] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

N/A

## 📝 Notes for Reviewers

N/A
