### PR TITLE
feat(linter): Add a fixer action for redundant final modifiers

### DIFF
--- a/crates/linter/src/rule/redundancy/no_redundant_final.rs
+++ b/crates/linter/src/rule/redundancy/no_redundant_final.rs
@@ -1,4 +1,5 @@
 use indoc::indoc;
+use mago_fixer::SafetyClassification;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -128,7 +129,9 @@ impl LintRule for NoRedundantFinalRule {
                     )
                     .with_help("Remove the redundant `final` modifier.");
 
-                ctx.collector.report(issue);
+                ctx.collector.propose(issue, |plan| {
+                    plan.delete(final_modifier.span().to_range(), SafetyClassification::Safe);
+                });
             }
         }
     }


### PR DESCRIPTION
## 📌 What Does This PR Do?

This extends the linter rule for redundant `final` modifiers with a fixer feature to automatically remove the redundant modifier.

## 🔍 Context & Motivation

It adds the fixer feature to the existing no-redundant-final rule.

## 🛠️ Summary of Changes

- **Feature:** Added support to automatically remove redundant `final` modifiers.

## 📂 Affected Areas

- [x] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

This was suggested in PR #522

## 📝 Notes for Reviewers

None
