### PR TITLE
feat(analyzer): add support for @method annotations in doc comments

### DIFF
--- a/crates/analyzer/src/code.rs
+++ b/crates/analyzer/src/code.rs
@@ -148,6 +148,7 @@ pub enum IssueCode {
     NoValidCatchTypeFound,
     NoValue,
     NonClassUsedAsAttribute,
+    NonDocumentedMethod,
     NonExistentAttributeClass,
     NonExistentCatchType,
     NonExistentClass,
@@ -396,6 +397,7 @@ impl IssueCode {
             Self::NoValidCatchTypeFound => "no-valid-catch-type-found",
             Self::NoValue => "no-value",
             Self::NonClassUsedAsAttribute => "non-class-used-as-attribute",
+            Self::NonDocumentedMethod => "non-documented-method",
             Self::NonExistentAttributeClass => "non-existent-attribute-class",
             Self::NonExistentCatchType => "non-existent-catch-type",
             Self::NonExistentClass => "non-existent-class",
@@ -1007,7 +1009,7 @@ impl IssueCode {
         ]
     }
 
-    pub const fn get_method_issue_codes() -> [Self; 11] {
+    pub const fn get_method_issue_codes() -> [Self; 12] {
         [
             Self::AmbiguousObjectMethodAccess,
             Self::DeprecatedMethod,
@@ -1016,6 +1018,7 @@ impl IssueCode {
             Self::InvalidStaticMethodCall,
             Self::MethodAccessOnNull,
             Self::MixedMethodAccess,
+            Self::NonDocumentedMethod,
             Self::NonExistentMethod,
             Self::PossibleMethodAccessOnNull,
             Self::UnimplementedAbstractMethod,
@@ -1023,7 +1026,7 @@ impl IssueCode {
         ]
     }
 
-    pub const fn get_method_issue_code_values() -> [&'static str; 11] {
+    pub const fn get_method_issue_code_values() -> [&'static str; 12] {
         [
             "ambiguous-object-method-access",
             "deprecated-method",
@@ -1032,6 +1035,7 @@ impl IssueCode {
             "invalid-static-method-call",
             "method-access-on-null",
             "mixed-method-access",
+            "non-documented-method",
             "non-existent-method",
             "possible-method-access-on-null",
             "unimplemented-abstract-method",
@@ -1222,6 +1226,7 @@ impl std::str::FromStr for IssueCode {
             "no-valid-catch-type-found" => Ok(Self::NoValidCatchTypeFound),
             "no-value" => Ok(Self::NoValue),
             "non-class-used-as-attribute" => Ok(Self::NonClassUsedAsAttribute),
+            "non-documented-method" => Ok(Self::NonDocumentedMethod),
             "non-existent-attribute-class" => Ok(Self::NonExistentAttributeClass),
             "non-existent-catch-type" => Ok(Self::NonExistentCatchType),
             "non-existent-class" => Ok(Self::NonExistentClass),

--- a/crates/analyzer/tests/cases/method_docblock.php
+++ b/crates/analyzer/tests/cases/method_docblock.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @method void a($a) no type in param
+ * @method int e($a) no type in param
+ * @method int b(int $a) with types
+ * @method static int c(int $a) with static
+ * @method static int d(callable(int): int $callable) with static and callable param
+ * @method private static int f() private method
+ */
+class Test {}
+
+$t = new Test();
+
+$t->a(10);
+$e = $t->e(10);
+/** @mago-expect analysis:type-confirmation */
+Mago\confirm($e, 'int');
+$b = $t->b(10);
+/** @mago-expect analysis:type-confirmation */
+Mago\confirm($b, 'int');
+$c = Test::c(10);
+/** @mago-expect analysis:type-confirmation */
+Mago\confirm($c, 'int');
+$z = Test::d(fn(int $p) => $p * 2);
+/** @mago-expect analysis:type-confirmation */
+Mago\confirm($z, 'int');
+
+/** @mago-expect analysis:too-few-arguments */
+Test::c();
+
+/** @mago-expect analysis:too-many-arguments */
+Test::c(1, 2, 3);
+
+/** @mago-expect analysis:non-existent-method */
+Test::x();
+
+/** @mago-expect analysis:invalid-static-method-access */
+Test::a(10);
+
+/** @mago-expect analysis:invalid-method-access */
+Test::f();
+
+class X
+{
+    public function __call($name, $arguments) {}
+
+    public static function __callStatic($name, $arguments) {}
+}
+
+$x = new X();
+
+/** @mago-expect analysis:non-documented-method */
+$x::x();
+
+/** @mago-expect analysis:non-documented-method */
+$x->x();

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -164,6 +164,7 @@ test_case!(all_paths_return_value);
 test_case!(reconcile_scalars);
 test_case!(static_anonymous_class);
 test_case!(private_static_method);
+test_case!(method_docblock);
 test_case!(property_docblock);
 test_case!(untyped_property_docblock);
 

--- a/crates/codex/src/scanner/docblock.rs
+++ b/crates/codex/src/scanner/docblock.rs
@@ -29,6 +29,7 @@ pub struct ClassLikeDocblockComment {
     pub require_implements: Vec<TypeString>,
     pub inheritors: Option<TypeString>,
     pub unchecked: bool,
+    pub methods: Vec<MethodTag>,
     pub properties: Vec<PropertyTag>,
 }
 
@@ -105,6 +106,7 @@ impl ClassLikeDocblockComment {
         let mut inheritors = None;
         let mut is_enum_interface = false;
         let mut unchecked = false;
+        let mut methods = Vec::new();
         let mut properties = Vec::new();
 
         let parsed_docblock = parse_trivia(context.arena, docblock)?;
@@ -219,6 +221,11 @@ impl ClassLikeDocblockComment {
                     require_implements
                         .push(TypeString { value: tag.description.to_string(), span: tag.description_span });
                 }
+                TagKind::Method | TagKind::PsalmMethod => {
+                    if let Some(method) = parse_method_tag(tag.description, tag.description_span) {
+                        methods.push(method);
+                    }
+                }
                 TagKind::Property | TagKind::PsalmProperty => {
                     if let Some(property_tag) = parse_property_tag(tag.description, tag.description_span, true, true) {
                         properties.push(property_tag);
@@ -257,6 +264,7 @@ impl ClassLikeDocblockComment {
             require_implements,
             inheritors,
             unchecked,
+            methods,
             properties,
         }))
     }

--- a/scripts/regen-analyzer-issue-codes.php
+++ b/scripts/regen-analyzer-issue-codes.php
@@ -297,6 +297,7 @@ final class AnalyzerCodeModuleGenerator
         'invalid-override-attribute',
         'unused-parameter',
         'reference-reused-from-confusing-scope',
+        'non-documented-method',
     ];
 
     /**


### PR DESCRIPTION
## 📌 What Does This PR Do?

this PR adds support for analysis of `@method` annotations inside class doc comments

## 🛠️ Summary of Changes

- **Feature:** Add support for analysis of `@method` annotations inside class documentation comments.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Analyzer

## 🔗 Related Issues or PRs

related to #405 

