### PR TITLE
feat(install): add support for installing specific version

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ The most common way to install Mago on macOS and Linux is by using our shell scr
 curl --proto '=https' --tlsv1.2 -sSf https://carthage.software/mago.sh | bash
 ```
 
+To install a specific version:
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSf https://carthage.software/mago.sh | bash -s -- --version=1.0.0-beta.34
+```
+
 For all other installation methods, including Homebrew, Composer, and Cargo, please refer to our official **[Installation Guide](https://mago.carthage.software/guide/installation)**.
 
 ## Getting Started

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -23,6 +23,20 @@ curl --proto '=https' --tlsv1.2 -sSf https://carthage.software/mago.sh | bash
 wget -qO- https://carthage.software/mago.sh | bash
 ```
 
+#### Installing a specific version
+
+To install a specific version of Mago, use the `--version=` flag:
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSf https://carthage.software/mago.sh | bash -s -- --version=1.0.0-beta.34
+```
+
+Or with `wget`:
+
+```sh
+wget -qO- https://carthage.software/mago.sh | bash -s -- --version=1.0.0-beta.34
+```
+
 ## Manual download
 
 You can always download a pre-compiled binary directly from our GitHub Releases page. This is the **recommended method for Windows** and a reliable fallback for other systems.


### PR DESCRIPTION
## 📌 What Does This PR Do?

  Add support for installing specific version of Mago using the `--version=` flag in the shell installer script.

  ## 🔍 Context & Motivation

  Previously, the shell installer only supported installing the latest version of Mago. Users who needed to install a specific version had to manually download binaries from GitHub releases. This PR
  addresses that limitation by adding a `--version=` argument to the installer, making it easier to install any specific version of Mago.

  ## 🛠️ Summary of Changes

  - **Feature:** Added `--version=` argument support to `scripts/install.sh` for installing specific Mago versions
  - **Docs:** Updated installation guide in `docs/guide/installation.md` with comprehensive examples of version-specific installation
  - **Docs:** Updated `README.md` with quick example of version-specific installation

  ## 📂 Affected Areas

  - [ ] Linter
  - [ ] Formatter
  - [x] CLI
  - [ ] Composer Plugin
  - [ ] Dependencies
  - [x] Documentation
  - [ ] Other (please specify):

  ## 🔗 Related Issues or PRs

  Fixes #566

  ## 📝 Notes for Reviewers

  - The script maintains full backward compatibility - when no `--version` is specified, it defaults to installing the latest release (existing behavior)
  - Both `--version=` and `--install-dir=` flags can be used together or independently
  - Documentation includes examples for both `curl` and `wget` usage patterns
  - The version string should match the GitHub release tag exactly (e.g., `1.0.0-beta.34`)