### PR TITLE
feat(linter): implement no-redundant-use rule to remove unused imports

### DIFF
--- a/crates/linter/src/rule/mod.rs
+++ b/crates/linter/src/rule/mod.rs
@@ -182,6 +182,7 @@ define_rules! {
     NoRedundantFile(no_redundant_file @ NoRedundantFileRule),
     NoRedundantContinue(no_redundant_continue @ NoRedundantContinueRule),
     NoRedundantBlock(no_redundant_block @ NoRedundantBlockRule),
+    NoRedundantUse(no_redundant_use @ NoRedundantUseRule),
     NoPhpTagTerminator(no_php_tag_terminator @ NoPhpTagTerminatorRule),
     NoNoop(no_noop @ NoNoopRule),
     NoMultiAssignments(no_multi_assignments @ NoMultiAssignmentsRule),

--- a/crates/linter/src/rule/redundancy/mod.rs
+++ b/crates/linter/src/rule/redundancy/mod.rs
@@ -13,6 +13,7 @@ pub mod no_redundant_method_override;
 pub mod no_redundant_nullsafe;
 pub mod no_redundant_parentheses;
 pub mod no_redundant_string_concat;
+pub mod no_redundant_use;
 pub mod no_redundant_write_visibility;
 
 pub use constant_condition::*;
@@ -30,4 +31,5 @@ pub use no_redundant_method_override::*;
 pub use no_redundant_nullsafe::*;
 pub use no_redundant_parentheses::*;
 pub use no_redundant_string_concat::*;
+pub use no_redundant_use::*;
 pub use no_redundant_write_visibility::*;

--- a/crates/linter/src/rule/redundancy/no_redundant_use.rs
+++ b/crates/linter/src/rule/redundancy/no_redundant_use.rs
@@ -1,0 +1,185 @@
+use indoc::indoc;
+use mago_fixer::SafetyClassification;
+use mago_span::HasSpan;
+use mago_span::Span;
+use serde::Deserialize;
+use serde::Serialize;
+
+use mago_reporting::Annotation;
+use mago_reporting::Issue;
+use mago_reporting::Level;
+use mago_syntax::ast::*;
+
+use crate::category::Category;
+use crate::context::LintContext;
+use crate::requirements::RuleRequirements;
+use crate::rule::Config;
+use crate::rule::LintRule;
+use crate::rule_meta::RuleMeta;
+use crate::settings::RuleSettings;
+
+#[derive(Debug, Clone)]
+pub struct NoRedundantUseRule {
+    meta: &'static RuleMeta,
+    cfg: NoRedundantUseConfig,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct NoRedundantUseConfig {
+    pub level: Level,
+}
+
+impl Default for NoRedundantUseConfig {
+    fn default() -> Self {
+        Self { level: Level::Warning }
+    }
+}
+
+impl Config for NoRedundantUseConfig {
+    fn level(&self) -> Level {
+        self.level
+    }
+}
+
+impl LintRule for NoRedundantUseRule {
+    type Config = NoRedundantUseConfig;
+
+    fn meta() -> &'static RuleMeta {
+        const META: RuleMeta = RuleMeta {
+            name: "No Redundant Use",
+            code: "no-redundant-use",
+            description: indoc! {"
+                Detects `use` statements that import items that are never used.
+            "},
+            good_example: indoc! {r#"
+                <?php
+                namespace App;
+
+                use App\Helpers\ArrayHelper;
+
+                $result = ArrayHelper::combine([]);
+            "#},
+            bad_example: indoc! {r#"
+                <?php
+                namespace App;
+
+                use App\Helpers\ArrayHelper;
+                use App\Helpers\StringHelper;
+
+                $result = ArrayHelper::combine([]);
+            "#},
+            category: Category::Redundancy,
+            requirements: RuleRequirements::None,
+        };
+
+        &META
+    }
+
+    fn targets() -> &'static [NodeKind] {
+        const TARGETS: &[NodeKind] = &[NodeKind::Use];
+        TARGETS
+    }
+
+    fn build(settings: RuleSettings<Self::Config>) -> Self {
+        Self { meta: Self::meta(), cfg: settings.config }
+    }
+
+    fn check<'ast, 'arena>(&self, ctx: &mut LintContext<'_, 'arena>, node: Node<'ast, 'arena>) {
+        let Node::Use(use_statement) = node else {
+            return;
+        };
+
+        if is_entire_statement_unused(ctx, &use_statement.items) {
+            let issue = Issue::new(self.cfg.level(), "Unused import statement.")
+                .with_code(self.meta.code)
+                .with_annotation(Annotation::primary(use_statement.span()).with_message("This import is never used"))
+                .with_help("Remove the unused import statement.");
+
+            ctx.collector.propose(issue, |plan| {
+                plan.delete(use_statement.span().to_range(), SafetyClassification::Safe);
+            });
+        } else {
+            for (name, alias, span) in get_unused_items(ctx, &use_statement.items) {
+                let message = if let Some(alias) = alias {
+                    format!("Unused import: `{} as {}`", name, alias)
+                } else {
+                    format!("Unused import: `{}`", name)
+                };
+
+                let issue = Issue::new(self.cfg.level(), "Unused import statement.")
+                    .with_code(self.meta.code)
+                    .with_annotation(Annotation::primary(span).with_message(&message))
+                    .with_help("Remove the unused import from the group import statement.");
+
+                ctx.collector.propose(issue, |plan| {
+                    plan.delete(span.to_range(), SafetyClassification::Safe);
+                });
+            }
+        }
+    }
+}
+
+fn is_entire_statement_unused(ctx: &LintContext<'_, '_>, items: &UseItems) -> bool {
+    utils::get_use_items(items).all(|item| !utils::is_name_used(ctx, item))
+}
+
+fn get_unused_items<'arena>(
+    ctx: &LintContext<'_, 'arena>,
+    items: &'arena UseItems<'arena>,
+) -> Vec<(&'arena str, Option<&'arena str>, Span)> {
+    utils::get_use_items(items).filter_map(|item| utils::get_unused_item_info(ctx, item)).collect()
+}
+
+mod utils {
+    use crate::context::LintContext;
+    use mago_span::{HasSpan, Span};
+    use mago_syntax::ast::*;
+
+    pub fn get_use_items<'arena>(
+        items: &'arena UseItems<'arena>,
+    ) -> Box<dyn Iterator<Item = &'arena UseItem<'arena>> + 'arena> {
+        match items {
+            UseItems::Sequence(sequence) => Box::new(sequence.items.nodes.iter()),
+            UseItems::TypedSequence(sequence) => Box::new(sequence.items.nodes.iter()),
+            UseItems::TypedList(list) => Box::new(list.items.nodes.iter()),
+            UseItems::MixedList(list) => Box::new(list.items.nodes.iter().map(|typed_item| &typed_item.item)),
+        }
+    }
+
+    #[inline]
+    pub fn get_unused_item_info<'arena>(
+        ctx: &LintContext<'_, 'arena>,
+        item: &UseItem<'arena>,
+    ) -> Option<(&'arena str, Option<&'arena str>, Span)> {
+        if is_name_used(ctx, item) {
+            return None;
+        }
+
+        let name = extract_short_name(item.name.value());
+        let alias = item.alias.as_ref().map(|a| a.identifier.value);
+        Some((name, alias, item.span()))
+    }
+
+    #[inline]
+    fn extract_short_name<'a>(name: &'a str) -> &'a str {
+        name.rsplit('\\').next().unwrap_or(name)
+    }
+
+    #[inline]
+    pub fn is_name_used(ctx: &LintContext<'_, '_>, item: &UseItem) -> bool {
+        let identifier = item
+            .alias
+            .as_ref()
+            .map(|alias| alias.identifier.value)
+            .unwrap_or_else(|| extract_short_name(item.name.value()));
+
+        for (_position, (resolved_name, _was_imported)) in ctx.resolved_names.all().iter() {
+            if *resolved_name == identifier || extract_short_name(resolved_name) == identifier {
+                return true;
+            }
+        }
+
+        false
+    }
+}

--- a/crates/linter/src/settings.rs
+++ b/crates/linter/src/settings.rs
@@ -71,6 +71,7 @@ pub struct RulesSettings {
     pub no_redundant_file: RuleSettings<NoRedundantFileConfig>,
     pub no_redundant_continue: RuleSettings<NoRedundantContinueConfig>,
     pub no_redundant_block: RuleSettings<NoRedundantBlockConfig>,
+    pub no_redundant_use: RuleSettings<NoRedundantUseConfig>,
     pub no_php_tag_terminator: RuleSettings<NoPhpTagTerminatorConfig>,
     pub no_noop: RuleSettings<NoNoopConfig>,
     pub no_multi_assignments: RuleSettings<NoMultiAssignmentsConfig>,


### PR DESCRIPTION
## 📌 What Does This PR Do?

Adds a new linter rule `no-redundant-use` that detects and removes unused `use` statements. The rule identifies both entirely unused import statements and specific unused items within group imports


## 🔍 Context & Motivation

To Automatically detect and remove the unused/redundant imports

## 🛠️ Summary of Changes

- **Feature:** Added `redundancy/no-redundant-use` rule.


## 📂 Affected Areas

- [x] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Fixes #154 

## 📝 Notes for Reviewers


