### PR TITLE
feat(docblock): parse method blocks

### DIFF
--- a/crates/analyzer/src/resolver/method.rs
+++ b/crates/analyzer/src/resolver/method.rs
@@ -306,6 +306,16 @@ pub fn get_method_ids_from_object<'ctx, 'ast, 'arena, 'object>(
         }
 
         ids.push((class_metadata, method_id, outer_object, *name));
+    } else {
+        // Check if it's a pseudo method from @method docblock
+        let lowercase_method_name = ascii_lowercase_atom(method_id.get_method_name());
+        if class_metadata.pseudo_methods.contains(&lowercase_method_name)
+            || class_metadata.static_pseudo_methods.contains(&lowercase_method_name)
+        {
+            // It's a pseudo method, treat it as existing but don't add to resolved methods
+            // since we don't have full metadata for analysis
+            ids.push((class_metadata, method_id, outer_object, *name));
+        }
     }
 
     if let Some(intersection_types) = object_type.get_intersection_types() {

--- a/crates/codex/src/lib.rs
+++ b/crates/codex/src/lib.rs
@@ -143,10 +143,11 @@ pub fn method_exists(codebase: &CodebaseMetadata, fqcn: &str, method_name: &str)
     let lowercase_fqcn = ascii_lowercase_atom(fqcn);
     let lowercase_method_name = ascii_lowercase_atom(method_name);
 
-    codebase
-        .class_likes
-        .get(&lowercase_fqcn)
-        .is_some_and(|meta| meta.appearing_method_ids.contains_key(&lowercase_method_name))
+    codebase.class_likes.get(&lowercase_fqcn).is_some_and(|meta| {
+        meta.appearing_method_ids.contains_key(&lowercase_method_name)
+            || meta.pseudo_methods.contains(&lowercase_method_name)
+            || meta.static_pseudo_methods.contains(&lowercase_method_name)
+    })
 }
 
 pub fn method_identifier_exists(codebase: &CodebaseMetadata, method_identifier: &MethodIdentifier) -> bool {

--- a/crates/codex/src/scanner/docblock.rs
+++ b/crates/codex/src/scanner/docblock.rs
@@ -28,6 +28,8 @@ pub struct ClassLikeDocblockComment {
     pub require_extends: Vec<TypeString>,
     pub require_implements: Vec<TypeString>,
     pub inheritors: Option<TypeString>,
+    pub methods: Vec<MethodTag>,
+    pub static_methods: Vec<MethodTag>,
     pub unchecked: bool,
 }
 
@@ -104,6 +106,8 @@ impl ClassLikeDocblockComment {
         let mut inheritors = None;
         let mut is_enum_interface = false;
         let mut unchecked = false;
+        let mut methods = Vec::new();
+        let mut static_methods = Vec::new();
 
         let parsed_docblock = parse_trivia(context.arena, docblock)?;
 
@@ -149,6 +153,15 @@ impl ClassLikeDocblockComment {
 
                     if let Some((inheritors_tag, _)) = split_tag_content(description_str, description_span) {
                         inheritors = Some(inheritors_tag);
+                    }
+                }
+                TagKind::Method | TagKind::PsalmMethod => {
+                    if let Some(method_tag) = parse_method_tag(tag.description, tag.description_span) {
+                        if method_tag.is_static {
+                            static_methods.push(method_tag);
+                        } else {
+                            methods.push(method_tag);
+                        }
                     }
                 }
                 TagKind::PhpstanTemplate
@@ -240,6 +253,8 @@ impl ClassLikeDocblockComment {
             require_implements,
             inheritors,
             unchecked,
+            methods,
+            static_methods,
         }))
     }
 }


### PR DESCRIPTION
## 📌 What Does This PR Do?

Adds support for parsing and recognizing `@method` docblock tags to prevent "non-existent method" errors for magic methods documented in class docblocks.

## 🔍 Context & Motivation

PHP classes often use magic methods (`__call`, `__callStatic`) to dynamically handle method calls. These methods are typically documented using `@method` docblock tags to provide type information and IDE support. However, static analysis tools would report these methods as "non-existent" since they don't exist as actual PHP methods.

This change allows mago to recognize `@method` annotations and treat documented methods as valid, eliminating false positive errors during static analysis.

## 🛠️ Summary of Changes

- **Feature:** Added `@method` docblock tag parsing support
- **Feature:** Added `MethodTag` struct to represent parsed method information
- **Feature:** Added `parse_method_tag` function with support for static methods
- **Enhancement:** Extended `ClassLikeDocblockComment` to store method and static method tags
- **Enhancement:** Modified class scanner to create pseudo methods from `@method` tags
- **Enhancement:** Updated method existence checks to include pseudo methods
- **Enhancement:** Enhanced method resolution to recognize pseudo methods

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Analyzer, Docblock Parser, Codex

## 🔗 Related Issues or PRs

<!-- Enhances static analysis capabilities for PHP magic methods -->

## 📝 Notes for Reviewers

- The implementation creates `FunctionLikeMetadata` entries for pseudo methods to maintain consistency with the existing method resolution system
- Both `@method` and `@psalm-method` tags are supported
- Static methods are handled separately using `@method static` syntax
- Pseudo methods are stored in `pseudo_methods` and `static_pseudo_methods` sets in `ClassLikeMetadata`
- The change is backward compatible and doesn't affect existing functionality

### Example Usage:
```php
/**
 * @method string getName() Get the user name
 * @method static User create(array $data) Create a new user
 * @method void setAge(int $age) Set user age
 */
class User {
    public function __call($method, $args) {
        // Magic method implementation
    }
}

$user = new User();
$user->getName(); // No longer reports "non-existent method"
$user->setAge(25); // No longer reports "non-existent method"
User::create(['name' => 'John']); // No longer reports "non-existent method"
```