### PR TITLE
feat(guard): Introduce architectural validation command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1431,6 +1431,7 @@ dependencies = [
  "mago-database",
  "mago-fixer",
  "mago-formatter",
+ "mago-guard",
  "mago-linter",
  "mago-names",
  "mago-php-version",
@@ -1607,6 +1608,28 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "unicode-width 0.2.1",
+]
+
+[[package]]
+name = "mago-guard"
+version = "1.0.0-beta.28"
+dependencies = [
+ "ahash",
+ "bumpalo",
+ "indoc",
+ "mago-atom",
+ "mago-codex",
+ "mago-collector",
+ "mago-database",
+ "mago-names",
+ "mago-prelude",
+ "mago-reporting",
+ "mago-span",
+ "mago-syntax",
+ "mago-syntax-core",
+ "regex",
+ "serde",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ mago-semantics = { path = "crates/semantics", version = "1.0.0-beta.28" }
 mago-collector = { path = "crates/collector", version = "1.0.0-beta.28" }
 mago-database = { path = "crates/database", version = "1.0.0-beta.28" }
 mago-pager = { path = "crates/pager", version = "1.0.0-beta.28" }
+mago-guard = { path = "crates/guard", version = "1.0.0-beta.28" }
 tracing = { version = "0.1.40" }
 ahash = { version = "0.8", default-features = false, features = ["compile-time-rng", "std"] }
 serde_json = { version = "1.0.138" }
@@ -123,6 +124,7 @@ mago-semantics = { workspace = true }
 mago-prelude = { workspace = true }
 mago-codex = { workspace = true }
 mago-analyzer = { workspace = true }
+mago-guard = { workspace = true }
 serde = { workspace = true }
 clap = { workspace = true }
 ahash = { workspace = true }

--- a/Justfile
+++ b/Justfile
@@ -71,6 +71,7 @@ publish:
     cargo publish -p mago-codex
     cargo publish -p mago-prelude
     cargo publish -p mago-algebra
+    cargo publish -p mago-guard
     cargo publish -p mago-analyzer
     cargo publish -p mago-linter
     cargo publish -p mago-wasm

--- a/crates/guard/Cargo.toml
+++ b/crates/guard/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "mago-guard"
+description = "A PHP dependencies guard that helps keep your architecture clean."
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+mago-atom = { workspace = true }
+mago-reporting = { workspace = true }
+mago-span = { workspace = true }
+mago-syntax = { workspace = true }
+mago-names = { workspace = true }
+mago-collector = { workspace = true }
+mago-syntax-core = { workspace = true }
+mago-database = { workspace = true }
+mago-codex = { workspace = true }
+ahash = { workspace = true }
+serde = { workspace = true }
+regex = { workspace = true }
+bumpalo = { workspace = true }
+
+[dev-dependencies]
+mago-syntax = { workspace = true }
+mago-prelude = { workspace = true, features = ["build"] }
+indoc = { workspace = true }
+toml = { workspace = true }

--- a/crates/guard/src/context.rs
+++ b/crates/guard/src/context.rs
@@ -1,0 +1,69 @@
+use mago_codex::metadata::CodebaseMetadata;
+use mago_names::ResolvedNames;
+use mago_span::HasPosition;
+
+use crate::report::FortressReport;
+use crate::report::breach::BoundaryBreach;
+use crate::report::flaw::StructuralFlaw;
+use crate::settings::Settings;
+
+/// Context for guard operations, providing access to resolved names and issue collection.
+#[derive(Debug)]
+pub struct GuardContext<'ctx, 'arena> {
+    pub resolved_names: &'ctx ResolvedNames<'arena>,
+    pub settings: &'ctx Settings,
+    pub codebase: &'ctx CodebaseMetadata,
+    pub boundary_breaches: Vec<BoundaryBreach>,
+    pub structural_flaws: Vec<StructuralFlaw>,
+    pub current_namespace: Option<&'arena str>,
+}
+
+impl<'ctx, 'arena> GuardContext<'ctx, 'arena> {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        resolved_names: &'ctx ResolvedNames<'arena>,
+        settings: &'ctx Settings,
+        codebase: &'ctx CodebaseMetadata,
+    ) -> Self {
+        Self {
+            resolved_names,
+            settings,
+            codebase,
+            boundary_breaches: vec![],
+            structural_flaws: vec![],
+            current_namespace: None,
+        }
+    }
+
+    /// Sets the current namespace in the context.
+    pub fn set_current_namespace(&mut self, namespace: Option<&'arena str>) {
+        self.current_namespace = namespace;
+    }
+
+    /// Gets the current namespace from the context, or an empty string if none is set.
+    pub fn get_current_namespace(&self) -> &'arena str {
+        self.current_namespace.unwrap_or("")
+    }
+
+    /// Retrieves the fully qualified name associated with a given position in the code.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no name is found at the specified position.
+    pub fn lookup_name(&self, position: &impl HasPosition) -> &'arena str {
+        self.resolved_names.get(&position.position())
+    }
+
+    /// Attempts to retrieve the fully qualified name associated with a given position.
+    ///
+    /// Returns `None` if no name is found at the specified position.
+    pub fn try_lookup_name(&self, position: &impl HasPosition) -> Option<&'arena str> {
+        let pos = position.position();
+        if self.resolved_names.contains(&pos) { Some(self.resolved_names.get(&pos)) } else { None }
+    }
+
+    /// Consumes the context and generates a `FortressReport` containing all collected issues.
+    pub fn report(self) -> FortressReport {
+        FortressReport { boundary_breaches: self.boundary_breaches, structural_flaws: self.structural_flaws }
+    }
+}

--- a/crates/guard/src/lib.rs
+++ b/crates/guard/src/lib.rs
@@ -1,0 +1,61 @@
+use mago_codex::metadata::CodebaseMetadata;
+use mago_names::ResolvedNames;
+use mago_syntax::ast::Program;
+use mago_syntax::walker::MutWalker;
+
+use crate::context::GuardContext;
+use crate::perimeter::DependenciesGuardWalker;
+use crate::report::FortressReport;
+use crate::settings::Settings;
+use crate::structural::StructuralGuardWalker;
+
+pub mod path;
+pub mod report;
+pub mod settings;
+
+mod context;
+mod perimeter;
+mod structural;
+mod utils;
+
+#[derive(Debug)]
+pub struct ArchitecturalGuard {
+    settings: Settings,
+}
+
+impl ArchitecturalGuard {
+    /// Creates a new Guard instance.
+    ///
+    /// # Arguments
+    ///
+    /// * `arena` - The bump allocator to use for memory management
+    /// * `settings` - The guard settings containing architectural rules
+    pub fn new(settings: Settings) -> Self {
+        Self { settings }
+    }
+
+    /// Performs architectural boundary checking on a program.
+    ///
+    /// # Arguments
+    ///
+    /// * `codebase` - The codebase metadata for symbol lookups
+    /// * `program` - The AST of the program
+    /// * `resolved_names` - The resolved names for the program
+    ///
+    /// # Returns
+    ///
+    /// A `GuardResult` containing all violations found.
+    pub fn check<'ast, 'arena>(
+        &self,
+        codebase: &CodebaseMetadata,
+        program: &'ast Program<'arena>,
+        resolved_names: &'ast ResolvedNames<'arena>,
+    ) -> FortressReport {
+        let mut context = GuardContext::new(resolved_names, &self.settings, codebase);
+
+        DependenciesGuardWalker.walk_program(program, &mut context);
+        StructuralGuardWalker.walk_program(program, &mut context);
+
+        context.report()
+    }
+}

--- a/crates/guard/src/path.rs
+++ b/crates/guard/src/path.rs
@@ -1,0 +1,263 @@
+use std::fmt;
+use std::str::FromStr;
+
+use serde::Deserialize;
+use serde::Serialize;
+use serde::Serializer;
+use serde::de;
+use serde::de::Deserializer;
+
+use mago_syntax_core::part_of_identifier;
+use mago_syntax_core::start_of_identifier;
+
+const INVALID_PATH_ERROR: &str = "Invalid path: must be '*', '@all', '@self', '@this', '@native', '@php', '@builtin', a layer (e.g., '@layer:name'), a valid namespace (ending with '\\'), a valid symbol name, or a pattern containing wildcards ('*').";
+const INVALID_SELECTOR_ERROR: &str = "Invalid symbol selector: must be a valid namespace (ending with '\\'), a valid symbol name, or a pattern containing wildcards ('*').";
+const INVALID_NAMESPACE_ERROR: &str = "Invalid namespace: must be '@global' or a valid namespace ending with '\\'.";
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum NamespacePath {
+    Global,
+    Specific(String),
+}
+
+/// Selects a specific symbol or a group of symbols.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum SymbolSelector {
+    /// A specific namespace, e.g., `App\Domain\`
+    Namespace(NamespacePath),
+    /// A specific, fully qualified symbol name.
+    Symbol(String),
+    /// A glob-like pattern, e.g., `App\Domain\**`.
+    Pattern(String),
+}
+
+/// Represents a path, which can be a standard namespace, a layer, or a special keyword.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Path {
+    /// Represents all namespaces, often denoted as `*` or `@all`.
+    All,
+    /// The current namespace, represented as `@self` or `@this`.
+    Self_,
+    /// Native PHP symbols, represented as `@native`, `@php`, or `@builtin`.
+    Native,
+    /// A reusable layer reference, e.g., `@layer:common`.
+    Layer(String),
+    /// A selector for symbols, namespaces, or patterns.
+    Selector(SymbolSelector),
+}
+
+/// Checks if a string segment is a valid PHP identifier.
+pub(crate) fn is_valid_identifier_part(part: &str) -> bool {
+    if part.is_empty() {
+        return false;
+    }
+
+    let bytes = part.as_bytes();
+
+    matches!(bytes[0], start_of_identifier!()) && bytes[1..].iter().all(|byte| matches!(byte, part_of_identifier!()))
+}
+
+fn is_valid_pattern_part(part: &str) -> bool {
+    if part == "*" || part == "**" {
+        return true;
+    }
+
+    part.as_bytes().iter().all(|&byte| matches!(byte, part_of_identifier!() | b'*'))
+}
+
+impl FromStr for NamespacePath {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.eq_ignore_ascii_case("@global") {
+            return Ok(NamespacePath::Global);
+        }
+
+        let path_to_validate = s.strip_suffix('\\').unwrap_or(s);
+        if path_to_validate.split('\\').all(is_valid_identifier_part) {
+            Ok(NamespacePath::Specific(s.to_string()))
+        } else {
+            Err(INVALID_NAMESPACE_ERROR)
+        }
+    }
+}
+
+impl FromStr for SymbolSelector {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.contains('*') {
+            if s.split('\\').all(is_valid_pattern_part) {
+                Ok(SymbolSelector::Pattern(s.to_string()))
+            } else {
+                Err(INVALID_SELECTOR_ERROR)
+            }
+        } else if s.ends_with('\\') || s.eq_ignore_ascii_case("@global") {
+            s.parse().map(SymbolSelector::Namespace)
+        } else if s.split('\\').all(is_valid_identifier_part) {
+            Ok(SymbolSelector::Symbol(s.to_string()))
+        } else {
+            Err(INVALID_SELECTOR_ERROR)
+        }
+    }
+}
+
+impl FromStr for Path {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "*" || s.eq_ignore_ascii_case("@all") {
+            Ok(Path::All)
+        } else if s.eq_ignore_ascii_case("@self") || s.eq_ignore_ascii_case("@this") {
+            Ok(Path::Self_)
+        } else if s.eq_ignore_ascii_case("@native")
+            || s.eq_ignore_ascii_case("@php")
+            || s.eq_ignore_ascii_case("@builtin")
+        {
+            Ok(Path::Native)
+        } else if let Some(layer_name) = s.strip_prefix("@layer:").or_else(|| s.strip_prefix("@layers:")) {
+            Ok(Path::Layer(layer_name.to_string()))
+        } else {
+            s.parse().ok().map(Path::Selector).ok_or(INVALID_PATH_ERROR)
+        }
+    }
+}
+
+impl fmt::Display for NamespacePath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            NamespacePath::Global => write!(f, "@global"),
+            NamespacePath::Specific(s) => write!(f, "{}", s),
+        }
+    }
+}
+
+impl fmt::Display for SymbolSelector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SymbolSelector::Namespace(ns) => write!(f, "{}", ns),
+            SymbolSelector::Symbol(s) => write!(f, "{}", s),
+            SymbolSelector::Pattern(s) => write!(f, "{}", s),
+        }
+    }
+}
+
+impl fmt::Display for Path {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Path::All => write!(f, "@all"),
+            Path::Self_ => write!(f, "@self"),
+            Path::Native => write!(f, "@native"),
+            Path::Layer(name) => write!(f, "@layer:{}", name),
+            Path::Selector(selector) => write!(f, "{}", selector),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for NamespacePath {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        String::deserialize(deserializer)?.parse().map_err(de::Error::custom)
+    }
+}
+
+impl<'de> Deserialize<'de> for SymbolSelector {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        String::deserialize(deserializer)?.parse().map_err(de::Error::custom)
+    }
+}
+
+impl<'de> Deserialize<'de> for Path {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        String::deserialize(deserializer)?.parse().map_err(de::Error::custom)
+    }
+}
+
+impl Serialize for NamespacePath {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl Serialize for SymbolSelector {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl Serialize for Path {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_path_parsing_and_formatting() {
+        assert_eq!("@all".parse::<Path>().unwrap(), Path::All);
+        assert_eq!("@self".parse::<Path>().unwrap(), Path::Self_);
+        assert_eq!("@native".parse::<Path>().unwrap(), Path::Native);
+        assert_eq!("@layer:core".parse::<Path>().unwrap(), Path::Layer("core".to_string()));
+        assert_eq!(
+            "App\\Domain\\".parse::<Path>().unwrap(),
+            Path::Selector(SymbolSelector::Namespace(NamespacePath::Specific("App\\Domain\\".to_string())))
+        );
+        assert_eq!(
+            "App\\Domain\\Model".parse::<Path>().unwrap(),
+            Path::Selector(SymbolSelector::Symbol("App\\Domain\\Model".to_string()))
+        );
+        assert_eq!("App\\**".parse::<Path>().unwrap(), Path::Selector(SymbolSelector::Pattern("App\\**".to_string())));
+
+        assert_eq!(Path::All.to_string(), "@all");
+        assert_eq!(Path::Self_.to_string(), "@self");
+        assert_eq!(Path::Native.to_string(), "@native");
+        assert_eq!(Path::Layer("core".to_string()).to_string(), "@layer:core");
+        assert_eq!(Path::Selector(SymbolSelector::Namespace(NamespacePath::Global)).to_string(), "@global");
+        assert_eq!(
+            Path::Selector(SymbolSelector::Namespace(NamespacePath::Specific("App\\Domain\\".to_string()))).to_string(),
+            "App\\Domain\\"
+        );
+        assert_eq!(Path::Selector(SymbolSelector::Symbol("My\\Class".to_string())).to_string(), "My\\Class");
+        assert_eq!(Path::Selector(SymbolSelector::Pattern("My\\**".to_string())).to_string(), "My\\**");
+    }
+
+    #[test]
+    fn test_valid_patterns_parse_correctly() {
+        assert!("App\\*".parse::<Path>().is_ok());
+        assert!("App\\**".parse::<Path>().is_ok());
+        assert!("App\\*Something".parse::<Path>().is_ok());
+        assert!("App\\*Something*".parse::<Path>().is_ok());
+        assert!("App\\*Some*thing".parse::<Path>().is_ok());
+    }
+
+    #[test]
+    fn test_invalid_paths_fail_to_parse() {
+        assert!("Invalid-Class".parse::<Path>().is_err());
+        assert!("My\\Invalid-Namespace\\".parse::<Path>().is_err());
+        assert!("1LeadingNumber".parse::<Path>().is_err());
+        assert!("My\\1LeadingNumber".parse::<Path>().is_err());
+        assert!("@My\\Namespace\\".parse::<Path>().is_err());
+        assert!("My\\Invalid-Namespace\\".parse::<Path>().is_err());
+        assert!("App\\Invalid-*.php".parse::<Path>().is_err());
+    }
+}

--- a/crates/guard/src/perimeter/checker.rs
+++ b/crates/guard/src/perimeter/checker.rs
@@ -1,0 +1,233 @@
+use mago_codex::metadata::CodebaseMetadata;
+use mago_span::Span;
+
+use crate::context::GuardContext;
+use crate::path::NamespacePath;
+use crate::path::Path;
+use crate::path::SymbolSelector;
+use crate::report::breach::BoundaryBreach;
+use crate::report::breach::BreachReason;
+use crate::report::breach::BreachVector;
+use crate::settings::PermittedDependency;
+use crate::settings::PermittedDependencyKind;
+use crate::settings::Settings;
+use crate::utils::matches_pattern;
+
+/// Checks a symbol usage and reports violations.
+///
+/// # Arguments
+///
+/// * `ctx` - The guard context
+/// * `target_fqn` - The fully qualified name being used
+/// * `target_type` - The type of symbol being used
+/// * `usage_kind` - The kind of usage
+/// * `span` - The span of the usage in the source code
+pub fn check_usage(
+    ctx: &mut GuardContext<'_, '_>,
+    dependency_fqn: &str,
+    dependency_kind: PermittedDependencyKind,
+    vector: BreachVector,
+    span: Span,
+) {
+    if let Some(reason) = check_allowed(ctx, dependency_fqn, dependency_kind) {
+        ctx.boundary_breaches.push(BoundaryBreach {
+            source_namespace: ctx.get_current_namespace().to_string(),
+            dependency_fqn: dependency_fqn.to_string(),
+            dependency_kind,
+            vector,
+            span,
+            reason,
+        });
+    }
+}
+
+/// Checks if a usage is allowed based on the configured rules.
+///
+/// # Arguments
+///
+/// * `codebase` - The codebase metadata for symbol lookups
+/// * `settings` - The guard settings
+/// * `source_namespace` - The namespace where the usage occurs
+/// * `target_fqn` - The fully qualified name being used
+/// * `target_type` - The type of the symbol being used (class, interface, etc.)
+///
+/// # Returns
+///
+/// `Some(ArchitecturalViolationReason)` if the usage is not allowed, `None` if it is allowed
+/// or if layering rules apply and permit the usage.
+fn check_allowed(
+    ctx: &GuardContext<'_, '_>,
+    target_fqn: &str,
+    dependency_kind: PermittedDependencyKind,
+) -> Option<BreachReason> {
+    let rules: Vec<_> = ctx
+        .settings
+        .perimeter
+        .rules
+        .iter()
+        .filter(|rule| match &rule.namespace {
+            NamespacePath::Global => ctx.get_current_namespace().is_empty(),
+            NamespacePath::Specific(rule_namespace) => {
+                matches_pattern(ctx.get_current_namespace(), rule_namespace, true)
+            }
+        })
+        .collect();
+
+    if !rules.is_empty() {
+        for rule in &rules {
+            for allowed in &rule.permit {
+                match allowed {
+                    PermittedDependency::Dependency(path) => {
+                        if is_path_allowed(ctx.codebase, ctx.settings, path, ctx.get_current_namespace(), target_fqn) {
+                            return None;
+                        }
+                    }
+                    PermittedDependency::DependencyOfKind { path, kinds } => {
+                        if kinds.contains(&dependency_kind)
+                            && is_path_allowed(
+                                ctx.codebase,
+                                ctx.settings,
+                                path,
+                                ctx.get_current_namespace(),
+                                target_fqn,
+                            )
+                        {
+                            return None;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if !ctx.settings.perimeter.layering.is_empty() {
+        let source_layer_index = get_layer_index(ctx.get_current_namespace(), ctx.settings);
+        let target_layer_index = get_layer_index(target_fqn, ctx.settings);
+
+        if let (Some(src_idx), Some(tgt_idx)) = (source_layer_index, target_layer_index) {
+            if src_idx >= tgt_idx {
+                return None;
+            } else {
+                return Some(BreachReason::Layering {
+                    source_layer: ctx.settings.perimeter.layering[src_idx].clone(),
+                    target_layer: ctx.settings.perimeter.layering[tgt_idx].clone(),
+                });
+            }
+        }
+    }
+
+    if rules.is_empty() {
+        Some(BreachReason::NoMatchingRule)
+    } else {
+        Some(BreachReason::ForbiddenByRule { rule_namespaces: rules.iter().map(|r| r.namespace.clone()).collect() })
+    }
+}
+
+/// Extracts the root namespace from a fully qualified name.
+///
+/// # Arguments
+///
+/// * `fqn` - The fully qualified name
+///
+/// # Returns
+///
+/// The root namespace, or the full name if there's no namespace separator
+fn get_root_namespace(fqn: &str) -> &str {
+    if let Some(pos) = fqn.find('\\') { &fqn[..pos] } else { fqn }
+}
+
+/// Checks if a fully qualified name is considered native/builtin.
+///
+/// A symbol is native if:
+/// - It's a class-like with the BUILTIN metadata flag set
+/// - It's a function with the BUILTIN metadata flag set
+/// - It's a constant with the BUILTIN metadata flag set
+///
+/// # Arguments
+///
+/// * `codebase` - The codebase metadata to look up the symbol
+/// * `fqn` - The fully qualified name to check
+///
+/// # Returns
+///
+/// `true` if the name is considered native/builtin, `false` otherwise
+fn is_native(codebase: &CodebaseMetadata, fqn: &str) -> bool {
+    codebase
+        .get_class_like(fqn)
+        .map(|c| &c.flags)
+        .or_else(|| codebase.get_function(fqn).map(|f| &f.flags))
+        .or_else(|| codebase.get_constant(fqn).map(|c| &c.flags))
+        .is_some_and(|flags| flags.is_built_in())
+}
+
+fn get_layer_index(namespace: &str, settings: &Settings) -> Option<usize> {
+    for (i, layer_namespace) in settings.perimeter.layering.iter().enumerate() {
+        match layer_namespace {
+            NamespacePath::Global if namespace.is_empty() => {
+                return Some(i);
+            }
+            NamespacePath::Specific(ns) if matches_pattern(namespace, ns, true) => {
+                return Some(i);
+            }
+            _ => {}
+        }
+    }
+
+    None
+}
+
+/// Checks if a target FQN is allowed based on a specific path configuration.
+///
+/// # Arguments
+///
+/// * `codebase` - The codebase metadata for symbol lookups
+/// * `settings` - The guard settings
+/// * `path` - The path configuration
+/// * `source_namespace` - The namespace where the usage occurs
+/// * `target_fqn` - The fully qualified name being used
+/// * `_target_type` - The type of the symbol being used
+///
+/// # Returns
+///
+/// `true` if the path allows the target FQN, `false` otherwise
+fn is_path_allowed(
+    codebase: &CodebaseMetadata,
+    settings: &Settings,
+    path: &Path,
+    source_namespace: &str,
+    target_fqn: &str,
+) -> bool {
+    match path {
+        Path::All => true,
+        Path::Native => is_native(codebase, target_fqn),
+        Path::Self_ => {
+            matches_pattern(target_fqn, source_namespace, false)
+                || get_root_namespace(source_namespace).eq_ignore_ascii_case(get_root_namespace(target_fqn))
+        }
+        Path::Layer(layer_name) => settings.perimeter.layers.get(layer_name).is_some_and(|layer_patterns| {
+            layer_patterns
+                .iter()
+                .any(|pattern| is_path_allowed(codebase, settings, pattern, source_namespace, target_fqn))
+        }),
+        Path::Selector(selector) => match selector {
+            SymbolSelector::Namespace(ns) => match ns {
+                NamespacePath::Global => !target_fqn.contains('\\'),
+                NamespacePath::Specific(pattern) => matches_pattern(target_fqn, pattern, true),
+            },
+            SymbolSelector::Symbol(sn) => target_fqn.eq_ignore_ascii_case(sn),
+            SymbolSelector::Pattern(p) => matches_pattern(target_fqn, p, false),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_root_namespace() {
+        assert_eq!(get_root_namespace("Foo\\Bar\\Baz"), "Foo");
+        assert_eq!(get_root_namespace("Foo\\Bar"), "Foo");
+        assert_eq!(get_root_namespace("Foo"), "Foo");
+    }
+}

--- a/crates/guard/src/perimeter/mod.rs
+++ b/crates/guard/src/perimeter/mod.rs
@@ -1,0 +1,325 @@
+mod checker;
+
+use mago_atom::concat_atom;
+use mago_span::HasSpan;
+use mago_syntax::ast::*;
+use mago_syntax::walker::MutWalker;
+
+use crate::context::GuardContext;
+use crate::perimeter::checker::check_usage;
+use crate::report::breach::BreachVector;
+use crate::settings::PermittedDependencyKind;
+
+#[derive(Debug, Clone, Copy)]
+pub struct DependenciesGuardWalker;
+
+impl DependenciesGuardWalker {
+    fn check_hint_in_context(hint: &Hint, usage_kind: BreachVector, context: &mut GuardContext<'_, '_>) {
+        Self::check_hint_recursive(hint, usage_kind, context);
+    }
+
+    fn check_hint_recursive(hint: &Hint, usage_kind: BreachVector, context: &mut GuardContext<'_, '_>) {
+        match hint {
+            Hint::Identifier(identifier) => {
+                let fqn = context.lookup_name(identifier);
+                check_usage(context, fqn, PermittedDependencyKind::ClassLike, usage_kind, identifier.span());
+            }
+            Hint::Parenthesized(parenthesized) => {
+                Self::check_hint_recursive(parenthesized.hint, usage_kind, context);
+            }
+            Hint::Nullable(nullable) => {
+                Self::check_hint_recursive(nullable.hint, usage_kind, context);
+            }
+            Hint::Union(union) => {
+                Self::check_hint_recursive(union.left, usage_kind, context);
+                Self::check_hint_recursive(union.right, usage_kind, context);
+            }
+            Hint::Intersection(intersection) => {
+                Self::check_hint_recursive(intersection.left, usage_kind, context);
+                Self::check_hint_recursive(intersection.right, usage_kind, context);
+            }
+            _ => {}
+        }
+    }
+}
+
+impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for DependenciesGuardWalker {
+    fn walk_in_namespace(&mut self, namespace: &'ast Namespace<'arena>, context: &mut GuardContext<'ctx, 'arena>) {
+        context.set_current_namespace(namespace.name.as_ref().map(|n| n.value()));
+    }
+
+    fn walk_out_namespace(&mut self, _namespace: &'ast Namespace<'arena>, context: &mut GuardContext<'ctx, 'arena>) {
+        context.set_current_namespace(None);
+    }
+
+    // Check use statements
+    fn walk_in_use(&mut self, r#use: &'ast Use<'arena>, context: &mut GuardContext<'ctx, 'arena>) {
+        match &r#use.items {
+            UseItems::Sequence(use_item_sequence) => {
+                use_item_sequence.items.iter().for_each(|use_item| {
+                    check_usage(
+                        context,
+                        use_item.name.value(),
+                        PermittedDependencyKind::ClassLike,
+                        BreachVector::Use,
+                        use_item.name.span(),
+                    );
+                });
+            }
+            UseItems::TypedSequence(typed_use_item_sequence) => {
+                let symbol_kind = match typed_use_item_sequence.r#type {
+                    UseType::Function(_) => PermittedDependencyKind::Function,
+                    UseType::Const(_) => PermittedDependencyKind::Constant,
+                };
+
+                typed_use_item_sequence.items.iter().for_each(|typed_use_item| {
+                    check_usage(
+                        context,
+                        typed_use_item.name.value(),
+                        symbol_kind,
+                        BreachVector::Use,
+                        typed_use_item.name.span(),
+                    );
+                });
+            }
+            UseItems::TypedList(typed_use_item_list) => {
+                let symbol_kind = match typed_use_item_list.r#type {
+                    UseType::Function(_) => PermittedDependencyKind::Function,
+                    UseType::Const(_) => PermittedDependencyKind::Constant,
+                };
+
+                typed_use_item_list.items.iter().for_each(|typed_use_item| {
+                    let fqn =
+                        concat_atom!(typed_use_item_list.namespace.value(), "\\", typed_use_item.name.value()).as_str();
+
+                    check_usage(context, fqn, symbol_kind, BreachVector::Use, typed_use_item.name.span());
+                });
+            }
+            UseItems::MixedList(mixed_use_item_list) => {
+                mixed_use_item_list.items.iter().for_each(|mixed_use_item| {
+                    let symbol_kind = match mixed_use_item.r#type {
+                        Some(UseType::Function(_)) => PermittedDependencyKind::Function,
+                        Some(UseType::Const(_)) => PermittedDependencyKind::Constant,
+                        None => PermittedDependencyKind::ClassLike,
+                    };
+
+                    let fqn =
+                        concat_atom!(mixed_use_item_list.namespace.value(), "\\", mixed_use_item.item.name.value())
+                            .as_str();
+
+                    check_usage(context, fqn, symbol_kind, BreachVector::Use, mixed_use_item.item.name.span());
+                });
+            }
+        }
+    }
+
+    fn walk_in_attribute(&mut self, attribute: &'ast Attribute<'arena>, context: &mut GuardContext<'ctx, 'arena>) {
+        let fqn = context.lookup_name(&attribute.name);
+
+        check_usage(context, fqn, PermittedDependencyKind::ClassLike, BreachVector::Attribute, attribute.name.span());
+    }
+
+    // Check class-like extends
+    fn walk_in_extends(&mut self, extends: &'ast Extends<'arena>, context: &mut GuardContext<'ctx, 'arena>) {
+        for extended_typ in extends.types.iter() {
+            let fqn = context.lookup_name(extended_typ);
+
+            check_usage(context, fqn, PermittedDependencyKind::ClassLike, BreachVector::Extends, extended_typ.span());
+        }
+    }
+
+    // Check class-like implements
+    fn walk_in_implements(&mut self, implements: &'ast Implements<'arena>, context: &mut GuardContext<'ctx, 'arena>) {
+        for interface in implements.types.iter() {
+            let fqn = context.lookup_name(interface);
+
+            check_usage(context, fqn, PermittedDependencyKind::ClassLike, BreachVector::Implements, interface.span());
+        }
+    }
+
+    // Check trait uses
+    fn walk_in_trait_use(&mut self, trait_use: &'ast TraitUse<'arena>, context: &mut GuardContext<'ctx, 'arena>) {
+        for trait_name in trait_use.trait_names.iter() {
+            let fqn = context.lookup_name(trait_name);
+
+            check_usage(context, fqn, PermittedDependencyKind::ClassLike, BreachVector::TraitUse, trait_name.span());
+        }
+    }
+
+    // Check property type hints
+    fn walk_in_property(&mut self, property: &'ast Property<'arena>, context: &mut GuardContext<'ctx, 'arena>) {
+        if let Some(hint) = property.hint() {
+            Self::check_hint_in_context(hint, BreachVector::PropertyType, context);
+        }
+    }
+
+    // Check function-like parameter type hints
+    fn walk_in_function_like_parameter(
+        &mut self,
+        function_like_parameter: &'ast FunctionLikeParameter<'arena>,
+        context: &mut GuardContext<'ctx, 'arena>,
+    ) {
+        if let Some(hint) = &function_like_parameter.hint {
+            Self::check_hint_in_context(hint, BreachVector::ParameterType, context);
+        }
+    }
+
+    // Check function-like return type hints
+    fn walk_in_function_like_return_type_hint(
+        &mut self,
+        function_like_return_type_hint: &'ast FunctionLikeReturnTypeHint<'arena>,
+        context: &mut GuardContext<'ctx, 'arena>,
+    ) {
+        Self::check_hint_in_context(&function_like_return_type_hint.hint, BreachVector::ReturnType, context);
+    }
+
+    // Check instantiations
+    fn walk_in_instantiation(
+        &mut self,
+        instantiation: &'ast Instantiation<'arena>,
+        context: &mut GuardContext<'ctx, 'arena>,
+    ) {
+        if let Expression::Identifier(class_name) = instantiation.class {
+            let fqn = context.lookup_name(class_name);
+
+            check_usage(
+                context,
+                fqn,
+                PermittedDependencyKind::ClassLike,
+                BreachVector::Instantiation,
+                class_name.span(),
+            );
+        }
+    }
+
+    // Check static method calls
+    fn walk_in_static_method_call(
+        &mut self,
+        static_call: &'ast StaticMethodCall<'arena>,
+        context: &mut GuardContext<'ctx, 'arena>,
+    ) {
+        if let Expression::Identifier(class_name) = static_call.class {
+            let fqn = context.lookup_name(class_name);
+
+            check_usage(
+                context,
+                fqn,
+                PermittedDependencyKind::ClassLike,
+                BreachVector::StaticMethodCall,
+                class_name.span(),
+            );
+        }
+    }
+
+    // Check static method closure creations
+    fn walk_in_static_method_closure_creation(
+        &mut self,
+        static_method_closure_creation: &'ast StaticMethodClosureCreation<'arena>,
+        context: &mut GuardContext<'ctx, 'arena>,
+    ) {
+        if let Expression::Identifier(class_name) = static_method_closure_creation.class {
+            let fqn = context.lookup_name(class_name);
+
+            check_usage(
+                context,
+                fqn,
+                PermittedDependencyKind::ClassLike,
+                BreachVector::StaticMethodCall,
+                class_name.span(),
+            );
+        }
+    }
+
+    // Check static property accesses
+    fn walk_in_static_property_access(
+        &mut self,
+        static_access: &'ast StaticPropertyAccess<'arena>,
+        context: &mut GuardContext<'ctx, 'arena>,
+    ) {
+        if let Expression::Identifier(class_name) = static_access.class {
+            let fqn = context.lookup_name(class_name);
+
+            check_usage(
+                context,
+                fqn,
+                PermittedDependencyKind::ClassLike,
+                BreachVector::StaticPropertyAccess,
+                class_name.span(),
+            );
+        }
+    }
+
+    // Check function calls
+    fn walk_in_function_call(
+        &mut self,
+        function_call: &'ast FunctionCall<'arena>,
+        context: &mut GuardContext<'ctx, 'arena>,
+    ) {
+        if let Expression::Identifier(function_name) = function_call.function
+            && let Some(fqn) = context.try_lookup_name(function_name)
+        {
+            check_usage(
+                context,
+                fqn,
+                PermittedDependencyKind::Function,
+                BreachVector::FunctionCall,
+                function_name.span(),
+            );
+        }
+    }
+
+    // Check function closure creations
+    fn walk_in_function_closure_creation(
+        &mut self,
+        function_closure_creation: &'ast FunctionClosureCreation<'arena>,
+        context: &mut GuardContext<'ctx, 'arena>,
+    ) {
+        if let Expression::Identifier(function_name) = function_closure_creation.function
+            && let Some(fqn) = context.try_lookup_name(function_name)
+        {
+            check_usage(
+                context,
+                fqn,
+                PermittedDependencyKind::Function,
+                BreachVector::FunctionCall,
+                function_name.span(),
+            );
+        }
+    }
+
+    // Check class constant accesses
+    fn walk_in_class_constant_access(
+        &mut self,
+        constant_access: &'ast ClassConstantAccess<'arena>,
+        context: &mut GuardContext<'ctx, 'arena>,
+    ) {
+        if let Expression::Identifier(class_name) = constant_access.class {
+            let fqn = context.lookup_name(class_name);
+
+            check_usage(
+                context,
+                fqn,
+                PermittedDependencyKind::ClassLike,
+                BreachVector::ClassConstantAccess,
+                class_name.span(),
+            );
+        }
+    }
+
+    // Check constant accesses
+    fn walk_in_constant_access(
+        &mut self,
+        constant_access: &'ast ConstantAccess<'arena>,
+        context: &mut GuardContext<'ctx, 'arena>,
+    ) {
+        if let Some(fqn) = context.try_lookup_name(&constant_access.name) {
+            check_usage(
+                context,
+                fqn,
+                PermittedDependencyKind::Constant,
+                BreachVector::ConstantAccess,
+                constant_access.name.span(),
+            );
+        }
+    }
+}

--- a/crates/guard/src/report/breach.rs
+++ b/crates/guard/src/report/breach.rs
@@ -1,0 +1,134 @@
+use std::fmt;
+
+use mago_reporting::Annotation;
+use mago_reporting::Issue;
+use mago_span::Span;
+
+use crate::path::NamespacePath;
+use crate::settings::PermittedDependencyKind;
+
+/// Represents a single, specific architectural boundary breach found by the guard.
+#[derive(Debug)]
+pub struct BoundaryBreach {
+    /// The namespace where the breach was detected.
+    pub source_namespace: String,
+    /// The fully qualified name of the symbol that was illegally used.
+    pub dependency_fqn: String,
+    /// The kind of the dependency being used (e.g., class-like, function).
+    pub dependency_kind: PermittedDependencyKind,
+    /// The specific code context where the breach occurred (e.g., an `extends` clause).
+    pub vector: BreachVector,
+    /// The source code location of the breach.
+    pub span: Span,
+    /// The logical reason why this dependency is considered a breach.
+    pub reason: BreachReason,
+}
+
+/// Describes the specific "vector" or method by which a boundary breach occurred.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BreachVector {
+    Extends,
+    Implements,
+    Use,
+    TraitUse,
+    PropertyType,
+    ParameterType,
+    ReturnType,
+    Instantiation,
+    StaticMethodCall,
+    StaticPropertyAccess,
+    ClassConstantAccess,
+    FunctionCall,
+    ConstantAccess,
+    Attribute,
+}
+
+/// Explains the underlying architectural rule that was broken.
+#[derive(Debug)]
+pub enum BreachReason {
+    /// A lower layer is trying to access a higher, more protected layer.
+    Layering { source_layer: NamespacePath, target_layer: NamespacePath },
+    /// No rule was found that explicitly allows this dependency.
+    NoMatchingRule,
+    /// One or more rules were evaluated, but none permitted this specific dependency.
+    ForbiddenByRule { rule_namespaces: Vec<NamespacePath> },
+}
+
+impl From<BoundaryBreach> for Issue {
+    fn from(breach: BoundaryBreach) -> Self {
+        let mut issue = Issue::error(format!("Illegal dependency on `{}`", breach.dependency_fqn))
+            .with_annotation(
+                Annotation::primary(breach.span)
+                    .with_message(format!("This {} is not allowed by the architectural rules", breach.vector)),
+            )
+            .with_note(format!("Breach occurred in namespace `{}`.", breach.source_namespace));
+
+        match breach.reason {
+            BreachReason::Layering { source_layer, target_layer } => {
+                issue = issue.with_note("Layering Rule Conflict").with_note(format!(
+                    "The `{}` layer is not allowed to depend on the `{}` layer.",
+                    source_layer, target_layer
+                ));
+            }
+            BreachReason::NoMatchingRule => {
+                issue = issue
+                    .with_note("No matching architectural rule found")
+                    .with_note("No rule was found that explicitly allows this dependency.");
+            }
+            BreachReason::ForbiddenByRule { rule_namespaces } => {
+                let namespaces = rule_namespaces.iter().map(|ns| format!("`{}`", ns)).collect::<Vec<_>>().join(", ");
+
+                issue = issue.with_note("Dependency forbidden by architectural rules").with_note(format!(
+                    "The following rule(s) were evaluated but none permitted this dependency: {}.",
+                    namespaces
+                ));
+            }
+        };
+
+        issue.with_help("Update your guard configuration to allow this dependency or refactor the code to remove it.")
+    }
+}
+
+impl fmt::Display for BreachVector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let description = match self {
+            Self::Extends => "extends clause",
+            Self::Implements => "implements clause",
+            Self::Use => "`use` statement",
+            Self::TraitUse => "trait `use`",
+            Self::PropertyType => "property type-hint",
+            Self::ParameterType => "parameter type-hint",
+            Self::ReturnType => "return type-hint",
+            Self::Instantiation => "instantiation",
+            Self::StaticMethodCall => "static method call",
+            Self::StaticPropertyAccess => "static property access",
+            Self::ClassConstantAccess => "class constant access",
+            Self::FunctionCall => "function call",
+            Self::ConstantAccess => "constant usage",
+            Self::Attribute => "attribute usage",
+        };
+
+        write!(f, "{}", description)
+    }
+}
+
+impl BreachVector {
+    pub fn error_code(&self) -> &'static str {
+        match self {
+            Self::Extends => "disallowed-extends",
+            Self::Implements => "disallowed-implements",
+            Self::Use => "disallowed-use",
+            Self::TraitUse => "disallowed-trait-use",
+            Self::PropertyType => "disallowed-property-type",
+            Self::ParameterType => "disallowed-parameter-type",
+            Self::ReturnType => "disallowed-return-type",
+            Self::Instantiation => "disallowed-instantiation",
+            Self::StaticMethodCall => "disallowed-static-call",
+            Self::StaticPropertyAccess => "disallowed-static-property",
+            Self::ClassConstantAccess => "disallowed-class-constant",
+            Self::FunctionCall => "disallowed-function-call",
+            Self::ConstantAccess => "disallowed-constant-usage",
+            Self::Attribute => "disallowed-attribute",
+        }
+    }
+}

--- a/crates/guard/src/report/flaw.rs
+++ b/crates/guard/src/report/flaw.rs
@@ -1,0 +1,129 @@
+use std::fmt;
+
+use mago_reporting::Annotation;
+use mago_reporting::Issue;
+use mago_span::Span;
+
+use crate::settings::StructuralInheritanceConstraint;
+use crate::settings::StructuralSymbolKind;
+
+/// Represents a single structural flaw where code does not adhere to defined architectural rules.
+#[derive(Debug)]
+pub struct StructuralFlaw {
+    /// The fully qualified name of the symbol that has a flaw.
+    pub symbol_fqn: String,
+    /// The kind of the flawed symbol (e.g., class-like, function).
+    pub symbol_kind: StructuralSymbolKind,
+    /// The source code location of the flawed symbol's definition.
+    pub span: Span,
+    /// The specific kind why the symbol's structure is considered flawed.
+    pub kind: FlawKind,
+    /// An optional human-readable explanation for the flaw.
+    pub reason: Option<String>,
+}
+
+/// Describes the specific kind of structural flaw.
+#[derive(Debug)]
+pub enum FlawKind {
+    MustBeNamed { pattern: String },
+    MustBeFinal,
+    MustNotBeFinal,
+    MustBeAbstract,
+    MustNotBeAbstract,
+    MustBeReadonly,
+    MustNotBeReadonly,
+    MustImplement { expected: StructuralInheritanceConstraint },
+    MustExtend { expected: StructuralInheritanceConstraint },
+    MustUseTrait { expected: StructuralInheritanceConstraint },
+    MustUseAttribute { expected: StructuralInheritanceConstraint },
+    MustBe { allowed: Vec<StructuralSymbolKind> },
+}
+
+impl From<StructuralFlaw> for Issue {
+    /// Converts a `StructuralFlaw` into a rich, user-friendly `Issue`.
+    fn from(flaw: StructuralFlaw) -> Self {
+        let mut issue = Issue::error(format!("Structural flaw in `{}`", flaw.symbol_fqn))
+            .with_annotation(Annotation::primary(flaw.span).with_message(flaw.kind.to_string()));
+
+        if let Some(reason) = flaw.reason {
+            issue = issue.with_note(reason);
+        }
+
+        let help = match &flaw.kind {
+            FlawKind::MustBeNamed { pattern } => {
+                format!("Rename this {} to match the pattern: `{}`.", flaw.symbol_kind, pattern)
+            }
+            FlawKind::MustBeFinal => format!("Declare this {} as `final`.", flaw.symbol_kind),
+            FlawKind::MustNotBeFinal => format!("Remove the `final` modifier from this {}.", flaw.symbol_kind),
+            FlawKind::MustBeAbstract => format!("Declare this {} as `abstract`.", flaw.symbol_kind),
+            FlawKind::MustNotBeAbstract => format!("Remove the `abstract` modifier from this {}.", flaw.symbol_kind),
+            FlawKind::MustBeReadonly => format!("Declare this {} as `readonly`.", flaw.symbol_kind),
+            FlawKind::MustNotBeReadonly => format!("Remove the `readonly` modifier from this {}.", flaw.symbol_kind),
+            FlawKind::MustImplement { .. } => {
+                format!("Ensure this {} implements the required interface(s).", flaw.symbol_kind)
+            }
+            FlawKind::MustExtend { .. } => {
+                format!("Ensure this {} extends the required base class.", flaw.symbol_kind)
+            }
+            FlawKind::MustUseTrait { .. } => format!("Ensure this {} uses the required trait(s).", flaw.symbol_kind),
+            FlawKind::MustUseAttribute { .. } => {
+                format!("Ensure this {} uses the required attribute(s).", flaw.symbol_kind)
+            }
+            FlawKind::MustBe { .. } => {
+                "Move this symbol to a different namespace or update your guard configuration.".to_string()
+            }
+        };
+
+        issue.with_help(help)
+    }
+}
+
+impl fmt::Display for FlawKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MustBeNamed { pattern } => write!(f, "Name does not match pattern `{}`", pattern),
+            Self::MustBeFinal => write!(f, "This must be declared as `final`"),
+            Self::MustNotBeFinal => write!(f, "This must not be declared as `final`"),
+            Self::MustBeAbstract => write!(f, "This must be declared as `abstract`"),
+            Self::MustNotBeAbstract => write!(f, "This must not be declared as `abstract`"),
+            Self::MustBeReadonly => write!(f, "This must be declared as `readonly`"),
+            Self::MustNotBeReadonly => write!(f, "This must not be declared as `readonly`"),
+            Self::MustImplement { expected } => {
+                write!(f, "Does not implement required interface(s): {}", expected)
+            }
+            Self::MustExtend { expected } => {
+                write!(f, "Does not extend required base class: {}", expected)
+            }
+            Self::MustUseTrait { expected } => {
+                write!(f, "Does not use required trait(s): {}", expected)
+            }
+            Self::MustUseAttribute { expected } => {
+                write!(f, "Does not use required attribute(s): {}", expected)
+            }
+            Self::MustBe { allowed } => {
+                let allowed_str = allowed.iter().map(|s| s.as_str()).collect::<Vec<_>>().join(", ");
+                write!(f, "This namespace should only contain: {}", allowed_str)
+            }
+        }
+    }
+}
+
+impl FlawKind {
+    /// Returns the error code for this type of flaw.
+    pub fn error_code(&self) -> &'static str {
+        match self {
+            Self::MustBeNamed { .. } => "must-be-named",
+            Self::MustBeFinal => "must-be-final",
+            Self::MustNotBeFinal => "must-be-non-final",
+            Self::MustBeAbstract => "must-be-abstract",
+            Self::MustNotBeAbstract => "must-be-non-abstract",
+            Self::MustBeReadonly => "must-be-readonly",
+            Self::MustNotBeReadonly => "must-be-non-readonly",
+            Self::MustImplement { .. } => "must-implement",
+            Self::MustExtend { .. } => "must-extend",
+            Self::MustUseTrait { .. } => "must-use-trait",
+            Self::MustUseAttribute { .. } => "must-use-attribute",
+            Self::MustBe { .. } => "must-be",
+        }
+    }
+}

--- a/crates/guard/src/report/mod.rs
+++ b/crates/guard/src/report/mod.rs
@@ -1,0 +1,39 @@
+use bumpalo::Bump;
+
+use mago_collector::Collector;
+use mago_database::file::File;
+use mago_reporting::IssueCollection;
+use mago_syntax::ast::Program;
+
+use crate::report::breach::BoundaryBreach;
+use crate::report::flaw::StructuralFlaw;
+
+pub mod breach;
+pub mod flaw;
+
+const COLLECTOR_CATEGORIES: &[&str] = &["guard"];
+
+#[derive(Debug, Default)]
+pub struct FortressReport {
+    pub boundary_breaches: Vec<BoundaryBreach>,
+    pub structural_flaws: Vec<StructuralFlaw>,
+}
+
+impl FortressReport {
+    pub fn is_empty(&self) -> bool {
+        self.boundary_breaches.is_empty() && self.structural_flaws.is_empty()
+    }
+
+    pub fn report_into_issues(self, arena: &Bump, source_file: &File, program: &Program) -> IssueCollection {
+        let mut collector = Collector::new(arena, source_file, program, COLLECTOR_CATEGORIES);
+        for boundary_breach in self.boundary_breaches {
+            collector.report_with_code(boundary_breach.vector.error_code(), boundary_breach.into());
+        }
+
+        for structural_flaw in self.structural_flaws {
+            collector.report_with_code(structural_flaw.kind.error_code(), structural_flaw.into());
+        }
+
+        collector.finish()
+    }
+}

--- a/crates/guard/src/settings.rs
+++ b/crates/guard/src/settings.rs
@@ -1,0 +1,378 @@
+use std::fmt;
+
+use ahash::HashMap;
+use serde::Deserialize;
+use serde::Serialize;
+use serde::de;
+use serde::de::Deserializer;
+use serde::de::MapAccess;
+use serde::de::Visitor;
+use serde::ser::SerializeStruct;
+use serde::ser::Serializer;
+
+use crate::path::NamespacePath;
+use crate::path::Path;
+use crate::path::is_valid_identifier_part;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct Settings {
+    pub perimeter: PerimeterSettings,
+    pub structural: StructuralSettings,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct PerimeterSettings {
+    pub layers: HashMap<String, Vec<Path>>,
+    pub layering: Vec<NamespacePath>,
+    pub rules: Vec<PerimeterRule>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PerimeterRule {
+    pub namespace: NamespacePath,
+    pub permit: Vec<PermittedDependency>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum PermittedDependency {
+    Dependency(Path),
+    DependencyOfKind { path: Path, kinds: Vec<PermittedDependencyKind> },
+}
+
+/// Represents the specific types of symbols allowed from a path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PermittedDependencyKind {
+    ClassLike,
+    Function,
+    Constant,
+    Attribute,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct StructuralSettings {
+    /// A list of structural rules to enforce across the codebase.
+    pub rules: Vec<StructuralRule>,
+}
+
+/// Represents a single structural enforcement rule from `[[guard.structural.rules]]`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct StructuralRule {
+    /// The namespace pattern this rule applies to.
+    pub on: String,
+    /// An optional exclusion pattern; if the namespace matches this, the rule is skipped.
+    pub not_on: Option<String>,
+    /// The kind of symbol this policy applies to (e.g., "class").
+    pub target: Option<StructuralSymbolKind>,
+    /// Restricts the namespace to only contain the specified symbol kinds.
+    pub must_be: Option<Vec<StructuralSymbolKind>>,
+    /// Optional naming pattern the symbol's name must match.
+    pub must_be_named: Option<String>,
+    /// If true, the symbol must be declared `final`.
+    pub must_be_final: Option<bool>,
+    /// If true, the symbol must be declared `abstract`.
+    pub must_be_abstract: Option<bool>,
+    /// If true, the symbol must be declared `readonly`.
+    pub must_be_readonly: Option<bool>,
+    /// Structural implementation constraints.
+    pub must_implement: Option<StructuralInheritanceConstraint>,
+    /// Structural extension constraints.
+    pub must_extend: Option<StructuralInheritanceConstraint>,
+    /// Structural trait usage constraints.
+    pub must_use_trait: Option<StructuralInheritanceConstraint>,
+    /// Structural attribute usage constraints.
+    pub must_use_attribute: Option<StructuralInheritanceConstraint>,
+    /// A human-readable reason for this rule.
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum StructuralSymbolKind {
+    ClassLike,
+    Class,
+    Interface,
+    Trait,
+    Enum,
+    Constant,
+    Function,
+}
+
+/// Represents a logical constraint for `implement`, `extend`, or `use_traits`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(untagged)]
+pub enum StructuralInheritanceConstraint {
+    /// An OR of ANDs, e.g., `[["A", "B"], ["C"]]`
+    AnyOfAllOf(Vec<Vec<String>>),
+    /// An AND group, e.g., `["A", "B"]`
+    AllOf(Vec<String>),
+    /// A single required item, e.g., `"A"`
+    Single(String),
+    /// `None` indicates the rule requires no constraints.
+    Nothing,
+}
+
+impl PermittedDependencyKind {
+    /// Returns the string representation of the symbol type.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            PermittedDependencyKind::ClassLike => "class-like",
+            PermittedDependencyKind::Function => "function",
+            PermittedDependencyKind::Constant => "constant",
+            PermittedDependencyKind::Attribute => "attribute",
+        }
+    }
+}
+
+impl StructuralSymbolKind {
+    /// Returns the string representation of the symbol kind.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            StructuralSymbolKind::ClassLike => "class-like",
+            StructuralSymbolKind::Class => "class",
+            StructuralSymbolKind::Interface => "interface",
+            StructuralSymbolKind::Trait => "trait",
+            StructuralSymbolKind::Enum => "enum",
+            StructuralSymbolKind::Constant => "constant",
+            StructuralSymbolKind::Function => "function",
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for PermittedDependency {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct AllowedPathVisitor;
+
+        impl<'de> Visitor<'de> for AllowedPathVisitor {
+            type Value = PermittedDependency;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a path string or a detailed object with path and types")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let path = Path::deserialize(de::value::StrDeserializer::new(value))?;
+                Ok(PermittedDependency::Dependency(path))
+            }
+
+            fn visit_map<M>(self, map: M) -> Result<Self::Value, M::Error>
+            where
+                M: MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct DetailedHelper {
+                    path: Path,
+                    kinds: Vec<PermittedDependencyKind>,
+                }
+
+                let helper: DetailedHelper = Deserialize::deserialize(de::value::MapAccessDeserializer::new(map))?;
+
+                Ok(PermittedDependency::DependencyOfKind { path: helper.path, kinds: helper.kinds })
+            }
+        }
+
+        deserializer.deserialize_any(AllowedPathVisitor)
+    }
+}
+
+impl<'de> Deserialize<'de> for StructuralInheritanceConstraint {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Helper enum to let serde handle the shape detection (string vs array vs array of arrays).
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Untagged {
+            AnyOfAllOf(Vec<Vec<String>>),
+            AllOf(Vec<String>),
+            Single(String),
+        }
+
+        match Untagged::deserialize(deserializer)? {
+            Untagged::Single(s) => {
+                if s.eq_ignore_ascii_case("@nothing") {
+                    Ok(Self::Nothing)
+                } else if s.split('\\').all(is_valid_identifier_part) {
+                    Ok(Self::Single(s))
+                } else {
+                    Err(de::Error::custom(format!(
+                        "Expected a valid fully qualified name or '@nothing', found '{}'",
+                        s
+                    )))
+                }
+            }
+            Untagged::AllOf(items) => {
+                for item in &items {
+                    if !item.split('\\').all(is_valid_identifier_part) {
+                        return Err(de::Error::custom(format!("'{}' is not a valid fully qualified name", item)));
+                    }
+                }
+
+                Ok(Self::AllOf(items))
+            }
+            Untagged::AnyOfAllOf(groups) => {
+                for group in &groups {
+                    for item in group {
+                        if !item.split('\\').all(is_valid_identifier_part) {
+                            return Err(de::Error::custom(format!("'{}' is not a valid fully qualified name", item)));
+                        }
+                    }
+                }
+
+                Ok(Self::AnyOfAllOf(groups))
+            }
+        }
+    }
+}
+
+impl Serialize for PermittedDependency {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            PermittedDependency::Dependency(path) => path.serialize(serializer),
+            PermittedDependency::DependencyOfKind { path, kinds } => {
+                let mut state = serializer.serialize_struct("DependencyOfKind", 2)?;
+                state.serialize_field("path", path)?;
+                state.serialize_field("kinds", kinds)?;
+                state.end()
+            }
+        }
+    }
+}
+
+impl fmt::Display for PermittedDependencyKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl fmt::Display for StructuralInheritanceConstraint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            // "nothing"
+            Self::Nothing => write!(f, "<nothing>"),
+            // "`SomeInterface`"
+            Self::Single(item) => write!(f, "`{}`", item),
+            // "`InterfaceA` and `InterfaceB`"
+            Self::AllOf(items) => {
+                let formatted = items.iter().map(|item| format!("`{}`", item)).collect::<Vec<_>>().join(" and ");
+                write!(f, "{}", formatted)
+            }
+            // "(`InterfaceA` and `InterfaceB`) or `InterfaceC`"
+            Self::AnyOfAllOf(groups) => {
+                let formatted = groups
+                    .iter()
+                    .map(|group| {
+                        let inner = group.iter().map(|item| format!("`{}`", item)).collect::<Vec<_>>().join(" and ");
+                        if group.len() > 1 { format!("({})", inner) } else { inner }
+                    })
+                    .collect::<Vec<_>>()
+                    .join(" or ");
+                write!(f, "{}", formatted)
+            }
+        }
+    }
+}
+
+impl fmt::Display for StructuralSymbolKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_structural_inheritance_constraint_display() {
+        let single = StructuralInheritanceConstraint::Single("SomeInterface".to_string());
+        assert_eq!(single.to_string(), "`SomeInterface`");
+
+        let all_of = StructuralInheritanceConstraint::AllOf(vec!["InterfaceA".to_string(), "InterfaceB".to_string()]);
+        assert_eq!(all_of.to_string(), "`InterfaceA` and `InterfaceB`");
+
+        let any_of_all_of = StructuralInheritanceConstraint::AnyOfAllOf(vec![
+            vec!["InterfaceA".to_string(), "InterfaceB".to_string()],
+            vec!["InterfaceC".to_string()],
+        ]);
+        assert_eq!(any_of_all_of.to_string(), "(`InterfaceA` and `InterfaceB`) or `InterfaceC`");
+
+        let none = StructuralInheritanceConstraint::Nothing;
+        assert_eq!(none.to_string(), "<nothing>");
+    }
+
+    #[derive(Deserialize)]
+    struct Wrapper {
+        constraint: StructuralInheritanceConstraint,
+    }
+
+    #[test]
+    fn it_deserializes_none_keyword() {
+        let toml = r#"constraint = "@nothing""#;
+        let wrapped: Wrapper = toml::from_str(toml).unwrap();
+        assert_eq!(wrapped.constraint, StructuralInheritanceConstraint::Nothing);
+    }
+
+    #[test]
+    fn it_deserializes_valid_single_string() {
+        let toml = r#"constraint = "App\\Domain\\MyInterface""#;
+        let wrapped: Wrapper = toml::from_str(toml).unwrap();
+        assert_eq!(wrapped.constraint, StructuralInheritanceConstraint::Single("App\\Domain\\MyInterface".to_string()));
+    }
+
+    #[test]
+    fn it_deserializes_valid_array_of_strings() {
+        let toml = r#"constraint = ["App\\InterfaceA", "App\\InterfaceB"]"#;
+        let wrapped: Wrapper = toml::from_str(toml).unwrap();
+        assert_eq!(
+            wrapped.constraint,
+            StructuralInheritanceConstraint::AllOf(vec!["App\\InterfaceA".to_string(), "App\\InterfaceB".to_string()])
+        );
+    }
+
+    #[test]
+    fn it_deserializes_valid_array_of_arrays() {
+        let toml = r#"constraint = [["App\\A", "App\\B"], ["App\\C"]]"#;
+        let wrapped: Wrapper = toml::from_str(toml).unwrap();
+        assert_eq!(
+            wrapped.constraint,
+            StructuralInheritanceConstraint::AnyOfAllOf(vec![
+                vec!["App\\A".to_string(), "App\\B".to_string()],
+                vec!["App\\C".to_string()]
+            ])
+        );
+    }
+
+    #[test]
+    fn it_fails_on_invalid_identifier_in_single_string() {
+        let toml = r#"constraint = "Invalid-Interface""#;
+        assert!(toml::from_str::<Wrapper>(toml).is_err());
+    }
+
+    #[test]
+    fn it_fails_on_invalid_identifier_in_array() {
+        let toml = r#"constraint = ["App\\InterfaceA", "Invalid-Interface"]"#;
+        assert!(toml::from_str::<Wrapper>(toml).is_err());
+    }
+
+    #[test]
+    fn it_fails_on_invalid_identifier_in_nested_array() {
+        let toml = r#"constraint = [["App\\A", "Invalid-B"], ["App\\C"]]"#;
+        assert!(toml::from_str::<Wrapper>(toml).is_err());
+    }
+}

--- a/crates/guard/src/structural/mod.rs
+++ b/crates/guard/src/structural/mod.rs
@@ -1,0 +1,642 @@
+use mago_syntax::ast::*;
+use mago_syntax::walker::MutWalker;
+
+use crate::context::GuardContext;
+use crate::report::flaw::FlawKind;
+use crate::report::flaw::StructuralFlaw;
+use crate::settings::StructuralInheritanceConstraint;
+use crate::settings::StructuralRule;
+use crate::settings::StructuralSymbolKind;
+use crate::utils::matches_pattern;
+
+#[derive(Debug, Clone, Copy)]
+pub struct StructuralGuardWalker;
+
+impl StructuralGuardWalker {
+    fn get_structural_rules<'ctx, 'arena>(
+        context: &'ctx GuardContext<'ctx, 'arena>,
+        fqn: &'arena str,
+        kind: StructuralSymbolKind,
+    ) -> Vec<&'ctx StructuralRule> {
+        context.settings.structural.rules.iter().filter(|rule| Self::applies_to(rule, fqn, kind)).collect()
+    }
+
+    fn applies_to(rule: &StructuralRule, fqn: &str, kind: StructuralSymbolKind) -> bool {
+        if let Some(rule_kind) = rule.target
+            && rule_kind != kind
+        {
+            return false;
+        }
+
+        if !matches_pattern(fqn, &rule.on, true) {
+            return false;
+        }
+
+        if let Some(not) = &rule.not_on
+            && matches_pattern(fqn, not, true)
+        {
+            return false;
+        }
+
+        true
+    }
+
+    fn satisfies_inheritance_constraint(
+        implemented_fqns: &[&str],
+        constraint: &StructuralInheritanceConstraint,
+    ) -> bool {
+        match constraint {
+            StructuralInheritanceConstraint::AnyOfAllOf(groups) => {
+                for items in groups {
+                    if items.iter().all(|item| implemented_fqns.iter().any(|imp| imp.eq_ignore_ascii_case(item))) {
+                        return true;
+                    }
+                }
+
+                false
+            }
+            StructuralInheritanceConstraint::AllOf(items) => {
+                for item in items {
+                    if !implemented_fqns.iter().any(|imp| imp.eq_ignore_ascii_case(item)) {
+                        return false;
+                    }
+                }
+
+                true
+            }
+            StructuralInheritanceConstraint::Single(item) => {
+                implemented_fqns.iter().any(|imp| imp.eq_ignore_ascii_case(item))
+            }
+            StructuralInheritanceConstraint::Nothing => implemented_fqns.is_empty(),
+        }
+    }
+}
+
+impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for StructuralGuardWalker {
+    fn walk_in_namespace(&mut self, namespace: &'ast Namespace<'arena>, context: &mut GuardContext<'ctx, 'arena>) {
+        context.set_current_namespace(namespace.name.as_ref().map(|n| n.value()));
+    }
+
+    fn walk_out_namespace(&mut self, _namespace: &'ast Namespace<'arena>, context: &mut GuardContext<'ctx, 'arena>) {
+        context.set_current_namespace(None);
+    }
+
+    fn walk_in_class(&mut self, class: &'ast Class<'arena>, context: &mut GuardContext<'ctx, 'arena>) {
+        let fqn = context.lookup_name(&class.name);
+        let structural_rules = Self::get_structural_rules(context, fqn, StructuralSymbolKind::Class);
+
+        let mut structural_flaws = vec![];
+
+        for structural_rule in structural_rules {
+            if let Some(must_be_named) = &structural_rule.must_be_named
+                && !matches_pattern(class.name.value, must_be_named, false)
+            {
+                structural_flaws.push(StructuralFlaw {
+                    symbol_fqn: fqn.to_string(),
+                    symbol_kind: StructuralSymbolKind::Class,
+                    span: class.name.span,
+                    kind: FlawKind::MustBeNamed { pattern: must_be_named.clone() },
+                    reason: structural_rule.reason.clone(),
+                });
+            }
+
+            if let Some(allowed_kinds) = &structural_rule.must_be
+                && !allowed_kinds.contains(&StructuralSymbolKind::Class)
+            {
+                structural_flaws.push(StructuralFlaw {
+                    symbol_fqn: fqn.to_string(),
+                    symbol_kind: StructuralSymbolKind::Class,
+                    span: class.name.span,
+                    kind: FlawKind::MustBe { allowed: allowed_kinds.clone() },
+                    reason: structural_rule.reason.clone(),
+                });
+            }
+
+            if let Some(must_be_final) = structural_rule.must_be_final {
+                let is_final = class.modifiers.contains_final();
+
+                match (must_be_final, is_final) {
+                    (true, false) => {
+                        structural_flaws.push(StructuralFlaw {
+                            symbol_fqn: fqn.to_string(),
+                            symbol_kind: StructuralSymbolKind::Class,
+                            span: class.name.span,
+                            kind: FlawKind::MustBeFinal,
+                            reason: structural_rule.reason.clone(),
+                        });
+                    }
+                    (false, true) => {
+                        structural_flaws.push(StructuralFlaw {
+                            symbol_fqn: fqn.to_string(),
+                            symbol_kind: StructuralSymbolKind::Class,
+                            span: class.name.span,
+                            kind: FlawKind::MustNotBeFinal,
+                            reason: structural_rule.reason.clone(),
+                        });
+                    }
+                    _ => {}
+                }
+            }
+
+            if let Some(must_be_abstract) = structural_rule.must_be_abstract {
+                let is_abstract = class.modifiers.contains_abstract();
+
+                match (must_be_abstract, is_abstract) {
+                    (true, false) => {
+                        structural_flaws.push(StructuralFlaw {
+                            symbol_fqn: fqn.to_string(),
+                            symbol_kind: StructuralSymbolKind::Class,
+                            span: class.name.span,
+                            kind: FlawKind::MustBeAbstract,
+                            reason: structural_rule.reason.clone(),
+                        });
+                    }
+                    (false, true) => {
+                        structural_flaws.push(StructuralFlaw {
+                            symbol_fqn: fqn.to_string(),
+                            symbol_kind: StructuralSymbolKind::Class,
+                            span: class.name.span,
+                            kind: FlawKind::MustNotBeAbstract,
+                            reason: structural_rule.reason.clone(),
+                        });
+                    }
+                    _ => {}
+                }
+            }
+
+            if let Some(must_be_readonly) = structural_rule.must_be_readonly {
+                let is_readonly = class.modifiers.contains_readonly();
+
+                match (must_be_readonly, is_readonly) {
+                    (true, false) => {
+                        structural_flaws.push(StructuralFlaw {
+                            symbol_fqn: fqn.to_string(),
+                            symbol_kind: StructuralSymbolKind::Class,
+                            span: class.name.span,
+                            kind: FlawKind::MustBeReadonly,
+                            reason: structural_rule.reason.clone(),
+                        });
+                    }
+                    (false, true) => {
+                        structural_flaws.push(StructuralFlaw {
+                            symbol_fqn: fqn.to_string(),
+                            symbol_kind: StructuralSymbolKind::Class,
+                            span: class.name.span,
+                            kind: FlawKind::MustNotBeReadonly,
+                            reason: structural_rule.reason.clone(),
+                        });
+                    }
+                    _ => {}
+                }
+            }
+
+            if let Some(must_extends) = &structural_rule.must_extend {
+                let extended_fqns: Vec<_> = class
+                    .extends
+                    .as_ref()
+                    .iter()
+                    .flat_map(|ext| ext.types.iter())
+                    .map(|ident| context.lookup_name(ident))
+                    .collect();
+
+                if !Self::satisfies_inheritance_constraint(
+                    &extended_fqns.iter().map(|s| s.as_ref()).collect::<Vec<_>>(),
+                    must_extends,
+                ) {
+                    structural_flaws.push(StructuralFlaw {
+                        symbol_fqn: fqn.to_string(),
+                        symbol_kind: StructuralSymbolKind::Class,
+                        span: class.name.span,
+                        kind: FlawKind::MustExtend { expected: must_extends.clone() },
+                        reason: structural_rule.reason.clone(),
+                    });
+                }
+            }
+
+            if let Some(must_implement) = &structural_rule.must_implement {
+                let implemented_fqns: Vec<_> = class
+                    .implements
+                    .as_ref()
+                    .iter()
+                    .flat_map(|ext| ext.types.iter())
+                    .map(|ident| context.lookup_name(ident))
+                    .collect();
+
+                if !Self::satisfies_inheritance_constraint(
+                    &implemented_fqns.iter().map(|s| s.as_ref()).collect::<Vec<_>>(),
+                    must_implement,
+                ) {
+                    structural_flaws.push(StructuralFlaw {
+                        symbol_fqn: fqn.to_string(),
+                        symbol_kind: StructuralSymbolKind::Class,
+                        span: class.name.span,
+                        kind: FlawKind::MustImplement { expected: must_implement.clone() },
+                        reason: structural_rule.reason.clone(),
+                    });
+                }
+            }
+
+            if let Some(must_use_traits) = &structural_rule.must_use_trait {
+                let used_fqns: Vec<_> = class
+                    .members
+                    .iter()
+                    .filter_map(|member| match member {
+                        ClassLikeMember::TraitUse(trait_use) => Some(trait_use),
+                        _ => None,
+                    })
+                    .flat_map(|trait_use| trait_use.trait_names.iter())
+                    .map(|ident| context.lookup_name(ident))
+                    .collect();
+
+                if !Self::satisfies_inheritance_constraint(
+                    &used_fqns.iter().map(|s| s.as_ref()).collect::<Vec<_>>(),
+                    must_use_traits,
+                ) {
+                    structural_flaws.push(StructuralFlaw {
+                        symbol_fqn: fqn.to_string(),
+                        symbol_kind: StructuralSymbolKind::Class,
+                        span: class.name.span,
+                        kind: FlawKind::MustUseTrait { expected: must_use_traits.clone() },
+                        reason: structural_rule.reason.clone(),
+                    });
+                }
+            }
+
+            if let Some(must_use_attributes) = &structural_rule.must_use_attribute {
+                let used_attributes: Vec<_> = class
+                    .attribute_lists
+                    .iter()
+                    .flat_map(|attribute_list| attribute_list.attributes.iter())
+                    .map(|attr| context.lookup_name(&attr.name))
+                    .collect();
+
+                if !Self::satisfies_inheritance_constraint(
+                    &used_attributes.iter().map(|s| s.as_ref()).collect::<Vec<_>>(),
+                    must_use_attributes,
+                ) {
+                    structural_flaws.push(StructuralFlaw {
+                        symbol_fqn: fqn.to_string(),
+                        symbol_kind: StructuralSymbolKind::Class,
+                        span: class.name.span,
+                        kind: FlawKind::MustUseAttribute { expected: must_use_attributes.clone() },
+                        reason: structural_rule.reason.clone(),
+                    });
+                }
+            }
+        }
+
+        context.structural_flaws.extend(structural_flaws);
+    }
+
+    fn walk_in_interface(&mut self, interface: &'ast Interface<'arena>, context: &mut GuardContext<'ctx, 'arena>) {
+        let fqn = context.lookup_name(&interface.name);
+        let structural_rules = Self::get_structural_rules(context, fqn, StructuralSymbolKind::Interface);
+
+        let mut structural_flaws = vec![];
+        for structural_rule in structural_rules {
+            if let Some(must_be_named) = &structural_rule.must_be_named
+                && !matches_pattern(interface.name.value, must_be_named, false)
+            {
+                structural_flaws.push(StructuralFlaw {
+                    symbol_fqn: fqn.to_string(),
+                    symbol_kind: StructuralSymbolKind::Interface,
+                    span: interface.name.span,
+                    kind: FlawKind::MustBeNamed { pattern: must_be_named.clone() },
+                    reason: structural_rule.reason.clone(),
+                });
+            }
+
+            if let Some(allowed_kinds) = &structural_rule.must_be
+                && !allowed_kinds.contains(&StructuralSymbolKind::Interface)
+            {
+                structural_flaws.push(StructuralFlaw {
+                    symbol_fqn: fqn.to_string(),
+                    symbol_kind: StructuralSymbolKind::Interface,
+                    span: interface.name.span,
+                    kind: FlawKind::MustBe { allowed: allowed_kinds.clone() },
+                    reason: structural_rule.reason.clone(),
+                });
+            }
+
+            if let Some(must_extends) = &structural_rule.must_extend {
+                let extended_fqns: Vec<_> = interface
+                    .extends
+                    .as_ref()
+                    .iter()
+                    .flat_map(|ext| ext.types.iter())
+                    .map(|ident| context.lookup_name(ident))
+                    .collect();
+
+                if !Self::satisfies_inheritance_constraint(
+                    &extended_fqns.iter().map(|s| s.as_ref()).collect::<Vec<_>>(),
+                    must_extends,
+                ) {
+                    structural_flaws.push(StructuralFlaw {
+                        symbol_fqn: fqn.to_string(),
+                        symbol_kind: StructuralSymbolKind::Interface,
+                        span: interface.name.span,
+                        kind: FlawKind::MustExtend { expected: must_extends.clone() },
+                        reason: structural_rule.reason.clone(),
+                    });
+                }
+            }
+
+            if let Some(must_use_attributes) = &structural_rule.must_use_attribute {
+                let used_attributes: Vec<_> = interface
+                    .attribute_lists
+                    .iter()
+                    .flat_map(|attribute_list| attribute_list.attributes.iter())
+                    .map(|attr| context.lookup_name(&attr.name))
+                    .collect();
+
+                if !Self::satisfies_inheritance_constraint(
+                    &used_attributes.iter().map(|s| s.as_ref()).collect::<Vec<_>>(),
+                    must_use_attributes,
+                ) {
+                    structural_flaws.push(StructuralFlaw {
+                        symbol_fqn: fqn.to_string(),
+                        symbol_kind: StructuralSymbolKind::Interface,
+                        span: interface.name.span,
+                        kind: FlawKind::MustUseAttribute { expected: must_use_attributes.clone() },
+                        reason: structural_rule.reason.clone(),
+                    });
+                }
+            }
+        }
+    }
+
+    fn walk_in_enum(&mut self, r#enum: &'ast Enum<'arena>, context: &mut GuardContext<'ctx, 'arena>) {
+        let fqn = context.lookup_name(&r#enum.name);
+        let structural_rules = Self::get_structural_rules(context, fqn, StructuralSymbolKind::Enum);
+
+        let mut structural_flaws = vec![];
+        for structural_rule in structural_rules {
+            if let Some(must_be_named) = &structural_rule.must_be_named
+                && !matches_pattern(r#enum.name.value, must_be_named, false)
+            {
+                structural_flaws.push(StructuralFlaw {
+                    symbol_fqn: fqn.to_string(),
+                    symbol_kind: StructuralSymbolKind::Enum,
+                    span: r#enum.name.span,
+                    kind: FlawKind::MustBeNamed { pattern: must_be_named.clone() },
+                    reason: structural_rule.reason.clone(),
+                });
+            }
+
+            if let Some(allowed_kinds) = &structural_rule.must_be
+                && !allowed_kinds.contains(&StructuralSymbolKind::Enum)
+            {
+                structural_flaws.push(StructuralFlaw {
+                    symbol_fqn: fqn.to_string(),
+                    symbol_kind: StructuralSymbolKind::Enum,
+                    span: r#enum.name.span,
+                    kind: FlawKind::MustBe { allowed: allowed_kinds.clone() },
+                    reason: structural_rule.reason.clone(),
+                });
+            }
+
+            if let Some(must_implement) = &structural_rule.must_implement {
+                let implemented_fqns: Vec<_> = r#enum
+                    .implements
+                    .as_ref()
+                    .iter()
+                    .flat_map(|ext| ext.types.iter())
+                    .map(|ident| context.lookup_name(ident))
+                    .collect();
+
+                if !Self::satisfies_inheritance_constraint(
+                    &implemented_fqns.iter().map(|s| s.as_ref()).collect::<Vec<_>>(),
+                    must_implement,
+                ) {
+                    structural_flaws.push(StructuralFlaw {
+                        symbol_fqn: fqn.to_string(),
+                        symbol_kind: StructuralSymbolKind::Enum,
+                        span: r#enum.name.span,
+                        kind: FlawKind::MustImplement { expected: must_implement.clone() },
+                        reason: structural_rule.reason.clone(),
+                    });
+                }
+            }
+
+            if let Some(must_use_attributes) = &structural_rule.must_use_attribute {
+                let used_attributes: Vec<_> = r#enum
+                    .attribute_lists
+                    .iter()
+                    .flat_map(|attribute_list| attribute_list.attributes.iter())
+                    .map(|attr| context.lookup_name(&attr.name))
+                    .collect();
+
+                if !Self::satisfies_inheritance_constraint(
+                    &used_attributes.iter().map(|s| s.as_ref()).collect::<Vec<_>>(),
+                    must_use_attributes,
+                ) {
+                    structural_flaws.push(StructuralFlaw {
+                        symbol_fqn: fqn.to_string(),
+                        symbol_kind: StructuralSymbolKind::Enum,
+                        span: r#enum.name.span,
+                        kind: FlawKind::MustUseAttribute { expected: must_use_attributes.clone() },
+                        reason: structural_rule.reason.clone(),
+                    });
+                }
+            }
+        }
+
+        context.structural_flaws.extend(structural_flaws);
+    }
+
+    fn walk_in_trait(&mut self, r#trait: &'ast Trait<'arena>, context: &mut GuardContext<'ctx, 'arena>) {
+        let fqn = context.lookup_name(&r#trait.name);
+        let structural_rules = Self::get_structural_rules(context, fqn, StructuralSymbolKind::Trait);
+
+        let mut structural_flaws = vec![];
+        for structural_rule in structural_rules {
+            if let Some(must_be_named) = &structural_rule.must_be_named
+                && !matches_pattern(r#trait.name.value, must_be_named, false)
+            {
+                structural_flaws.push(StructuralFlaw {
+                    symbol_fqn: fqn.to_string(),
+                    symbol_kind: StructuralSymbolKind::Trait,
+                    span: r#trait.name.span,
+                    kind: FlawKind::MustBeNamed { pattern: must_be_named.clone() },
+                    reason: structural_rule.reason.clone(),
+                });
+            }
+
+            if let Some(allowed_kinds) = &structural_rule.must_be
+                && !allowed_kinds.contains(&StructuralSymbolKind::Trait)
+            {
+                structural_flaws.push(StructuralFlaw {
+                    symbol_fqn: fqn.to_string(),
+                    symbol_kind: StructuralSymbolKind::Trait,
+                    span: r#trait.name.span,
+                    kind: FlawKind::MustBe { allowed: allowed_kinds.clone() },
+                    reason: structural_rule.reason.clone(),
+                });
+            }
+
+            if let Some(must_use_traits) = &structural_rule.must_use_trait {
+                let used_fqns: Vec<_> = r#trait
+                    .members
+                    .iter()
+                    .filter_map(|member| match member {
+                        ClassLikeMember::TraitUse(trait_use) => Some(trait_use),
+                        _ => None,
+                    })
+                    .flat_map(|trait_use| trait_use.trait_names.iter())
+                    .map(|ident| context.lookup_name(ident))
+                    .collect();
+
+                if !Self::satisfies_inheritance_constraint(
+                    &used_fqns.iter().map(|s| s.as_ref()).collect::<Vec<_>>(),
+                    must_use_traits,
+                ) {
+                    structural_flaws.push(StructuralFlaw {
+                        symbol_fqn: fqn.to_string(),
+                        symbol_kind: StructuralSymbolKind::Trait,
+                        span: r#trait.name.span,
+                        kind: FlawKind::MustUseTrait { expected: must_use_traits.clone() },
+                        reason: structural_rule.reason.clone(),
+                    });
+                }
+            }
+
+            if let Some(must_use_attributes) = &structural_rule.must_use_attribute {
+                let used_attributes: Vec<_> = r#trait
+                    .attribute_lists
+                    .iter()
+                    .flat_map(|attribute_list| attribute_list.attributes.iter())
+                    .map(|attr| context.lookup_name(&attr.name))
+                    .collect();
+
+                if !Self::satisfies_inheritance_constraint(
+                    &used_attributes.iter().map(|s| s.as_ref()).collect::<Vec<_>>(),
+                    must_use_attributes,
+                ) {
+                    structural_flaws.push(StructuralFlaw {
+                        symbol_fqn: fqn.to_string(),
+                        symbol_kind: StructuralSymbolKind::Trait,
+                        span: r#trait.name.span,
+                        kind: FlawKind::MustUseAttribute { expected: must_use_attributes.clone() },
+                        reason: structural_rule.reason.clone(),
+                    });
+                }
+            }
+        }
+
+        context.structural_flaws.extend(structural_flaws);
+    }
+
+    fn walk_in_function(&mut self, function: &'ast Function<'arena>, context: &mut GuardContext<'ctx, 'arena>) {
+        let fqn = context.lookup_name(&function.name);
+        let structural_rules = Self::get_structural_rules(context, fqn, StructuralSymbolKind::Function);
+
+        let mut structural_flaws = vec![];
+        for structural_rule in structural_rules {
+            if let Some(must_be_named) = &structural_rule.must_be_named
+                && !matches_pattern(function.name.value, must_be_named, false)
+            {
+                structural_flaws.push(StructuralFlaw {
+                    symbol_fqn: fqn.to_string(),
+                    symbol_kind: StructuralSymbolKind::Function,
+                    span: function.name.span,
+                    kind: FlawKind::MustBeNamed { pattern: must_be_named.clone() },
+                    reason: structural_rule.reason.clone(),
+                });
+            }
+
+            if let Some(allowed_kinds) = &structural_rule.must_be
+                && !allowed_kinds.contains(&StructuralSymbolKind::Function)
+            {
+                structural_flaws.push(StructuralFlaw {
+                    symbol_fqn: fqn.to_string(),
+                    symbol_kind: StructuralSymbolKind::Function,
+                    span: function.name.span,
+                    kind: FlawKind::MustBe { allowed: allowed_kinds.clone() },
+                    reason: structural_rule.reason.clone(),
+                });
+            }
+
+            if let Some(must_use_attribute) = &structural_rule.must_use_attribute {
+                let used_attributes: Vec<_> = function
+                    .attribute_lists
+                    .iter()
+                    .flat_map(|attribute_list| attribute_list.attributes.iter())
+                    .map(|attr| context.lookup_name(&attr.name))
+                    .collect();
+
+                if !Self::satisfies_inheritance_constraint(
+                    &used_attributes.iter().map(|s| s.as_ref()).collect::<Vec<_>>(),
+                    must_use_attribute,
+                ) {
+                    structural_flaws.push(StructuralFlaw {
+                        symbol_fqn: fqn.to_string(),
+                        symbol_kind: StructuralSymbolKind::Function,
+                        span: function.name.span,
+                        kind: FlawKind::MustUseAttribute { expected: must_use_attribute.clone() },
+                        reason: structural_rule.reason.clone(),
+                    });
+                }
+            }
+        }
+
+        context.structural_flaws.extend(structural_flaws);
+    }
+
+    fn walk_in_constant(&mut self, constant: &'ast Constant<'arena>, context: &mut GuardContext<'ctx, 'arena>) {
+        let mut structural_flaws = vec![];
+        for constant_item in constant.items.iter() {
+            let fqn = context.lookup_name(&constant_item.name);
+            let structural_rules = Self::get_structural_rules(context, fqn, StructuralSymbolKind::Constant);
+
+            for structural_rule in structural_rules {
+                if let Some(must_be_named) = &structural_rule.must_be_named
+                    && !matches_pattern(constant_item.name.value, must_be_named, false)
+                {
+                    structural_flaws.push(StructuralFlaw {
+                        symbol_fqn: fqn.to_string(),
+                        symbol_kind: StructuralSymbolKind::Constant,
+                        span: constant_item.name.span,
+                        kind: FlawKind::MustBeNamed { pattern: must_be_named.clone() },
+                        reason: structural_rule.reason.clone(),
+                    });
+                }
+
+                if let Some(allowed_kinds) = &structural_rule.must_be
+                    && !allowed_kinds.contains(&StructuralSymbolKind::Constant)
+                {
+                    structural_flaws.push(StructuralFlaw {
+                        symbol_fqn: fqn.to_string(),
+                        symbol_kind: StructuralSymbolKind::Constant,
+                        span: constant_item.name.span,
+                        kind: FlawKind::MustBe { allowed: allowed_kinds.clone() },
+                        reason: structural_rule.reason.clone(),
+                    });
+                }
+
+                if let Some(must_use_attributes) = &structural_rule.must_use_attribute {
+                    let used_attributes: Vec<_> = constant
+                        .attribute_lists
+                        .iter()
+                        .flat_map(|attribute_list| attribute_list.attributes.iter())
+                        .map(|attr| context.lookup_name(&attr.name))
+                        .collect();
+
+                    if !Self::satisfies_inheritance_constraint(
+                        &used_attributes.iter().map(|s| s.as_ref()).collect::<Vec<_>>(),
+                        must_use_attributes,
+                    ) {
+                        structural_flaws.push(StructuralFlaw {
+                            symbol_fqn: fqn.to_string(),
+                            symbol_kind: StructuralSymbolKind::Constant,
+                            span: constant_item.name.span,
+                            kind: FlawKind::MustUseAttribute { expected: must_use_attributes.clone() },
+                            reason: structural_rule.reason.clone(),
+                        });
+                    }
+                }
+            }
+        }
+
+        context.structural_flaws.extend(structural_flaws);
+    }
+}

--- a/crates/guard/src/utils.rs
+++ b/crates/guard/src/utils.rs
@@ -1,0 +1,108 @@
+use regex::Regex;
+use std::collections::HashMap;
+use std::sync::LazyLock;
+use std::sync::RwLock;
+
+// A global, thread-safe cache for compiled regex patterns.
+// This is the core of the optimization. `LazyLock` ensures it's initialized
+// only once, and `RwLock` allows concurrent reads without blocking.
+static REGEX_CACHE: LazyLock<RwLock<HashMap<String, Regex>>> = LazyLock::new(|| RwLock::new(HashMap::new()));
+
+/// Checks if a fully qualified name matches a given pattern.
+pub fn matches_pattern(fqn: &str, pattern: &str, is_namespace: bool) -> bool {
+    if !pattern.contains('*') {
+        if is_namespace {
+            let ns_pattern = pattern.trim_end_matches('\\');
+            if !fqn.to_ascii_lowercase().starts_with(&ns_pattern.to_ascii_lowercase()) {
+                return false;
+            }
+
+            fqn.len() == ns_pattern.len() || fqn.as_bytes().get(ns_pattern.len()) == Some(&b'\\')
+        } else {
+            // This is an exact symbol match.
+            fqn.eq_ignore_ascii_case(pattern)
+        }
+    } else {
+        let cache = REGEX_CACHE.read().unwrap();
+        if let Some(re) = cache.get(pattern) {
+            return re.is_match(fqn);
+        }
+
+        drop(cache);
+
+        let mut cache = REGEX_CACHE.write().unwrap();
+
+        if let Some(re) = cache.get(pattern) {
+            return re.is_match(fqn);
+        }
+
+        let regex_pattern = pattern_to_regex(pattern);
+        if let Ok(re) = Regex::new(&regex_pattern) {
+            cache.insert(pattern.to_string(), re.clone());
+            re.is_match(fqn)
+        } else {
+            false
+        }
+    }
+}
+
+fn pattern_to_regex(pattern: &str) -> String {
+    let mut regex = String::from("(?i)^");
+    let mut chars = pattern.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            '*' => {
+                if chars.peek() == Some(&'*') {
+                    chars.next();
+                    regex.push_str(".*");
+                } else {
+                    regex.push_str("[^\\\\]+");
+                }
+            }
+            '\\' => regex.push_str("\\\\"),
+            '.' | '+' | '?' | '(' | ')' | '[' | ']' | '{' | '}' | '|' | '^' | '$' => {
+                regex.push('\\');
+                regex.push(ch);
+            }
+            _ => regex.push(ch),
+        }
+    }
+
+    regex.push('$');
+    regex
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_matches_pattern_exact() {
+        assert!(matches_pattern("Foo\\Bar", "Foo\\Bar", false));
+        assert!(!matches_pattern("Foo\\Bar", "Foo\\Baz", false));
+    }
+
+    #[test]
+    fn test_matches_namespace_prefix() {
+        assert!(matches_pattern("Foo\\Bar\\Baz", "Foo\\", true));
+        assert!(matches_pattern("Foo\\Bar\\Baz", "Foo\\Bar\\", true));
+        assert!(matches_pattern("Foo\\Bar", "Foo\\Bar\\", true));
+        assert!(!matches_pattern("Foo\\BarBaz", "Foo\\Bar\\", true));
+        assert!(!matches_pattern("Another\\Foo\\Bar", "Foo\\Bar\\", true));
+    }
+
+    #[test]
+    fn test_matches_pattern_single_wildcard() {
+        assert!(matches_pattern("Foo\\Bar", "Foo\\*", false));
+        assert!(matches_pattern("Foo\\Baz", "Foo\\*", false));
+        assert!(!matches_pattern("Foo\\Bar\\Baz", "Foo\\*", false));
+    }
+
+    #[test]
+    fn test_matches_pattern_recursive_wildcard() {
+        assert!(matches_pattern("Foo\\Bar", "Foo\\**", false));
+        assert!(matches_pattern("Foo\\Bar\\Baz", "Foo\\**", false));
+        assert!(matches_pattern("Foo\\Bar\\Baz\\Qux", "Foo\\**", false));
+    }
+}

--- a/crates/guard/tests/mod.rs
+++ b/crates/guard/tests/mod.rs
@@ -1,0 +1,528 @@
+use std::borrow::Cow;
+use std::sync::LazyLock;
+
+use ahash::HashSet;
+use bumpalo::Bump;
+use indoc::indoc;
+
+use mago_atom::AtomSet;
+use mago_codex::populator::populate_codebase;
+use mago_codex::scanner::scan_program;
+use mago_database::DatabaseReader;
+use mago_database::file::File;
+use mago_guard::ArchitecturalGuard;
+use mago_guard::path::NamespacePath;
+use mago_guard::path::Path;
+use mago_guard::path::SymbolSelector;
+use mago_guard::report::FortressReport;
+use mago_guard::report::breach::BreachVector;
+use mago_guard::settings::PerimeterRule;
+use mago_guard::settings::PerimeterSettings;
+use mago_guard::settings::PermittedDependency;
+use mago_guard::settings::PermittedDependencyKind;
+use mago_guard::settings::Settings;
+use mago_names::resolver::NameResolver;
+use mago_prelude::Prelude;
+use mago_syntax::parser::parse_file;
+
+static PRELUDE: LazyLock<Prelude> = LazyLock::new(Prelude::build);
+
+fn test_guard(name: &'static str, code: &'static str, settings: Settings) -> FortressReport {
+    let Prelude { mut database, mut metadata, mut symbol_references } = PRELUDE.clone();
+
+    let file = File::ephemeral(Cow::Borrowed(name), Cow::Borrowed(code));
+    let file_id = database.add(file);
+    let source_file = database.get_ref(&file_id).expect("File just added should exist");
+
+    let arena = Bump::new();
+    let (program, parse_issues) = parse_file(&arena, source_file);
+    if parse_issues.is_some() {
+        panic!("Test '{}' failed during parsing:\n{:#?}", name, parse_issues);
+    }
+
+    let resolver = NameResolver::new(&arena);
+    let resolved_names = resolver.resolve(program);
+
+    metadata.extend(scan_program(&arena, source_file, program, &resolved_names));
+
+    populate_codebase(&mut metadata, &mut symbol_references, AtomSet::default(), HashSet::default());
+
+    let guard = ArchitecturalGuard::new(settings);
+    guard.check(&metadata, program, &resolved_names)
+}
+
+#[test]
+pub fn test_extends_violation() {
+    let code = indoc! {r#"
+        <?php
+        namespace App\Core {}
+        namespace App\Module {
+            class MyClass extends \App\Core\BaseClass {}
+        }
+    "#};
+    let settings = Settings::default(); // Deny by default
+    let result = test_guard("extends_violation", code, settings);
+    assert_eq!(result.boundary_breaches.len(), 1);
+    assert_eq!(result.boundary_breaches[0].vector, BreachVector::Extends);
+}
+
+#[test]
+pub fn test_implements_violation() {
+    let code = indoc! {r#"
+        <?php
+
+        namespace App\Core {}
+
+        namespace App\Module {
+            class MyClass implements \App\Core\MyInterface {}
+        }
+    "#};
+
+    let settings = Settings::default();
+    let result = test_guard("implements_violation", code, settings);
+    assert_eq!(result.boundary_breaches.len(), 1);
+    assert_eq!(result.boundary_breaches[0].vector, BreachVector::Implements);
+}
+
+// Test for UsageKind::ReturnType
+#[test]
+pub fn test_return_type_violation() {
+    let code = indoc! {r#"
+        <?php
+
+        namespace App\Core {}
+        namespace App\Module {
+            function my_function(): \App\Core\MyType {}
+        }
+    "#};
+
+    let settings = Settings::default();
+    let result = test_guard("return_type_violation", code, settings);
+
+    assert_eq!(result.boundary_breaches.len(), 1);
+    assert_eq!(result.boundary_breaches[0].vector, BreachVector::ReturnType);
+}
+
+#[test]
+pub fn test_instantiation_violation() {
+    let code = indoc! {r#"
+        <?php
+
+        namespace App\Core {}
+
+        namespace App\Module {
+            new \App\Core\MyClass();
+        }
+    "#};
+
+    let settings = Settings::default();
+    let result = test_guard("instantiation_violation", code, settings);
+    assert_eq!(result.boundary_breaches.len(), 1);
+    assert_eq!(result.boundary_breaches[0].vector, BreachVector::Instantiation);
+}
+
+#[test]
+pub fn test_static_method_call_violation() {
+    let code = indoc! {r#"
+        <?php
+
+        namespace App\Core { class Helper { public static function do() {} } }
+
+        namespace App\Module {
+            \App\Core\Helper::do();
+        }
+    "#};
+
+    let settings = Settings::default();
+    let result = test_guard("static_method_call_violation", code, settings);
+    assert_eq!(result.boundary_breaches.len(), 1);
+    assert_eq!(result.boundary_breaches[0].vector, BreachVector::StaticMethodCall);
+}
+
+#[test]
+pub fn test_interface_dependency_violation() {
+    let code = indoc! {r#"
+        <?php
+
+        namespace App\Core { interface ServiceInterface {} }
+
+        namespace App\Module {
+            class MyService implements \App\Core\ServiceInterface {}
+        }
+    "#};
+    let settings = Settings::default();
+    let result = test_guard("interface_dependency_violation", code, settings);
+
+    assert_eq!(result.boundary_breaches.len(), 1);
+    assert_eq!(result.boundary_breaches[0].dependency_kind, PermittedDependencyKind::ClassLike);
+}
+
+#[test]
+pub fn test_trait_dependency_violation() {
+    let code = indoc! {r#"
+        <?php
+
+        namespace App\Core { trait MyTrait {} }
+
+        namespace App\Module {
+            class MyClass { use \App\Core\MyTrait; }
+        }
+    "#};
+
+    let settings = Settings::default();
+    let result = test_guard("trait_dependency_violation", code, settings);
+    assert_eq!(result.boundary_breaches.len(), 1);
+    assert_eq!(result.boundary_breaches[0].dependency_kind, PermittedDependencyKind::ClassLike);
+}
+
+#[test]
+pub fn test_enum_dependency_violation() {
+    let code = indoc! {r#"
+        <?php
+
+        namespace App\Core {
+            enum MyEnum {}
+        }
+
+        namespace App\Module {
+            function test(\App\Core\MyEnum $e) {}
+        }
+    "#};
+
+    let settings = Settings {
+        perimeter: PerimeterSettings {
+            rules: vec![PerimeterRule {
+                namespace: NamespacePath::Specific("App\\Module\\".to_string()),
+                permit: vec![],
+            }],
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let result = test_guard("enum_dependency_violation", code, settings);
+    assert_eq!(result.boundary_breaches.len(), 1);
+
+    assert_eq!(result.boundary_breaches[0].dependency_kind, PermittedDependencyKind::ClassLike);
+}
+
+#[test]
+pub fn test_const_dependency_violation() {
+    let code = indoc! {r#"
+        <?php
+
+        namespace App\Core {
+            const MY_CONST = 1;
+        }
+
+        namespace App\Module {
+            $a = \App\Core\MY_CONST;
+        }
+    "#};
+
+    let settings = Settings::default();
+    let result = test_guard("const_dependency_violation", code, settings);
+
+    assert_eq!(result.boundary_breaches.len(), 1);
+    assert_eq!(result.boundary_breaches[0].dependency_kind, PermittedDependencyKind::Constant);
+}
+
+#[test]
+pub fn test_native_type_is_allowed() {
+    let code = indoc! {r#"
+        <?php
+
+        namespace App\Module;
+
+        use DateTime;
+        use Exception;
+
+        function test(DateTime $d): Exception {
+            throw new Exception();
+        }
+    "#};
+
+    let settings = Settings {
+        perimeter: PerimeterSettings {
+            rules: vec![PerimeterRule {
+                namespace: NamespacePath::Specific("App\\Module\\".to_string()),
+                permit: vec![PermittedDependency::Dependency(Path::Native)],
+            }],
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let result = test_guard("native_type_is_allowed", code, settings);
+    assert!(result.is_empty(), "Expected no violations for native types, found: {:#?}", result.boundary_breaches);
+}
+
+#[test]
+pub fn test_union_type_violation() {
+    let code = indoc! {r#"
+        <?php
+
+        namespace App\Core {
+            class A {}
+        }
+
+        namespace App\Domain {
+            class B {}
+        }
+
+        namespace App\Module {
+            use App\Core\A;
+            use App\Domain\B;
+
+            function test(A|B $ab) {
+            }
+        }
+    "#};
+
+    let settings = Settings {
+        perimeter: PerimeterSettings {
+            rules: vec![PerimeterRule {
+                namespace: NamespacePath::Specific("App\\Module\\".to_string()),
+                permit: vec![PermittedDependency::Dependency(Path::Selector(SymbolSelector::Namespace(
+                    NamespacePath::Specific("App\\Domain\\".to_string()),
+                )))],
+            }],
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let result = test_guard("union_type_violation", code, settings);
+    assert_eq!(result.boundary_breaches.len(), 2, "Expected 2 violations for Core\\A");
+    assert_eq!(result.boundary_breaches[0].dependency_fqn, "App\\Core\\A"); // `use`
+    assert_eq!(result.boundary_breaches[1].dependency_fqn, "App\\Core\\A"); // parameter type
+}
+
+#[test]
+pub fn test_intersection_type_violation() {
+    let code = indoc! {r#"
+        <?php
+
+        namespace App\Core {
+            interface A {}
+        }
+
+        namespace App\Domain {
+            interface B {}
+        }
+
+        namespace App\Module {
+            use App\Domain\B;
+
+            function test(\App\Core\A&B $ab) {}
+        }
+    "#};
+
+    let settings = Settings {
+        perimeter: PerimeterSettings {
+            rules: vec![PerimeterRule {
+                namespace: NamespacePath::Specific("App\\Module\\".to_string()),
+                permit: vec![PermittedDependency::Dependency(Path::Selector(SymbolSelector::Namespace(
+                    NamespacePath::Specific("App\\Domain\\".to_string()),
+                )))],
+            }],
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let result = test_guard("intersection_type_violation", code, settings);
+    assert_eq!(result.boundary_breaches.len(), 1, "Expected 1 violation for Core\\A");
+    assert_eq!(result.boundary_breaches[0].dependency_fqn, "App\\Core\\A");
+}
+
+#[test]
+pub fn test_multiple_allowed_types_rule() {
+    let code = indoc! {r#"
+        <?php
+
+        namespace App\Vendor {
+            class MyClass {}
+            interface MyInterface {}
+            trait MyTrait {}
+        }
+
+        namespace App\Module {
+            use App\Vendor\MyClass;
+            use App\Vendor\MyInterface;
+
+            class Test implements MyInterface {
+                public function create(): MyClass {
+                    \App\Vendor\some_function(...);
+
+                    return new MyClass();
+                }
+            }
+        }
+    "#};
+
+    let settings = Settings {
+        perimeter: PerimeterSettings {
+            rules: vec![PerimeterRule {
+                namespace: NamespacePath::Specific("App\\Module\\".to_string()),
+                permit: vec![PermittedDependency::DependencyOfKind {
+                    path: Path::Selector(SymbolSelector::Pattern("App\\Vendor\\**".to_string())),
+                    kinds: vec![PermittedDependencyKind::ClassLike],
+                }],
+            }],
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let result = test_guard("multiple_allowed_types_rule", code, settings);
+    assert_eq!(result.boundary_breaches.len(), 1, "Expected 1 violation for some_function");
+    assert_eq!(result.boundary_breaches[0].dependency_fqn, "App\\Vendor\\some_function");
+    assert_eq!(result.boundary_breaches[0].dependency_kind, PermittedDependencyKind::Function);
+}
+
+#[test]
+pub fn test_global_namespace_dependency_violation() {
+    let code = indoc! {r#"
+        <?php
+
+        namespace { class GlobalClass {} }
+
+        namespace App\Module {
+            function test(\GlobalClass $g) {}
+        }
+    "#};
+
+    let settings = Settings {
+        perimeter: PerimeterSettings {
+            rules: vec![PerimeterRule {
+                namespace: NamespacePath::Specific("App\\Module\\".to_string()),
+                permit: vec![],
+            }],
+            ..Default::default()
+        },
+
+        ..Default::default()
+    };
+    let result = test_guard("global_namespace_dependency_violation", code, settings);
+    assert_eq!(result.boundary_breaches.len(), 1);
+    assert_eq!(result.boundary_breaches[0].dependency_fqn, "GlobalClass");
+}
+
+#[test]
+pub fn test_ddd() {
+    let code = indoc! {r#"
+        <?php
+
+        namespace Symfony\Component\HttpFoundation {
+            class Request {}
+            class Response {}
+        }
+
+        namespace CarthageSoftware\Domain\Shared\Repository {
+            interface RepositoryInterface {
+                public function getOne(int $id): ?object;
+            }
+        }
+
+        namespace CarthageSoftware\Domain\Blogging\Entity {
+            class Post {}
+        }
+
+        namespace CarthageSoftware\Domain\Blogging\Repository {
+            use CarthageSoftware\Domain\Blogging\Entity\Post;
+            use CarthageSoftware\Domain\Shared\Repository\RepositoryInterface;
+
+            interface PostRepositoryInterface extends RepositoryInterface {
+                public function getOne(int $id): ?Post;
+            }
+        }
+
+        namespace CarthageSoftware\Application\Blogging\Command {
+            class CreatePostCommand {}
+        }
+
+        namespace CarthageSoftware\Application\Shared\Command {
+            interface CommandBusInterface {
+                public function dispatch(object $command): void;
+            }
+        }
+
+        namespace CarthageSoftware\UI\Blogging\Web\Controller {
+            use CarthageSoftware\Application\Blogging\Command\CreatePostCommand;
+            use CarthageSoftware\Application\Shared\Command\CommandBusInterface;
+            use CarthageSoftware\Domain\Blogging\Repository\PostRepositoryInterface;
+            use CarthageSoftware\Domain\Blogging\Entity\Post;
+            use Symfony\Component\HttpFoundation\Request;
+            use Symfony\Component\HttpFoundation\Response;
+
+            class PostController {
+                public function __construct(private CommandBusInterface $commandBus) {}
+
+                public function create(Request $request): Response {
+                    $command = new CreatePostCommand();
+                    $this->commandBus->dispatch($command);
+
+                    return new Response();
+                }
+            }
+
+            class ShowController {
+                public function __construct(private PostRepositoryInterface $postRepository) {}
+
+                public function show(int $id): ?Post {
+                    return $this->postRepository->getOne($id);
+                }
+            }
+        }
+    "#};
+
+    let settings = Settings {
+        perimeter: PerimeterSettings {
+            layering: vec![
+                NamespacePath::Specific("CarthageSoftware\\Domain\\".to_string()),
+                NamespacePath::Specific("CarthageSoftware\\Application\\".to_string()),
+                NamespacePath::Specific("CarthageSoftware\\UI\\".to_string()),
+                NamespacePath::Specific("CarthageSoftware\\Infrastructure\\".to_string()),
+            ],
+            rules: vec![
+                PerimeterRule {
+                    namespace: NamespacePath::Specific("CarthageSoftware\\UI\\".to_string()),
+                    permit: vec![
+                        PermittedDependency::Dependency(Path::Native),
+                        PermittedDependency::Dependency(Path::Selector(SymbolSelector::Namespace(
+                            NamespacePath::Specific("CarthageSoftware\\Domain\\".to_string()),
+                        ))),
+                        PermittedDependency::Dependency(Path::Selector(SymbolSelector::Namespace(
+                            NamespacePath::Specific("CarthageSoftware\\Application\\".to_string()),
+                        ))),
+                        PermittedDependency::Dependency(Path::Selector(SymbolSelector::Namespace(
+                            NamespacePath::Specific("Symfony\\Component\\HttpFoundation\\".to_string()),
+                        ))),
+                    ],
+                },
+                PerimeterRule {
+                    namespace: NamespacePath::Specific("CarthageSoftware\\Application\\".to_string()),
+                    permit: vec![
+                        PermittedDependency::Dependency(Path::Selector(SymbolSelector::Namespace(
+                            NamespacePath::Specific("CarthageSoftware\\Domain\\".to_string()),
+                        ))),
+                        PermittedDependency::Dependency(Path::Native),
+                    ],
+                },
+                PerimeterRule {
+                    namespace: NamespacePath::Specific("CarthageSoftware\\Domain\\".to_string()),
+                    permit: vec![
+                        PermittedDependency::Dependency(Path::Self_),
+                        PermittedDependency::Dependency(Path::Native),
+                    ],
+                },
+                PerimeterRule {
+                    namespace: NamespacePath::Specific("CarthageSoftware\\Domain\\".to_string()),
+                    permit: vec![PermittedDependency::Dependency(Path::Native)],
+                },
+            ],
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let result = test_guard("test_ddd", code, settings);
+
+    assert_eq!(result.boundary_breaches.len(), 0, "Expected no violations, found: {:#?}", result.boundary_breaches);
+}

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -159,6 +159,22 @@ export default defineConfig({
             ],
           },
           {
+            text: "Architectural Guard",
+            collapsed: true,
+            items: [
+              { text: "Overview", link: "/tools/guard/overview" },
+              { text: "Usage", link: "/tools/guard/usage" },
+              {
+                text: "Configuration reference",
+                link: "/tools/guard/configuration-reference",
+              },
+              {
+                text: "Command reference",
+                link: "/tools/guard/command-reference",
+              },
+            ],
+          },
+          {
             text: "Lexer & parser",
             collapsed: true,
             items: [

--- a/docs/fundamentals/command-line-interface.md
+++ b/docs/fundamentals/command-line-interface.md
@@ -45,6 +45,7 @@ Mago is organized into several tools and utility commands, each accessed via a s
 | [`mago analyze`](/tools/analyzer/command-reference.md) | Analyzes PHP code for type-safety and other issues.        |
 | [`mago ast`](/tools/lexer-parser/command-reference.md) | Inspects the Abstract Syntax Tree of a PHP file.           |
 | [`mago format`](/tools/formatter/command-reference.md) | Formats PHP code.                                          |
+| [`mago guard`](/tools/guard/command-reference.md)      | Enforces architectural rules and boundaries.               |
 | [`mago lint`](/tools/linter/command-reference.md)      | Lints PHP code for style, correctness, and best practices. |
 
 ### Utility Commands

--- a/docs/fundamentals/suppressing-issues.md
+++ b/docs/fundamentals/suppressing-issues.md
@@ -6,10 +6,11 @@ Both pragmas require you to specify the exact issue you intend to suppress, usin
 
 ## Categories
 
-There are two issue categories available:
+There are three issue categories available:
 
-- `lint` ( alias: `linter` ): For issues reported by the linter.
-- `analysis` ( alias: `analyzer`, `analyser`): For issues reported by the static analyzer.
+- `lint` (alias: `linter`): For issues reported by the linter.
+- `analysis` (alias: `analyzer`, `analyser`): For issues reported by the static analyzer.
+- `guard`: For issues reported by the architectural guard.
 
 ## Asserting an Issue (`@mago-expect`)
 
@@ -87,7 +88,11 @@ function foo(): string {
 Here are some practical examples of using pragma suppressions:
 
 ```php
-// Suppress a single issue
+// Suppress a guard issue
+// @mago-expect guard:disallowed-use
+use App\Infrastructure\SomeForbiddenClass;
+
+// Suppress a single lint issue
 // @mago-expect lint:no-shorthand-ternary
 $result = $condition ?: 'default';
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -53,6 +53,7 @@ For details on configuring the linter, formatter, and analyzer, see their respec
 - [Linter Configuration](/tools/linter/configuration-reference.md)
 - [Formatter Configuration](/tools/formatter/configuration-reference.md)
 - [Analyzer Configuration](/tools/analyzer/configuration-reference.md)
+- [Guard Configuration](/tools/guard/configuration-reference.md)
 
 ## The `config` Command
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -8,9 +8,10 @@ Welcome to **Mago**! You're about to experience a new level of speed and precisi
 
 **Mago** is a complete toolchain for PHP, written in Rust, designed from the ground up for maximum performance. It includes:
 
-- A blazing-fast [formatter](/tools/formatter/overview.md) that automatically formats your code according to PSR-12, ending style debates forever.
+- A blazing-fast [formatter](/tools/formatter/overview.md) that automatically formats your code according to PER-CS, ending style debates forever.
 - An intelligent [linter](/tools/linter/overview.md) that catches stylistic issues, inconsistencies, and code smells before they become problems.
 - A powerful static [analyzer](/tools/analyzer/overview.md) that finds type errors and logical bugs in your code without you ever having to run it.
+- A robust [architectural guard](/tools/guard/overview.md) that enforces dependency rules and structural conventions.
 
 This guide will walk you through installing Mago and setting it up for your project in just a few minutes.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ features:
     details: Mago is engineered from the ground up for maximum performance, leveraging Rust and a parallel pipeline to analyze and format code faster than any other tool.
   - icon: 🛠️
     title: All-in-one solution
-    details: Get a powerful static analyzer, a configurable linter with auto-fixing, and an opinionated code formatter in a single, cohesive binary.
+    details: Get a powerful static analyzer, a configurable linter, an architectural guard, and an opinionated code formatter in a single, cohesive binary.
   - icon: 🎨
     title: Smart & opinionated
     details: With a focus on correctness and modern PHP standards, Mago provides intelligent feedback and consistent formatting to eliminate style debates and prevent bugs.

--- a/docs/tools/guard/command-reference.md
+++ b/docs/tools/guard/command-reference.md
@@ -1,0 +1,42 @@
+---
+title: Guard Command Reference
+outline: deep
+---
+
+# Command Reference
+
+The `mago guard` command is the entry point for running Mago's architectural guard.
+
+:::tip
+For global options that can be used with any command, see the [Command-Line Interface overview](/fundamentals/command-line-interface.md). Remember to specify global options **before** the `guard` command.
+:::
+
+```sh
+Usage: mago guard [OPTIONS] [PATHS]...
+```
+
+## Arguments
+
+### `[PATHS]...`
+
+Optional. A list of specific files or directories to analyze. If you provide paths here, they will be used instead of the `paths` defined in your `mago.toml` configuration.
+
+## Options
+
+The `guard` command currently does not have any specific flags of its own, but it shares the common set of options for reporting issues.
+
+### Shared Reporting Options
+
+The `guard` command uses a shared set of options for reporting the issues it finds.
+
+[**See the Shared Reporting and Fixing Options documentation.**](/fundamentals/shared-reporting-options.md)
+
+:::info
+Auto-fixing and baseline features are not applicable to the `guard` command.
+:::
+
+### Help
+
+| Flag, Alias(es) | Description                             |
+| :-------------- | :-------------------------------------- |
+| `--help`, `-h`  | Print the help summary for the command. |

--- a/docs/tools/guard/configuration-reference.md
+++ b/docs/tools/guard/configuration-reference.md
@@ -1,0 +1,180 @@
+---
+title: Guard Configuration Reference
+outline: deep
+---
+
+# Configuration Reference
+
+`mago guard` is configured under the `[guard]` table in your `mago.toml` file. The configuration is split into two main parts: `[guard.perimeter]` for dependency rules and `[[guard.structural.rules]]` for code convention rules.
+
+## Top-Level `[guard]` Table
+
+This is the main table for the guard tool.
+
+| Option     | Type       | Default | Description                                                |
+| :--------- | :--------- | :------ | :--------------------------------------------------------- |
+| `excludes` | `string[]` | `[]`    | A list of paths or glob patterns to exclude from analysis. |
+
+## Perimeter Guard: `[guard.perimeter]`
+
+This section defines the rules for dependency validation between different parts of your application.
+
+```toml
+[guard.perimeter]
+# Defines the architectural layers from core to infrastructure.
+layering = [
+    "CarthageSoftware\\Domain",
+    "CarthageSoftware\\Application",
+    "CarthageSoftware\\UI",
+    "CarthageSoftware\\Infrastructure"
+]
+
+# Creates reusable aliases for groups of namespaces.
+[guard.perimeter.layers]
+core = ["@native", "Psl\\**"]
+psr = ["Psr\\**"]
+framework = ["Symfony\\**", "Doctrine\\**"]
+
+# Defines dependency rules for specific namespaces.
+[[guard.perimeter.rules]]
+namespace = "CarthageSoftware\\Domain"
+permit = ["@layer:core"]
+
+[[guard.perimeter.rules]]
+namespace = "CarthageSoftware\\Application"
+permit = ["@layer:core", "@layer:psr"]
+
+[[guard.perimeter.rules]]
+namespace = "CarthageSoftware\\Infrastructure"
+permit = ["@layer:core", "@layer:psr", "@layer:framework"]
+
+[[guard.perimeter.rules]]
+namespace = "CarthageSoftware\\Tests"
+permit = ["@all"]
+```
+
+### `layering`
+
+An array of namespaces defining the architectural layers of your application, from the most independent (core) to the outermost layers. This enforces a top-down dependency flow, meaning a layer can only depend on layers defined *before* it in this list. If a dependency points to a layer defined *after* its own, a violation is reported.
+
+### `[guard.perimeter.layers]`
+
+This table allows you to create reusable aliases for groups of namespaces or other paths. These aliases can then be referenced in your permission rules using the `@layer:<name>` syntax.
+
+### `[[guard.perimeter.rules]]`
+
+This is an array of tables where each table defines a dependency rule for a specific part of your codebase.
+
+*   `namespace`: The namespace this rule applies to. This can be a full namespace ending in `\` or the special keyword `@global` for the global namespace.
+*   `permit`: A list of permitted dependencies for the `namespace`. This can be a simple string or a detailed object.
+
+#### `permit` Values
+
+The `permit` array accepts a list of "paths". A path can be a special keyword, a namespace, a symbol, or a glob pattern.
+
+| Path Syntax        | Description                                                                                                                                                           |
+| :----------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@global`          | Allows dependencies on symbols defined in the global namespace.                                                                                                       |
+| `@all`             | Allows dependencies on any symbol in the entire codebase, including vendor packages. Useful for tests.                                                                |
+| `@self` / `@this`  | Allows dependencies on any symbol within the same root namespace as the rule's `namespace`.                                                                             |
+| `@native` / `@php` | Allows dependencies on PHP's native (built-in) functions, classes, and constants.                                                                                       |
+| `@layer:<name>`    | Allows dependencies on all namespaces and paths defined in the specified layer alias from `[guard.perimeter.layers]`.                                                   |
+| `App\Shared\\**`   | A glob pattern. `*` matches any part of a namespace segment, and `**` matches zero or more segments. Allows dependencies on any symbol matching the pattern.             |
+| `App\Service`      | An exact, fully-qualified symbol name. Allows a dependency on this specific class, interface, trait, function, or constant.                                            |
+| `App\Service\\`    | An exact namespace. Allows dependencies on any symbol directly within this namespace.                                                                                   |
+
+You can also specify permissions in more detail using an object:
+
+```toml
+[[guard.perimeter.rules]]
+namespace = "DoctrineMigrations\\"
+# Allow depending on any class-like symbol, but not functions or constants.
+permit = [ { path = "@all", kinds = ["class-like"] } ]
+```
+
+*   `path`: Any of the valid path strings described above.
+*   `kinds`: An array specifying which *kinds* of symbols are permitted from that path.
+    *   `class-like`: Includes classes, interfaces, traits, and enums.
+    *   `function`
+    *   `constant`
+    *   `attribute`
+
+## Structural Guard: `[[guard.structural.rules]]`
+
+This section is for enforcing coding conventions and structural rules. Each table in this array defines a rule that applies to symbols matching a set of selectors.
+
+```toml
+[[guard.structural.rules]]
+on               = "CarthageSoftware\\UI\\**\\Controller\\**"
+target           = "class"
+must-be-named    = "*Controller"
+must-be-final    = true
+must-be-readonly = true
+reason           = "Controllers must be final and follow naming conventions."
+
+[[guard.structural.rules]]
+on            = "CarthageSoftware\\Domain\\**\\Repository\\**"
+target        = "interface"
+must-be-named = "*RepositoryInterface"
+reason        = "Domain repository interfaces must follow a standard naming convention."
+
+[[guard.structural.rules]]
+on            = "CarthageSoftware\\Infrastructure\\**\\Repository\\**"
+target        = "class"
+must-be-final = true
+must-extend   = "CarthageSoftware\\Infrastructure\\Shared\\Repository\\AbstractRepository"
+reason        = "Infrastructure repositories must extend our abstract class."
+
+[[guard.structural.rules]]
+on          = "CarthageSoftware\\Domain\\**\\Enum\\**"
+must-be     = ["enum"]
+reason      = "This namespace is designated for enums only."
+```
+
+### Selector Keys
+
+These keys determine which symbols a rule applies to.
+
+| Key      | Description                                                                                                                            |
+| :------- | :------------------------------------------------------------------------------------------------------------------------------------- |
+| `on`     | **Required.** A glob pattern matching the fully-qualified name of the symbols to target.                                                |
+| `not-on` | An optional glob pattern to exclude symbols that would otherwise be matched by `on`.                                                     |
+| `target` | An optional filter to apply the rule only to a specific kind of symbol. <br/>**Values:** `class`, `interface`, `trait`, `enum`, `function`, `constant`. |
+
+### Constraint Keys
+
+These keys define the architectural constraints to enforce on the selected symbols.
+
+| Key                 | Description                                                                                                                            |
+| :------------------ | :------------------------------------------------------------------------------------------------------------------------------------- |
+| `must-be`             | Restricts the `on` namespace to contain *only* the specified symbol kinds. <br/>**Values:** `class`, `interface`, `trait`, `enum`, `function`, `constant`. |
+| `must-be-named`       | Enforces a naming convention using a glob pattern (e.g., `*Controller`).                                                               |
+| `must-be-final`       | A boolean. If `true`, the symbol must be `final`. If `false`, it must *not* be `final`.                                                 |
+| `must-be-abstract`    | A boolean. If `true`, the symbol must be `abstract`. If `false`, it must *not* be `abstract`.                                           |
+| `must-be-readonly`    | A boolean. If `true`, the symbol must be `readonly`. If `false`, it must *not* be `readonly`.                                           |
+| `must-implement`      | Enforces that a class must implement one or more interfaces.                                                                           |
+| `must-extend`         | Enforces that a class must extend a specific parent class.                                                                             |
+| `must-use-trait`      | Enforces that a class or trait must use one or more traits.                                                                            |
+| `must-use-attribute`  | Enforces that a symbol must have one or more attributes.                                                                               |
+| `reason`              | An optional human-readable string explaining why the rule exists. This will be displayed in the error message.                         |
+
+#### Inheritance Constraints (`must-implement`, `must-extend`, etc.)
+
+These constraints can be a single string, an array of strings (for an `AND` condition), or an array of arrays of strings (for an `OR` of `AND`s).
+
+```toml
+# Must extend a single class
+must-extend = "App\\BaseClass"
+
+# Must implement ALL of these interfaces
+must-implement = ["App\\InterfaceA", "App\\InterfaceB"]
+
+# Must extend (AbstractA AND AbstractB) OR (AbstractC)
+must-extend = [
+    ["App\AbstractA", "App\\AbstractB"],
+    ["App\AbstractC"],
+]
+
+# Must not implement any interface
+must-implement = "@nothing"
+```

--- a/docs/tools/guard/overview.md
+++ b/docs/tools/guard/overview.md
@@ -1,0 +1,38 @@
+--- 
+title: Architectural Guard
+outline: deep
+---
+
+# Architectural Guard 🛡️
+
+`mago guard` is a powerful architectural validation utility for enforcing boundaries and coding standards within a PHP project. It acts as a high-performance, single-binary replacement for tools like **deptrac** (for dependency validation) and **arkitect** (for structural rule enforcement).
+
+Think of it as a two-part fortress for your codebase: the **Perimeter Guard** and the **Structural Guard**.
+
+### Perimeter Guard: Defending Your Boundaries
+
+The Perimeter Guard is responsible for **dependency validation**. It ensures that different parts of your application only communicate in ways you've explicitly allowed. Its primary goal is to protect your architectural layers and prevent invalid dependencies from crossing into your core domain logic.
+
+For example, you can enforce rules like:
+-   Your `Domain` layer must not depend on any other layer.
+-   Your `UI` layer can depend on the `Application` layer, but not the other way around.
+-   A specific module is only allowed to use certain approved libraries.
+
+This is crucial for maintaining a clean, decoupled architecture that is easy to maintain and scale.
+
+### Structural Guard: Enforcing Internal Order
+
+The Structural Guard is responsible for **enforcing coding conventions** on the symbols themselves. It inspects the internal structure of your code to ensure it follows a consistent and predictable pattern.
+
+For example, you can enforce rules like:
+-   All classes in the `App\Http\Controllers` namespace must be `final` and have names ending in `Controller`.
+-   Interfaces in the `Domain` must be named with an `Interface` suffix.
+-   A specific namespace may only contain `enum` definitions.
+
+This helps maintain a high level of code quality and consistency across the entire project.
+
+## Dive In
+
+- **[Configuration Reference](./configuration-reference.md)**: A detailed guide to all `guard` settings in `mago.toml`.
+- **[Command Reference](./command-reference.md)**: Learn how to run the guard from the command line.
+

--- a/docs/tools/guard/usage.md
+++ b/docs/tools/guard/usage.md
@@ -1,0 +1,110 @@
+---
+title: Guard Usage
+outline: deep
+---
+
+# Using the Guard
+
+The `mago guard` command is your entry point for running all architectural validation checks.
+
+## Running the Guard
+
+To check your entire project against the rules defined in your `mago.toml` file, simply run:
+
+```sh
+mago guard
+```
+
+Mago will scan your codebase and report any violations it finds.
+
+### Analyzing Specific Paths
+
+You can also run the guard on specific files or directories by passing them as arguments. This is useful for focusing on a particular module or for pre-commit hooks.
+
+```sh
+# Analyze only the src/Domain directory
+mago guard src/Domain
+
+# Analyze a specific file
+mago guard src/UI/Controller/UserController.php
+```
+
+## Understanding the Output
+
+The guard produces two types of error reports: **Boundary Breaches** (from the Perimeter Guard) and **Structural Flaws** (from the Structural Guard).
+
+### Example: Boundary Breach
+
+If a part of your code violates a dependency rule, you'll get a "Boundary Breach" error.
+
+Consider this rule in `mago.toml`:
+```toml
+[[guard.perimeter.rules]]
+namespace = "App\\Domain\\"
+permit = ["@self", "@native"]
+```
+This rule states that the `App\Domain` namespace can only depend on itself and native PHP symbols.
+
+Now, if you have the following code:
+```php
+// src/Domain/Model/User.php
+namespace App\Domain\Model;
+
+use App\Infrastructure\Doctrine\Orm\Entity; // <-- Violation!
+
+class User extends Entity {}
+```
+
+Running `mago guard` would produce an error like this:
+
+```
+error[disallowed-use]: Illegal dependency on `App\Infrastructure\Doctrine\Orm\Entity`
+  ┌─ src/Domain/Model/User.php:4:5
+  │
+4 │ use App\Infrastructure\Doctrine\Orm\Entity;
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This `use` statement is not allowed by the architectural rules
+  │
+  = Breach occurred in namespace `App\Domain\Model`.
+  = Dependency forbidden by architectural rules
+  = The following rule(s) were evaluated but none permitted this dependency: `App\Domain\\`.
+  = Help: Update your guard configuration to allow this dependency or refactor the code to remove it.
+```
+
+The error clearly shows the forbidden dependency, where it occurred, and which rule was violated.
+
+### Example: Structural Flaw
+
+If a symbol doesn't adhere to a structural rule, you'll get a "Structural Flaw" error.
+
+Consider this rule:
+```toml
+[[guard.structural.rules]]
+on            = "App\\UI\\**\\Controller\\**"
+target        = "class"
+must-be-final = true
+reason        = "Controllers should be final to prevent extension."
+```
+
+And this code:
+```php
+// src/UI/Controller/UserController.php
+namespace App\UI\Controller;
+
+class UserController // <-- Violation! Not final.
+{
+    // ...
+}
+```
+
+Running `mago guard` would report:
+
+```
+error[must-be-final]: Structural flaw in `App\UI\Controller\UserController`
+   ┌─ src/UI/Controller/UserController.php:3:7
+   │
+ 3 │ class UserController
+   │       ^^^^^^^^^^^^^^ This must be declared as `final`
+   │
+   = Controllers should be final to prevent extension.
+   = Help: Declare this class as `final`.
+```The report identifies the symbol, the location, the exact flaw, and the reason provided in the configuration.

--- a/docs/tools/overview.md
+++ b/docs/tools/overview.md
@@ -21,6 +21,10 @@ The **linter** is a blazing-fast tool for finding stylistic issues, inconsistenc
 
 The **analyzer** is a powerful static analysis engine that finds logical errors, type mismatches, and potential bugs in your code _before_ you run it. It's the core of Mago's ability to ensure your code is correct and robust.
 
+### [Architectural Guard](/tools/guard/overview.md)
+
+The **architectural guard** is a powerful architectural validation utility for enforcing boundaries and coding standards within a PHP project.
+
 ### [Lexer & parser](/tools/lexer-parser/overview.md)
 
 At the heart of Mago lies its high-performance Lexer and Parser. These components turn your raw PHP source code into a structured Abstract Syntax Tree (AST). The `mago ast` command provides a powerful way to inspect this structure for debugging and learning.

--- a/src/commands/analyze.rs
+++ b/src/commands/analyze.rs
@@ -11,6 +11,7 @@ use mago_prelude::Prelude;
 use crate::commands::args::baseline::BaselineArgs;
 use crate::commands::args::reporting::ReportingArgs;
 use crate::config::Configuration;
+use crate::consts::PRELUDE_BYTES;
 use crate::database;
 use crate::error::Error;
 use crate::pipeline::analysis::run_analysis_pipeline;
@@ -81,8 +82,6 @@ impl AnalyzeCommand {
         let (base_db, codebase_metadata, symbol_references) = if self.no_stubs {
             (Default::default(), Default::default(), Default::default())
         } else {
-            const PRELUDE_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/prelude.bin"));
-
             let prelude = Prelude::decode(PRELUDE_BYTES).expect("Failed to decode embedded prelude");
 
             (prelude.database, prelude.metadata, prelude.symbol_references)

--- a/src/commands/guard.rs
+++ b/src/commands/guard.rs
@@ -1,0 +1,119 @@
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::ColorChoice;
+use clap::Parser;
+
+use mago_database::DatabaseReader;
+use mago_database::file::FileType;
+use mago_prelude::Prelude;
+
+use crate::commands::args::baseline::BaselineArgs;
+use crate::commands::args::reporting::ReportingArgs;
+use crate::config::Configuration;
+use crate::consts::PRELUDE_BYTES;
+use crate::database;
+use crate::error::Error;
+use crate::pipeline::guard::run_guard_pipeline;
+
+/// Check architectural boundaries using guard rules.
+///
+/// The `guard` command performs architectural boundary checking on your PHP codebase.
+/// It analyzes symbol dependencies and ensures they comply with the architectural rules
+/// defined in your configuration.
+///
+/// Guard helps enforce:
+///
+/// • Layer boundaries between different parts of your application
+/// • Dependency direction rules (e.g., domain should not depend on infrastructure)
+/// • Allowed symbol types for specific dependencies
+/// • Namespace isolation and architectural constraints
+///
+/// You can define rules in your `mago.toml` file to specify which namespaces can
+/// depend on others and what types of symbols are allowed.
+#[derive(Parser, Debug)]
+#[command(name = "guard")]
+pub struct GuardCommand {
+    /// Specific files or directories to check instead of using configuration.
+    ///
+    /// When provided, these paths override the source configuration in mago.toml.
+    /// The guard will focus only on the specified files or directories.
+    ///
+    /// This is useful for targeted checking, testing changes, or integrating
+    /// with development workflows and CI systems.
+    #[arg()]
+    pub paths: Vec<PathBuf>,
+
+    /// Disable built-in PHP and library stubs for checking.
+    ///
+    /// By default, guard uses stubs for built-in PHP functions and popular
+    /// libraries to provide accurate symbol information. Disabling this may result
+    /// in more warnings when external symbols can't be resolved.
+    #[arg(long, default_value_t = false)]
+    pub no_stubs: bool,
+
+    /// Arguments related to reporting issues.
+    #[clap(flatten)]
+    pub reporting: ReportingArgs,
+
+    /// Arguments related to baseline functionality.
+    #[clap(flatten)]
+    pub baseline: BaselineArgs,
+}
+
+impl GuardCommand {
+    /// Executes the guard command.
+    ///
+    /// This function orchestrates the process of:
+    ///
+    /// 1. Loading source files.
+    /// 2. Compiling a codebase model from these files (with progress).
+    /// 3. Checking architectural boundaries against guard rules (with progress).
+    /// 4. Reporting any found violations.
+    pub fn execute(self, mut configuration: Configuration, color_choice: ColorChoice) -> Result<ExitCode, Error> {
+        if self.reporting.fix {
+            tracing::warn!("Fix mode is not yet implemented for guard. Running in check-only mode.");
+        }
+
+        configuration.source.excludes.extend(std::mem::take(&mut configuration.guard.excludes));
+
+        let (base_db, codebase_metadata, _) = {
+            let prelude = Prelude::decode(PRELUDE_BYTES).expect("Failed to decode embedded prelude");
+
+            (prelude.database, prelude.metadata, prelude.symbol_references)
+        };
+
+        let final_database = if !self.paths.is_empty() {
+            database::load_from_paths(&mut configuration.source, self.paths, Some(base_db))?
+        } else {
+            database::load_from_configuration(&mut configuration.source, false, Some(base_db))?
+        };
+
+        if !final_database.files().any(|f| f.file_type == FileType::Host) {
+            tracing::warn!("No files found to check with guard.");
+
+            return Ok(ExitCode::SUCCESS);
+        }
+
+        let guard_settings = configuration.guard.settings.clone();
+        let issues = run_guard_pipeline(final_database.read_only(), codebase_metadata, guard_settings)?;
+
+        let config_baseline = configuration.guard.baseline.clone();
+        let read_database = final_database.read_only();
+
+        let (filtered_issues, should_fail_from_baseline, early_exit) =
+            self.baseline.process_baseline(issues, config_baseline.as_deref(), &read_database)?;
+
+        if let Some(exit_code) = early_exit {
+            return Ok(exit_code);
+        }
+
+        self.reporting.process_issues_with_baseline_result(
+            filtered_issues,
+            configuration,
+            color_choice,
+            final_database,
+            should_fail_from_baseline,
+        )
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -13,6 +13,7 @@ use crate::commands::analyze::AnalyzeCommand;
 use crate::commands::ast::AstCommand;
 use crate::commands::config::ConfigCommand;
 use crate::commands::format::FormatCommand;
+use crate::commands::guard::GuardCommand;
 use crate::commands::init::InitCommand;
 use crate::commands::lint::LintCommand;
 use crate::commands::self_update::SelfUpdateCommand;
@@ -24,6 +25,7 @@ pub mod analyze;
 pub mod ast;
 pub mod config;
 pub mod format;
+pub mod guard;
 pub mod init;
 pub mod lint;
 pub mod self_update;
@@ -56,6 +58,9 @@ pub enum MagoCommand {
     /// Analyze PHP code using Mago's analyzer.
     #[command(name = "analyze")]
     Analyze(AnalyzeCommand),
+    /// Check architectural boundaries using guard rules.
+    #[command(name = "guard")]
+    Guard(GuardCommand),
     /// Format PHP code using Mago's formatter.
     #[command(name = "format")]
     Format(FormatCommand),

--- a/src/config/guard.rs
+++ b/src/config/guard.rs
@@ -1,0 +1,20 @@
+use std::path::PathBuf;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use mago_guard::settings::Settings;
+
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct GuardConfiguration {
+    /// A list of patterns to exclude from guard checking.
+    pub excludes: Vec<String>,
+
+    /// Path to a baseline file to ignore listed issues.
+    pub baseline: Option<PathBuf>,
+
+    /// Guard settings including rules, layers, and layering.
+    #[serde(flatten)]
+    pub settings: Settings,
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,6 +16,7 @@ use mago_php_version::PHPVersion;
 
 use crate::config::analyzer::AnalyzerConfiguration;
 use crate::config::formatter::FormatterConfiguration;
+use crate::config::guard::GuardConfiguration;
 use crate::config::linter::LinterConfiguration;
 use crate::config::source::SourceConfiguration;
 use crate::consts::*;
@@ -23,6 +24,7 @@ use crate::error::Error;
 
 pub mod analyzer;
 pub mod formatter;
+pub mod guard;
 pub mod linter;
 pub mod source;
 
@@ -64,6 +66,10 @@ pub struct Configuration {
     /// Configuration options for the analyzer.
     #[serde(default)]
     pub analyzer: AnalyzerConfiguration,
+
+    /// Configuration options for the guard.
+    #[serde(default)]
+    pub guard: GuardConfiguration,
 
     /// The log filter.
     ///
@@ -194,6 +200,7 @@ impl Configuration {
             linter: LinterConfiguration::default(),
             formatter: FormatterConfiguration::default(),
             analyzer: AnalyzerConfiguration::default(),
+            guard: GuardConfiguration::default(),
             log: Value::new(None, ValueKind::Nil),
         }
     }

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -74,3 +74,5 @@ pub static CURRENT_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
         std::process::exit(1);
     })
 });
+
+pub const PRELUDE_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/prelude.bin"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,7 @@ pub fn run() -> Result<ExitCode, Error> {
         MagoCommand::Format(cmd) => cmd.execute(configuration, color_choice),
         MagoCommand::Ast(cmd) => cmd.execute(configuration, color_choice),
         MagoCommand::Analyze(cmd) => cmd.execute(configuration, color_choice),
+        MagoCommand::Guard(cmd) => cmd.execute(configuration, color_choice),
         MagoCommand::SelfUpdate(_) => {
             unreachable!("The self-update command should have been handled before this point.")
         }

--- a/src/pipeline/guard.rs
+++ b/src/pipeline/guard.rs
@@ -1,0 +1,87 @@
+use mago_codex::metadata::CodebaseMetadata;
+use mago_database::ReadDatabase;
+use mago_guard::ArchitecturalGuard;
+use mago_guard::settings::Settings;
+use mago_names::resolver::NameResolver;
+use mago_reporting::Issue;
+use mago_reporting::IssueCollection;
+use mago_syntax::parser::parse_file;
+
+use crate::error::Error;
+use crate::pipeline::StatelessParallelPipeline;
+use crate::pipeline::StatelessReducer;
+
+/// The "reduce" step for the guard pipeline.
+///
+/// This struct aggregates the `IssueCollection` from each parallel task into a single,
+/// final `IssueCollection` for the entire project.
+#[derive(Debug, Clone)]
+struct GuardResultReducer;
+
+impl StatelessReducer<IssueCollection, IssueCollection> for GuardResultReducer {
+    fn reduce(&self, results: Vec<IssueCollection>) -> Result<IssueCollection, Error> {
+        let mut aggregated_issues = IssueCollection::new();
+
+        for result in results {
+            aggregated_issues.extend(result);
+        }
+
+        Ok(aggregated_issues)
+    }
+}
+
+/// Runs the parallel guard checking phase on a fully compiled codebase.
+///
+/// This function orchestrates the guard workflow using a [`ParallelPipeline`].
+/// It takes a database containing all source files and the pre-compiled codebase
+/// metadata, then runs architectural boundary checking on each "host" file in parallel.
+///
+/// # Arguments
+///
+/// * `database`: The read-only database containing all files to be checked.
+/// * `codebase`: The pre-compiled `CodebaseMetadata` from the prelude.
+/// * `symbol_references`: The pre-compiled `SymbolReferences` from the prelude.
+/// * `guard_settings`: The configured settings for the guard.
+///
+/// # Returns
+///
+/// A `Result` containing the final, aggregated [`IssueCollection`] for the
+/// entire project, or an [`Error`].
+pub fn run_guard_pipeline(
+    database: ReadDatabase,
+    codebase: CodebaseMetadata,
+    guard_settings: Settings,
+) -> Result<IssueCollection, Error> {
+    const GUARD_PROGRESS_PREFIX: &str = "🛡️  Guarding";
+
+    let pipeline = StatelessParallelPipeline::new(
+        GUARD_PROGRESS_PREFIX,
+        database,
+        (codebase, guard_settings),
+        Box::new(GuardResultReducer),
+        true,
+    );
+
+    pipeline.run(|(codebase, guard_settings), arena, source_file| {
+        let mut issues = IssueCollection::new();
+
+        let (program, parsing_error) = parse_file(arena, &source_file);
+
+        if let Some(parsing_error) = parsing_error {
+            issues.push(Issue::from(&parsing_error));
+
+            return Ok(issues);
+        }
+
+        let resolved_names = NameResolver::new(arena).resolve(program);
+        let guard = ArchitecturalGuard::new(guard_settings);
+        let report = guard.check(&codebase, program, &resolved_names);
+
+        issues.extend(
+            // Report as issues
+            report.report_into_issues(arena, &source_file, program),
+        );
+
+        Ok(issues)
+    })
+}

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -23,6 +23,7 @@ use crate::utils::progress::remove_progress_bar;
 
 pub mod analysis;
 pub mod format;
+pub mod guard;
 pub mod lint;
 
 use std::fmt::Debug;


### PR DESCRIPTION
This PR introduces the new `mago guard` command, a high-performance tool for enforcing architectural rules in PHP projects. It integrates the core functionalities of `deptrac` (for dependency checking) and `arkitect` (for structural validation) into a single, cohesive tool within the `mago` ecosystem.

The primary goal is to provide developers with instant feedback on architectural violations, leveraging a clear, declarative configuration in `mago.toml`.

The design of `mago guard` is built around a "Fortress" metaphor to make the concepts intuitive:

  * 🏰 **The Fortress** is your entire codebase.
  * 🧱 **Perimeter Rules** define the defensive walls and layers. They control which namespaces can communicate, preventing illegal dependencies between layers (e.g., Domain depending on UI). A violation is a **`BoundaryBreach`**.
  * 🏛️ **Structural Rules** define the building codes inside the fortress. They ensure that code within a namespace is built correctly (e.g., all Controllers are final, all Repositories implement an interface). A violation is a **`StructuralFlaw`**.