### PR TITLE
docs: update link for PHP CodeSniffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Mago stands on the shoulders of giants. Our design and functionality are heavily
 
 ### Acknowledgements:
 
-We deeply respect the foundational work of tools like [PHP-CS-Fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer), [Psalm](https://github.com/vimeo/psalm), [PHPStan](https://github.com/phpstan/phpstan), and [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer). While Mago aims to offer a unified and faster alternative, these tools paved the way for modern PHP development.
+We deeply respect the foundational work of tools like [PHP-CS-Fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer), [Psalm](https://github.com/vimeo/psalm), [PHPStan](https://github.com/phpstan/phpstan), and [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer). While Mago aims to offer a unified and faster alternative, these tools paved the way for modern PHP development.
 
 ## License
 


### PR DESCRIPTION
## 📌 What Does This PR Do?

Provides an updated link for PHP CodeSniffer in the README.

## 🔍 Context & Motivation

The repo linked to is no longer current.

## 🛠️ Summary of Changes

- **Docs:** Updated README.

## 📂 Affected Areas

- [X] Documentation
