### PR TITLE
fix(analyzer): clone type recognition inside traits

### DIFF
--- a/crates/analyzer/src/expression/clone.rs
+++ b/crates/analyzer/src/expression/clone.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
 use mago_codex::class_or_interface_exists;
+use mago_codex::trait_exists;
 use mago_codex::ttype::TType;
 use mago_codex::ttype::atomic::TAtomic;
 use mago_codex::ttype::atomic::object::TObject;
@@ -51,7 +52,9 @@ impl<'ast, 'arena> Analyzable<'ast, 'arena> for Clone<'arena> {
                         invalid_clone_atomics.push(atomic_type);
                     }
                     TObject::Named(named_object) => {
-                        if !class_or_interface_exists(context.codebase, &named_object.name) {
+                        if !trait_exists(context.codebase, &named_object.name)
+                            && !class_or_interface_exists(context.codebase, &named_object.name)
+                        {
                             invalid_clone_atomics.push(atomic_type);
                         } else {
                             has_cloneable_object = true;

--- a/crates/analyzer/tests/cases/issue_415.php
+++ b/crates/analyzer/tests/cases/issue_415.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+interface ResponseInterface {}
+class Response implements ResponseInterface
+{
+    use Responseable;
+
+    public int $status = 200;
+}
+
+trait Responseable
+{
+    private Response $response;
+
+    public function withStatus(int $code): static
+    {
+        $cloned = clone $this;
+        $cloned->response->status = $code;
+        return $cloned;
+    }
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -175,3 +175,4 @@ test_case!(issue_391);
 test_case!(issue_393);
 test_case!(issue_396);
 test_case!(issue_400);
+test_case!(issue_415);


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR fixes type recognition when using clone $this inside a trait object.

## 🔍 Context & Motivation

<!-- Why is this change needed? Is it fixing a bug, adding a feature, or refactoring? -->

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed not being able to call clone on Trait objects, the analyzer will now properly assert a better type.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Analyzer

## 🔗 Related Issues or PRs

fixed #415 

## 📝 Notes for Reviewers

There is another "bug", when returning `$this` or a clone of `$this`, and we return static. Maybe we should look who's calling the method and return `T` instead of `T&static`.
