### PR TITLE
feat(linter): lint redundant readonly modifiers

### DIFF
--- a/crates/linter/src/rule/mod.rs
+++ b/crates/linter/src/rule/mod.rs
@@ -179,6 +179,7 @@ define_rules! {
     NoRedundantMath(no_redundant_math @ NoRedundantMathRule),
     NoRedundantLabel(no_redundant_label @ NoRedundantLabelRule),
     NoRedundantFinal(no_redundant_final @ NoRedundantFinalRule),
+    NoRedundantReadonly(no_redundant_readonly @ NoRedundantReadonlyRule),
     NoRedundantFile(no_redundant_file @ NoRedundantFileRule),
     NoRedundantContinue(no_redundant_continue @ NoRedundantContinueRule),
     NoRedundantBlock(no_redundant_block @ NoRedundantBlockRule),

--- a/crates/linter/src/rule/redundancy/mod.rs
+++ b/crates/linter/src/rule/redundancy/mod.rs
@@ -12,6 +12,7 @@ pub mod no_redundant_math;
 pub mod no_redundant_method_override;
 pub mod no_redundant_nullsafe;
 pub mod no_redundant_parentheses;
+pub mod no_redundant_readonly;
 pub mod no_redundant_string_concat;
 pub mod no_redundant_write_visibility;
 
@@ -29,5 +30,6 @@ pub use no_redundant_math::*;
 pub use no_redundant_method_override::*;
 pub use no_redundant_nullsafe::*;
 pub use no_redundant_parentheses::*;
+pub use no_redundant_readonly::*;
 pub use no_redundant_string_concat::*;
 pub use no_redundant_write_visibility::*;

--- a/crates/linter/src/rule/redundancy/no_redundant_readonly.rs
+++ b/crates/linter/src/rule/redundancy/no_redundant_readonly.rs
@@ -1,0 +1,124 @@
+use indoc::indoc;
+use mago_fixer::SafetyClassification;
+use serde::Deserialize;
+use serde::Serialize;
+
+use mago_reporting::Annotation;
+use mago_reporting::Issue;
+use mago_reporting::Level;
+use mago_span::HasSpan;
+use mago_syntax::ast::ClassLikeMember;
+use mago_syntax::ast::Node;
+use mago_syntax::ast::NodeKind;
+
+use crate::category::Category;
+use crate::context::LintContext;
+use crate::requirements::RuleRequirements;
+use crate::rule::Config;
+use crate::rule::LintRule;
+use crate::rule_meta::RuleMeta;
+use crate::settings::RuleSettings;
+
+#[derive(Debug, Clone)]
+pub struct NoRedundantReadonlyRule {
+    meta: &'static RuleMeta,
+    cfg: NoRedundantReadonlyConfig,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct NoRedundantReadonlyConfig {
+    pub level: Level,
+}
+
+impl Default for NoRedundantReadonlyConfig {
+    fn default() -> Self {
+        Self { level: Level::Help }
+    }
+}
+
+impl Config for NoRedundantReadonlyConfig {
+    fn default_enabled() -> bool {
+        // TODO(azjezz): enable in the next major release
+        false
+    }
+
+    fn level(&self) -> Level {
+        self.level
+    }
+}
+
+impl LintRule for NoRedundantReadonlyRule {
+    type Config = NoRedundantReadonlyConfig;
+
+    fn meta() -> &'static RuleMeta {
+        const META: RuleMeta = RuleMeta {
+            name: "No Redundant Readonly",
+            code: "no-redundant-readonly",
+            description: indoc! {"
+                Detects redundant readonly modifiers on properties.
+            "},
+            good_example: indoc! {r#"
+                <?php
+
+                readonly class User
+                {
+                    public $name;
+                }
+            "#},
+            bad_example: indoc! {r#"
+                <?php
+
+                readonly class User
+                {
+                    public readonly $name;
+                }
+            "#},
+            category: Category::Redundancy,
+
+            requirements: RuleRequirements::None,
+        };
+
+        &META
+    }
+
+    fn targets() -> &'static [NodeKind] {
+        const TARGETS: &[NodeKind] = &[NodeKind::Class];
+
+        TARGETS
+    }
+
+    fn build(settings: RuleSettings<Self::Config>) -> Self {
+        Self { meta: Self::meta(), cfg: settings.config }
+    }
+
+    fn check<'ast, 'arena>(&self, ctx: &mut LintContext<'_, 'arena>, node: Node<'ast, 'arena>) {
+        let Node::Class(class) = node else {
+            return;
+        };
+
+        if !class.modifiers.contains_readonly() {
+            return;
+        }
+
+        for member in class.members.iter() {
+            if let ClassLikeMember::Property(property) = member
+                && let Some(readonly_modifier) = property.modifiers().get_readonly()
+            {
+                let issue = Issue::new(
+                    self.cfg.level(),
+                    "The `readonly` modifier is redundant as the class is already readonly.",
+                )
+                .with_code(self.meta.code)
+                .with_annotation(
+                    Annotation::primary(readonly_modifier.span()).with_message("This `readonly` modifier is redundant"),
+                )
+                .with_help("Remove the redundant `readonly` modifier.");
+
+                ctx.collector.propose(issue, |plan| {
+                    plan.delete(readonly_modifier.span().to_range(), SafetyClassification::Safe);
+                });
+            }
+        }
+    }
+}

--- a/crates/linter/src/settings.rs
+++ b/crates/linter/src/settings.rs
@@ -68,6 +68,7 @@ pub struct RulesSettings {
     pub no_redundant_math: RuleSettings<NoRedundantMathConfig>,
     pub no_redundant_label: RuleSettings<NoRedundantLabelConfig>,
     pub no_redundant_final: RuleSettings<NoRedundantFinalConfig>,
+    pub no_redundant_readonly: RuleSettings<NoRedundantReadonlyConfig>,
     pub no_redundant_file: RuleSettings<NoRedundantFileConfig>,
     pub no_redundant_continue: RuleSettings<NoRedundantContinueConfig>,
     pub no_redundant_block: RuleSettings<NoRedundantBlockConfig>,

--- a/docs/tools/linter/rules/redundancy.md
+++ b/docs/tools/linter/rules/redundancy.md
@@ -23,6 +23,7 @@ This document details the rules available in the `Redundancy` category.
 | No Redundant Method Override | [`no-redundant-method-override`](#no-redundant-method-override) |
 | No Redundant Nullsafe | [`no-redundant-nullsafe`](#no-redundant-nullsafe) |
 | No Redundant Parentheses | [`no-redundant-parentheses`](#no-redundant-parentheses) |
+| No Redundant Readonly | [`no-redundant-readonly`](#no-redundant-readonly) |
 | No Redundant String Concat | [`no-redundant-string-concat`](#no-redundant-string-concat) |
 | No Redundant Write Visibility | [`no-redundant-write-visibility`](#no-redundant-write-visibility) |
 
@@ -574,6 +575,42 @@ $foo = 42;
 <?php
 
 $foo = (42);
+```
+
+
+## <a id="no-redundant-readonly"></a>`no-redundant-readonly`
+
+Detects redundant `readonly` modifiers on properties in readonly classes.
+
+
+
+### Configuration
+
+| Option | Type | Default |
+| :--- | :--- | :--- |
+| `enabled` | `boolean` | `false` |
+| `level` | `string` | `"help"` |
+
+### Examples
+
+#### Correct code
+
+```php
+<?php
+
+readonly class User {
+    public $name;
+}
+```
+
+#### Incorrect code
+
+```php
+<?php
+
+readonly class User {
+    public readonly $name;
+}
 ```
 
 


### PR DESCRIPTION
In a readonly class, properties don't need their own readonly qualifiers.

## 📌 What Does This PR Do?

This adds a linter rule that checks for redundant `readonly` modifiers

## 🔍 Context & Motivation

Similar to the check for `final` modifiers, this adds a feature to detect redundant code.

## 🛠️ Summary of Changes

- **Feature:** Added a linter rule for redundant `readonly` properties.

## 📂 Affected Areas

- [x] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

None

## 📝 Notes for Reviewers

None
