### PR TITLE
fix: make session argument optional

### DIFF
--- a/crates/prelude/assets/extensions/session.php
+++ b/crates/prelude/assets/extensions/session.php
@@ -70,7 +70,7 @@ function session_save_path(null|string $path): string|false
 {
 }
 
-function session_id(null|string $id): string|false
+function session_id(null|string $id = null): string|false
 {
 }
 

--- a/crates/prelude/assets/extensions/session.php
+++ b/crates/prelude/assets/extensions/session.php
@@ -58,15 +58,15 @@ class SessionHandler implements SessionHandlerInterface, SessionIdInterface
     }
 }
 
-function session_name(null|string $name): string|false
+function session_name(null|string $name = null): string|false
 {
 }
 
-function session_module_name(null|string $module): string|false
+function session_module_name(null|string $module = null): string|false
 {
 }
 
-function session_save_path(null|string $path): string|false
+function session_save_path(null|string $path = null): string|false
 {
 }
 
@@ -127,11 +127,11 @@ function session_set_save_handler(SessionHandlerInterface $sessionhandler, bool 
 {
 }
 
-function session_cache_limiter(null|string $value): string|false
+function session_cache_limiter(null|string $value = null): string|false
 {
 }
 
-function session_cache_expire(null|int $value): int|false
+function session_cache_expire(null|int $value = null): int|false
 {
 }
 

--- a/crates/prelude/assets/extensions/standard.php
+++ b/crates/prelude/assets/extensions/standard.php
@@ -2123,7 +2123,7 @@ function escapeshellarg(string $arg): string
  *
  * @pure
  */
-function passthru(string $command, &$result_code): null|false
+function passthru(string $command, &$result_code = null): null|false
 {
 }
 

--- a/crates/prelude/assets/extensions/standard.php
+++ b/crates/prelude/assets/extensions/standard.php
@@ -2120,8 +2120,6 @@ function escapeshellarg(string $arg): string
 
 /**
  * @param-out int $result_code
- *
- * @pure
  */
 function passthru(string $command, &$result_code = null): null|false
 {


### PR DESCRIPTION
## 📌 What Does This PR Do?

<!-- Briefly describe what this PR introduces or fixes. -->
Small fix in the session_id() stub.
See https://www.php.net/manual/de/function.session-id.php for refrence

## 🔍 Context & Motivation
<!-- Why is this change needed? Is it fixing a bug, adding a feature, or refactoring? -->

Unexpected errors get thrown by mago anlyze.
```
error[too-few-arguments]: Too few arguments provided for function `session_id`.
    ┌─ php_source\lib\index.php:151:25
    │
151 │ $session_id = session_id();
    │               ----------^^ More arguments expected here
    │               │
    │               For this function call
    │
    = Expected at least 1 argument(s) for non-optional parameters, but received 0.
    = Help: Provide all required arguments.
```


## 🛠️ Summary of Changes
- **Bug Fix:** Fixed Stub
- 
## 📂 Affected Areas

- [x] Analyze
- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs
<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
