### PR TITLE
feat(analyzer): add support for `@property` annotations

### DIFF
--- a/crates/analyzer/tests/cases/property_docblock.php
+++ b/crates/analyzer/tests/cases/property_docblock.php
@@ -1,0 +1,28 @@
+<?php
+
+class A {}
+
+/**
+ * @property-read A|int $x
+ * @property int $y
+ * @property-write int $z
+ */
+class T {
+ private A|int $x;
+}
+
+$t = new T();
+
+$a = $t->x;
+/** @mago-expect analysis:invalid-property-write */
+$t->x = 10;
+
+$b = $t->y;
+$t->y = 10;
+
+/** @mago-expect analysis:undefined-variable */
+$c = $t->z;
+$t->z = 10;
+/** @mago-expect analysis:type-confirmation */
+Mago\confirm($z, 'int');
+

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -164,6 +164,7 @@ test_case!(all_paths_return_value);
 test_case!(reconcile_scalars);
 test_case!(static_anonymous_class);
 test_case!(private_static_method);
+test_case!(property_docblock);
 
 // Github Issues
 test_case!(issue_275);


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR adds support for `@property` annotations. All three (`@property`, `@property-read` and `@property-write`) are supported.

## 🛠️ Summary of Changes

- **Feature:** Added support for `@property` annotations.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Analyzer

## 🔗 Related Issues or PRs

related to #405 

