### PR TITLE
feat(analyzer): add a conditional return type for json_encode()

### DIFF
--- a/crates/analyzer/src/invocation/special_function_like_handler/mod.rs
+++ b/crates/analyzer/src/invocation/special_function_like_handler/mod.rs
@@ -12,6 +12,7 @@ use crate::invocation::special_function_like_handler::psl::type_component::TypeC
 use crate::invocation::special_function_like_handler::random::RandomFunctionsHandler;
 use crate::invocation::special_function_like_handler::spl::iterator::IteratorFunctionsHandler;
 use crate::invocation::special_function_like_handler::standard::array::ArrayFunctionsHandler;
+use crate::invocation::special_function_like_handler::standard::json::JsonFunctionsHandler;
 use crate::invocation::special_function_like_handler::standard::string::StringFunctionsHandler;
 
 mod core;
@@ -45,6 +46,7 @@ pub fn handle_special_functions<'ctx, 'ast, 'arena>(
         // Standard PHP function handlers
         &StringFunctionsHandler,
         &ArrayFunctionsHandler,
+        &JsonFunctionsHandler,
         // SPL function handlers
         &IteratorFunctionsHandler,
         // Random extension function handlers

--- a/crates/analyzer/src/invocation/special_function_like_handler/standard/json.rs
+++ b/crates/analyzer/src/invocation/special_function_like_handler/standard/json.rs
@@ -1,0 +1,58 @@
+use mago_codex::ttype::atomic::TAtomic;
+use mago_codex::ttype::atomic::scalar::TScalar;
+use mago_codex::ttype::atomic::scalar::bool::TBool;
+use mago_codex::ttype::atomic::scalar::string::TString;
+use mago_codex::ttype::union::TUnion;
+
+use crate::artifacts::AnalysisArtifacts;
+use crate::context::Context;
+use crate::context::block::BlockContext;
+use crate::invocation::Invocation;
+use crate::invocation::special_function_like_handler::SpecialFunctionLikeHandlerTrait;
+use crate::invocation::special_function_like_handler::utils::get_argument;
+
+const JSON_THROW_ON_ERROR: i64 = 4194304;
+
+#[derive(Debug)]
+pub struct JsonFunctionsHandler;
+
+impl SpecialFunctionLikeHandlerTrait for JsonFunctionsHandler {
+    fn get_return_type<'ctx, 'ast, 'arena>(
+        &self,
+        _context: &mut Context<'ctx, 'arena>,
+        _block_context: &BlockContext<'ctx>,
+        artifacts: &AnalysisArtifacts,
+        function_like_name: &str,
+        invocation: &Invocation<'ctx, 'ast, 'arena>,
+    ) -> Option<TUnion> {
+        match function_like_name {
+            "json_encode" => {
+                let int_flags = get_argument(invocation.arguments_source, 1, vec!["flags"])?;
+                let int_argument_type = artifacts.get_expression_type(int_flags)?;
+                let int_literal = int_argument_type.get_single_literal_int_value()?;
+
+                Some(if int_literal & JSON_THROW_ON_ERROR > 0 {
+                    TUnion::from_atomic(TAtomic::Scalar(TScalar::String(TString::new(
+                        None,
+                        false,
+                        false,
+                        true,
+                        false,
+                    ))))
+                } else {
+                    TUnion::from_vec(vec![
+                        TAtomic::Scalar(TScalar::String(TString::new(
+                            None,
+                            false,
+                            false,
+                            true,
+                            false,
+                        ))),
+                        TAtomic::Scalar(TScalar::Bool(TBool { value: Some(false) }))
+                    ])
+                })
+            }
+            _ => None,
+        }
+    }
+}

--- a/crates/analyzer/src/invocation/special_function_like_handler/standard/mod.rs
+++ b/crates/analyzer/src/invocation/special_function_like_handler/standard/mod.rs
@@ -1,2 +1,3 @@
 pub mod array;
+pub mod json;
 pub mod string;

--- a/crates/analyzer/tests/cases/issue_425_json_encode.php
+++ b/crates/analyzer/tests/cases/issue_425_json_encode.php
@@ -1,0 +1,9 @@
+<?php
+
+function encode(mixed $input): string|false {
+    return json_encode($input);
+}
+
+function encodeOrThrow(mixed $input): string {
+    return json_encode($input, JSON_THROW_ON_ERROR);
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -225,6 +225,7 @@ test_case!(issue_413);
 test_case!(issue_414);
 test_case!(issue_415);
 test_case!(issue_417);
+test_case!(issue_425_json_encode);
 test_case!(issue_451);
 test_case!(issue_461);
 test_case!(issue_459);


### PR DESCRIPTION
## 📌 What Does This PR Do?

The default return type of PHP's json_encode() is string|false. But when the function receives the flag JSON_THROW_ON_ERROR, then the return type becomes string. So a new handler was created for ext/json, with a special case for the function json_encode().

## 🔍 Context & Motivation

Closes #425

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed incorrect return type of PHP `json_encode(..., JSON_THROW_ON_ERROR)`.

## 📂 Affected Areas

- [x] Analyzer

## 🔗 Related Issues or PRs

#425
