### PR TITLE
fix(analyzer): correct negated isset handling for array accesses

### DIFF
--- a/crates/analyzer/src/reconciler/simple_negated_assertion_reconciler.rs
+++ b/crates/analyzer/src/reconciler/simple_negated_assertion_reconciler.rs
@@ -1138,8 +1138,11 @@ fn reconcile_not_isset(
     key: Option<&String>,
     span: Option<&Span>,
 ) -> TUnion {
+    // When !isset is true, the value is definitely not set (either null or undefined)
+    // For array accesses, this means the key doesn't exist or the value is null
+    // In both cases, the resulting type should be null
     if possibly_undefined {
-        return get_never();
+        return get_null();
     }
 
     if !existing_var_type.is_nullable()

--- a/crates/analyzer/tests/cases/issue_557.php
+++ b/crates/analyzer/tests/cases/issue_557.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @param null $value
+ */
+function expectsNull($value): void
+{
+}
+
+function expectsString(string $value): void
+{
+}
+
+/**
+ * @param array{bar?: string} $value
+ * @return void
+ */
+function expectsArray(array $value): void
+{
+}
+
+/** @var array{foo?: string} $x */
+$x = [];
+
+// Test 1: Direct negated isset check
+// When !isset($x['foo']) is true, $x['foo'] should be null
+if (!isset($x['foo'])) {
+    expectsNull($x['foo']);
+}
+
+// Test 2: Negated isset check via else branch
+// The else branch uses negation internally as well
+if (isset($x['foo'])) {
+    expectsString($x['foo']);
+} else {
+    expectsNull($x['foo']);
+}
+
+// Test 3: Nested array access with negated isset
+/** @var array{foo?: array {bar?: string}} $y */
+$y = [];
+
+if (!isset($y['foo']['bar'])) {
+    expectsNull($y['foo']['bar']);
+} else {
+    expectsArray($y['foo']);
+}
+
+if (isset($y['foo']['bar'])) {
+    expectsString($y['foo']['bar']);
+} else {
+    expectsNull($y['foo']['bar']);
+}
+
+// Test 4: Positive isset for comparison - should correctly narrow to string
+/** @var array{qux?: string} $w */
+$w = [];
+
+if (isset($w['qux'])) {
+    expectsString($w['qux']);
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -238,6 +238,7 @@ test_case!(issue_540);
 test_case!(issue_535);
 test_case!(issue_541);
 test_case!(issue_546);
+test_case!(issue_557);
 
 #[test]
 fn test_all_test_cases_are_ran() {


### PR DESCRIPTION
## 📌 What Does This PR Do?

Partially fixes negated `isset()` checks on array accesses by correctly narrowing single array access types to `null` when `!isset()` is true.

## 🔍 Context & Motivation

When `!isset($x['foo'])` was true for a possibly undefined array key, the reconciler was incorrectly returning `never` type instead of `null`. This caused the type system to fall back to the array shape's original type (e.g., `string`), making it appear as if the value was still set when it actually wasn't.

## 🛠️ Summary of Changes

- **Bug Fix:** Changed `reconcile_not_isset` in `simple_negated_assertion_reconciler.rs` to return `null` instead of `never` when `possibly_undefined` is true

📂 Affected Areas

- Analyzer

🔗 Related Issues or PRs

Fixes #557 (partially)

📝 Notes for Reviewers

What was NOT fixed

Multi-variable isset() checks with negation still have incorrect behavior and were deliberately NOT fixed in this PR:

```php
if (!isset($x['foo'], $z['baz'])) {
// Currently both are narrowed to null, but this is incorrect!
// We only know that AT LEAST ONE is not set, not which one(s)
}
```

Why this can't be fixed easily:

1. `isset($a, $b)` means "both are set" → represented as `$a => IsIsset AND $b => IsIsset` 
2. `!isset($a, $b)` means "at least one is NOT set" → should be `($a => IsNotIsset) OR ($b => IsNotIsset)`
3. But the assertion system can't express OR relationships across variables 
4. So it incorrectly narrows both: `$a => IsNotIsset AND $b => IsNotIsset`

The correct solution would be to not narrow either variable when `!isset()` has multiple arguments, but supporting disjunctive constraints across variables is beyond my capabilities.