### PR TITLE
feat(formatter) support for spaces in call arguments

### DIFF
--- a/crates/formatter/src/internal/format/call_arguments.rs
+++ b/crates/formatter/src/internal/format/call_arguments.rs
@@ -84,6 +84,12 @@ pub(super) fn print_argument_list<'arena>(
 
     let mut contents = vec![in f.arena; clone_in_arena(f.arena, &left_parenthesis)];
 
+    if  f.settings.space_within_call_arguments {
+        contents.push(Document::Space(Space {
+            soft: true,
+        }));
+    }
+
     // First, run all the decision functions with unformatted arguments
     let should_break_all = force_break || should_break_all_arguments(f, argument_list, for_attribute);
     let should_inline = !force_break && should_inline_breaking_arguments(f, argument_list);
@@ -317,6 +323,13 @@ pub(super) fn print_argument_list<'arena>(
     if f.settings.trailing_comma {
         contents.push(Document::IfBreak(IfBreak::then(f.arena, Document::String(","))));
     }
+
+    if  f.settings.space_within_call_arguments {
+        contents.push(Document::Space(Space {
+            soft: true,
+        }));
+    }
+
     contents.push(print_right_parenthesis(f, dangling_comments.as_ref(), &right_parenthesis, None));
 
     Document::Group(Group::new(contents).with_id(group_id))

--- a/crates/formatter/src/settings.rs
+++ b/crates/formatter/src/settings.rs
@@ -726,6 +726,15 @@ pub struct FormatSettings {
     #[serde(default = "default_false")]
     pub space_within_grouping_parenthesis: bool,
 
+    /// Whether to add spaces within call arguments.
+    ///
+    /// When enabled: `foo( $arg1, $arg2 )`
+    /// When disabled: `foo($arg1, $arg2)`
+    ///
+    /// Default: false
+    #[serde(default = "default_false")]
+    pub space_within_call_arguments: bool,
+
     /// Whether to add an empty line after control structures (if, for, foreach, while, do, switch).
     ///
     /// Note: if an empty line already exists, it will be preserved regardless of this
@@ -892,6 +901,7 @@ impl Default for FormatSettings {
             space_before_closure_use_clause_parenthesis: true,
             space_around_assignment_in_declare: false,
             space_within_grouping_parenthesis: false,
+            space_within_call_arguments: false,
             space_before_hook_parameter_list_parenthesis: false,
             space_around_concatenation_binary_operator: true,
             space_after_cast_unary_prefix_operators: true,


### PR DESCRIPTION
## 📌 What Does This PR Do?

Adds an option to add spaces around the arguments list in function calls etc.

## 🔍 Context & Motivation

Adds an option in the search of supporting the WordPress PHP Coding Standard

## 🛠️ Summary of Changes

- **Feature:** Added `formatter/space-within-call-arguments ` setting.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

If this is the right approach, there are several other rules to add around spacing (e.g. arguments in control structure arguments such as `if`, `switch` etc.
