### PR TITLE
Include Cargo and Rustc in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,8 @@
       in {
         devShells.default = pkgs.mkShell {
           buildInputs = [
+            pkgs.cargo
+            pkgs.rustc
             pkgs.rustup
             pkgs.rust-analyzer
             pkgs.pkg-config


### PR DESCRIPTION
## 📌 What Does This PR Do?

Adds `rustc` and `cargo` to the `flake.nix` packages.

## 🔍 Context & Motivation

As of `nixos-25.05` (stable) the cargo and rustc versions were not up-to-date
enough to compile Mago. Including them explicitly in the `flake.nix`
ensures that mago can be compiled in the development shell.

## 📂 Affected Areas

- [x] Other (please specify): flake.nix

---

As an aside I'm the maintainer of the Phpactor language server, and I'm looking
forward to the day that I'm not :sweat_smile: but jokes-aside just dropping a
note here to offer my support and will be keeping an eye on the progress as
I'm sure this project will provide a responsive and reliable PHP language
server!
