### PR TITLE
test(analyzer): add missing test coverage for Psl\Type\optional and  Psl\Type\shape functions

### DIFF
--- a/crates/analyzer/tests/cases/psl_integration.php
+++ b/crates/analyzer/tests/cases/psl_integration.php
@@ -116,6 +116,15 @@ namespace {
         ]),
     ]);
 
+    $flexible_type = Psl\Type\shape([
+        'required_field' => Psl\Type\string(),
+    ], true);
+
+    $flexible = $flexible_type->assert(get_mixed());
+
+    /* @mago-expect analysis:type-confirmation */
+    Mago\confirm($flexible, 'array{required_field: string, ...}');
+
     $enum_type = Psl\Type\instance_of(Example::class);
 
     $array = $array_type->assert(get_mixed());


### PR DESCRIPTION
## 📌 What Does This PR Do?

Add test cases for 
 - the Psl\Type\optional function to verify array shapes with optional fields.
 - the Psl\Type\shape function with `$allow_unknown_fields = true`

## 🔍 Context & Motivation

Prevent regressions

## 🛠️ Summary of Changes

- **Tests:** add test coverage for Psl\Type\optional function
- **Tests:** add test coverage for Psl\Type\shape function with `$allow_unknown_fields = true`

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Analyser

## 🔗 Related Issues or PRs

## 📝 Notes for Reviewers

