### PR TITLE
fix(analyzer): add check for visibility when calling methods statically

### DIFF
--- a/crates/analyzer/src/expression/call/static_method_call.rs
+++ b/crates/analyzer/src/expression/call/static_method_call.rs
@@ -23,7 +23,7 @@ impl<'ast, 'arena> Analyzable<'ast, 'arena> for StaticMethodCall<'arena> {
         artifacts: &mut AnalysisArtifacts,
     ) -> Result<(), AnalysisError> {
         let method_resolution =
-            resolve_static_method_targets(context, block_context, artifacts, self.class, &self.method)?;
+            resolve_static_method_targets(context, block_context, artifacts, self.class, &self.method, self.span())?;
 
         let mut invocation_targets = vec![];
         for resolved_method in method_resolution.resolved_methods {

--- a/crates/analyzer/src/expression/closure_creation/static_method_closure_creation.rs
+++ b/crates/analyzer/src/expression/closure_creation/static_method_closure_creation.rs
@@ -4,6 +4,7 @@ use mago_codex::ttype::atomic::callable::TCallable;
 use mago_codex::ttype::get_mixed_closure;
 use mago_codex::ttype::get_never;
 use mago_codex::ttype::union::TUnion;
+use mago_span::HasSpan;
 use mago_syntax::ast::*;
 
 use crate::analyzable::Analyzable;
@@ -21,7 +22,7 @@ impl<'ast, 'arena> Analyzable<'ast, 'arena> for StaticMethodClosureCreation<'are
         artifacts: &mut AnalysisArtifacts,
     ) -> Result<(), AnalysisError> {
         let method_resolution =
-            resolve_static_method_targets(context, block_context, artifacts, self.class, &self.method)?;
+            resolve_static_method_targets(context, block_context, artifacts, self.class, &self.method, self.span())?;
 
         let mut callables = vec![];
         for resolved_method in method_resolution.resolved_methods {

--- a/crates/analyzer/tests/cases/private_static_method.php
+++ b/crates/analyzer/tests/cases/private_static_method.php
@@ -1,0 +1,10 @@
+<?php
+
+class X {
+    private static function x(): void
+    {
+    }
+}
+
+/** @mago-expect analysis:invalid-method-access */
+X::x();

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -163,6 +163,7 @@ test_case!(arrow_function_inherits_method_templates);
 test_case!(all_paths_return_value);
 test_case!(reconcile_scalars);
 test_case!(static_anonymous_class);
+test_case!(private_static_method);
 
 // Github Issues
 test_case!(issue_275);


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR fixes a bug when visibility analysis was not performed, when a method was being called statically.

## 🔍 Context & Motivation

<!-- Why is this change needed? Is it fixing a bug, adding a feature, or refactoring? -->

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed an issue with static method calls were not properly analyzed for visibility checks.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Analyzer

## 🔗 Related Issues or PRs

