### PR TITLE
fix(install-script): fixed typo in install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -257,7 +257,7 @@ separator
 
 green "Installing binary to ${binary_dir}..."
 if mv "${destination}/${BIN_NAME}" "${binary_dir}/"; then
-  chmod +x "${binary_dir}/${BIN_NAME}" || bail "Failed to make the binary executable."
+  chmod +x "${binary_dir}/${BIN_NAME}" || fail "Failed to make the binary executable."
   green "Installation complete!"
 
   if ! echo "$PATH" | grep -qE "(^|:)$binary_dir($|:)"; then


### PR DESCRIPTION
## 📌 What Does This PR Do?

Changes bail to fail

## 🔍 Context & Motivation

The install script will fail with a descriptive message instead of failing with a 'Command not found' message.

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed typo in install.sh.

## 📂 Affected Areas

- [x] Other (please specify): Scripts

## 🔗 Related Issues or PRs

None

## 📝 Notes for Reviewers