### PR TITLE
fix(linter): use-compound-assignment applies only to Assign operator

### DIFF
--- a/crates/linter/src/rule/best_practices/use_compound_assignment.rs
+++ b/crates/linter/src/rule/best_practices/use_compound_assignment.rs
@@ -91,6 +91,10 @@ impl LintRule for UseCompoundAssignmentRule {
             return;
         };
 
+        if !assignment.operator.is_assign() {
+            return;
+        }
+
         let Expression::Binary(binary) = assignment.rhs else {
             return;
         };


### PR DESCRIPTION
## 📌 What Does This PR Do?

fixes #470 

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed a bug in linter that would apply `use-compound-assignment` rule to assignments which are already compound.

## 📂 Affected Areas

- [x] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs
fixes #470 