### PR TITLE
fix(prelude): pdo fetchObject stub

### DIFF
--- a/crates/prelude/assets/extensions/pdo.php
+++ b/crates/prelude/assets/extensions/pdo.php
@@ -744,7 +744,7 @@ namespace {
          *
          * @param class-string<T>|null $class
          *
-         * @return T|null
+         * @return T|null|false
          *
          * @throws PDOException
          */


### PR DESCRIPTION
## 📌 What Does This PR Do?

when using PDO without exceptions, PDOStatement::fetchObject returns false on error:

Returns an instance of the required class with property names that correspond to the column names or false on failure.

## 🛠️ Summary of Changes

- **Bug Fix:** Corrected PDO::fetchObject return value.

