### PR TITLE
fix(prelude): adjust implode array param to allow for all stringable types

### DIFF
--- a/crates/prelude/assets/extensions/standard.php
+++ b/crates/prelude/assets/extensions/standard.php
@@ -1731,7 +1731,7 @@ function explode(string $separator, string $string, int $limit = PHP_INT_MAX): a
 
 /**
  * @param array<string>|string $separator
- * @param array<string>|null $array
+ * @param array<int|string|float|bool|null|Stringable>|null $array
  *
  * @pure
  */
@@ -1741,7 +1741,7 @@ function implode(array|string $separator = '', null|array $array = null): string
 
 /**
  * @param array<string>|string $separator
- * @param array<string>|null $array
+ * @param array<int|string|float|bool|null|Stringable>|null $array
  *
  * @pure
  */


### PR DESCRIPTION
## 📌 What Does This PR Do?

allows for passing array of [1, 1.5, true, false, 'asdf', Stringable] into implode/join

## 🔍 Context & Motivation

<!-- Why is this change needed? Is it fixing a bug, adding a feature, or refactoring? -->

## 🛠️ Summary of Changes

- **Bug Fix:** Enhance stubs for `join` and `implode` functions

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):
