### PR TITLE
feat(list-files): Add a new command to list all scanned files

### DIFF
--- a/docs/fundamentals/command-line-interface.md
+++ b/docs/fundamentals/command-line-interface.md
@@ -52,5 +52,6 @@ Mago is organized into several tools and utility commands, each accessed via a s
 | Command                                | Description                                             |
 | :------------------------------------- | :------------------------------------------------------ |
 | [`mago config`](/guide/configuration)  | Displays the final, merged configuration Mago is using. |
+| [`mago list-files`](/guide/list-files) | Displays a list of the files scanned by Mago.           |
 | [`mago init`](/guide/initialization)   | Initializes a new Mago configuration file.              |
 | [`mago self-update`](/guide/upgrading) | Updates Mago to the latest version.                     |

--- a/docs/guide/list-files.md
+++ b/docs/guide/list-files.md
@@ -1,0 +1,54 @@
+---
+title: Listing files
+---
+
+# Listing scanned files
+
+Sometimes it might be useful to get a list of all files that a given Mago
+command would scan given the current configuration. For example to use it to
+refine the current configuration, or to pass it to a different tool for some
+kind of processing For example to use it to refine the current configuration,
+or to pass it to a different tool for some kind of processing. This can be done
+using the list-files command.
+
+## Usage
+
+To get a list of all files configured as sources, simply run the `list-files` command:
+
+```sh
+mago list-files
+```
+
+As Mago's command can have their own file exclusions, the set of files might
+differ between the commands. If you want to see which files a certain command
+would process, use the `--command` option:
+
+```sh
+mago list-files --command linter
+```
+
+As filenames may contain newlines, the default of printing one name per line is prone to errors when passing the list to other tools like `xargs`. In that case, you can have the filenames be zero-terminated instead:
+
+```sh
+mago list-files -0 | xargs -0r ls -l
+```
+
+## Command reference
+
+:::tip
+For global options that can be used with any command, see the [Command-Line
+Interface overview](/fundamentals/command-line-interface.md). Remember to
+specify global options **before** the `list-files` command.
+:::
+
+```sh
+Usage: mago list-files [OPTIONS]
+```
+
+### Options
+
+| Flag, Alias(es)           | Description                                                                                                    |
+| :------------------------ | :------------------------------------------------------------------------------------------------------------- |
+|       `--command`         | Select for which command the file list should be generated. <br/>**Values:** `linter`, `formatter`, `analyzer` |
+| `-0`, `--zero-terminate`  | Use NUL bytes instead of newlines to terminate the filenames.                                                  |
+| `-h`, `--help`            | Print help information.                                                                                        |

--- a/src/commands/list_files.rs
+++ b/src/commands/list_files.rs
@@ -1,0 +1,66 @@
+use std::process::ExitCode;
+
+use clap::Parser;
+use clap::ValueEnum;
+use mago_database::DatabaseReader;
+
+use crate::config::Configuration;
+use crate::database;
+use crate::error::Error;
+
+#[derive(ValueEnum, Debug, Clone, Copy)]
+#[value(rename_all = "kebab-case")]
+enum Command {
+    Linter,
+    Formatter,
+    Analyzer,
+}
+
+/// Display all files that will be scanned given the current configuration
+///
+/// This command is useful for debugging your setup. It prints a full list of
+/// all files that would be scanned by Mago given the current configuration.
+#[derive(Parser, Debug)]
+#[command(
+    name = "list-files",
+    about = "Display all files that will be scanned.",
+    long_about = "Display a list of all files that will be scanned by Mago.\n\n\
+                  This can be useful if you want to see which files you might still need\n\
+                  to include or exclude in your configuration."
+)]
+pub struct ListFilesCommand {
+    /// Display the list of files for a specific command.
+    ///
+    /// If given, the exclude rules for that command are taken into
+    /// consideration. Otherwise, only the `sources` configuration is used.
+    ///
+    /// Available commands: linter, formatter, analyzer.
+    #[arg(long, value_enum)]
+    command: Option<Command>,
+
+    /// Use a NUL byte as the filename terminator.
+    ///
+    /// If given, instead of a newline a NUL byte will be used to terminate the
+    /// filenames. This is useful if filenames might contains newlines themselves.
+    #[arg(long, short = '0', default_value_t = false)]
+    zero_terminate: bool,
+}
+
+impl ListFilesCommand {
+    pub fn execute(self, mut configuration: Configuration) -> Result<ExitCode, Error> {
+        if let Some(command) = self.command {
+            configuration.source.excludes.extend(std::mem::take(match command {
+                Command::Linter => &mut configuration.linter.excludes,
+                Command::Formatter => &mut configuration.formatter.excludes,
+                Command::Analyzer => &mut configuration.analyzer.excludes,
+            }));
+        }
+
+        let database = database::load_from_configuration(&mut configuration.source, false, None)?;
+        for file in database.files() {
+            print!("{}{}", file.name, if self.zero_terminate { '\0' } else { '\n' });
+        }
+
+        Ok(ExitCode::SUCCESS)
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -15,6 +15,7 @@ use crate::commands::config::ConfigCommand;
 use crate::commands::format::FormatCommand;
 use crate::commands::init::InitCommand;
 use crate::commands::lint::LintCommand;
+use crate::commands::list_files::ListFilesCommand;
 use crate::commands::self_update::SelfUpdateCommand;
 use crate::error::Error;
 
@@ -26,6 +27,7 @@ pub mod config;
 pub mod format;
 pub mod init;
 pub mod lint;
+pub mod list_files;
 pub mod self_update;
 
 /// Styling for the Mago CLI.
@@ -47,6 +49,9 @@ pub enum MagoCommand {
     /// Display the final, merged configuration that Mago is using.
     #[command(name = "config")]
     Config(ConfigCommand),
+    /// Display all files that will be scanned by Mago.
+    #[command(name = "list-files")]
+    ListFiles(ListFilesCommand),
     /// Analyze the abstract syntax tree (AST) of PHP code.
     #[command(name = "ast")]
     Ast(AstCommand),

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,6 +96,7 @@ pub fn run() -> Result<ExitCode, Error> {
     match command {
         MagoCommand::Init(cmd) => cmd.execute(configuration, None),
         MagoCommand::Config(cmd) => cmd.execute(configuration),
+        MagoCommand::ListFiles(cmd) => cmd.execute(configuration),
         MagoCommand::Lint(cmd) => cmd.execute(configuration, color_choice),
         MagoCommand::Format(cmd) => cmd.execute(configuration, color_choice),
         MagoCommand::Ast(cmd) => cmd.execute(configuration, color_choice),


### PR DESCRIPTION
## 📌 What Does This PR Do?

This adds a new command to list all files that a certain mago command would scan.

## 🔍 Context & Motivation

This is useful if one wants to figure out what configuration changes are needed to get to the desired set of scanned files without having to run the actual commands every time.

## 🛠️ Summary of Changes

- **Feature:** Added a new list-files command to list scanned files.
- **Docs:** Added docs for the new list-files command.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [x] Documentation
- [x] Other (please specify): new command

## 🔗 Related Issues or PRs

None

## 📝 Notes for Reviewers

None
