### PR TITLE
feat(cli): Add support for generating shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2348487adcd4631696ced64ccdb40d38ac4d31cae7f2eec8817fcea1b9d1c43c"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,6 +1420,7 @@ version = "1.0.0-beta.34"
 dependencies = [
  "bumpalo",
  "clap",
+ "clap_complete",
  "colored",
  "config",
  "dhat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ indicatif = { version = "0.18.0" }
 paste = "1.0.15"
 criterion = "0.7.0"
 clap = { version = "4.5.20", features = ["cargo", "derive", "unicode", "wrap_help"] }
+clap_complete = "4.5.59"
 async-walkdir = "2.0.0"
 termtree = "0.5.1"
 wasm-bindgen = "0.2.97"
@@ -126,6 +127,7 @@ mago-guard = { workspace = true }
 mago-orchestrator = { workspace = true }
 serde = { workspace = true }
 clap = { workspace = true }
+clap_complete = { workspace = true }
 termtree = { workspace = true }
 serde_json = { workspace = true }
 strum = { workspace = true }

--- a/docs/fundamentals/command-line-interface.md
+++ b/docs/fundamentals/command-line-interface.md
@@ -50,9 +50,10 @@ Mago is organized into several tools and utility commands, each accessed via a s
 
 ### Utility Commands
 
-| Command                                | Description                                             |
-| :------------------------------------- | :------------------------------------------------------ |
-| [`mago config`](/guide/configuration)  | Displays the final, merged configuration Mago is using. |
-| [`mago list-files`](/guide/list-files) | Displays a list of the files scanned by Mago.           |
-| [`mago init`](/guide/initialization)   | Initializes a new Mago configuration file.              |
-| [`mago self-update`](/guide/upgrading) | Updates Mago to the latest version.                     |
+| Command                                                    | Description                                             |
+| :--------------------------------------------------------- | :------------------------------------------------------ |
+| [`mago config`](/guide/configuration)                      | Displays the final, merged configuration Mago is using. |
+| [`mago list-files`](/guide/list-files)                     | Displays a list of the files scanned by Mago.           |
+| [`mago generate-completions`](/guide/generate-completions) | Generate shell completions for Mago.                    |
+| [`mago init`](/guide/initialization)                       | Initializes a new Mago configuration file.              |
+| [`mago self-update`](/guide/upgrading)                     | Updates Mago to the latest version.                     |

--- a/docs/guide/generate-completions.md
+++ b/docs/guide/generate-completions.md
@@ -1,0 +1,35 @@
+---
+title: Generating shell completions
+---
+
+# Generating shell completions
+
+Mago comes with a subcommand to generate completions for common shells.
+
+## Usage
+
+To get the completions for your shell, run the `generate-completions` command
+with the desired shell name as its arguments.
+
+```sh
+mago generate-completions fish
+```
+
+You can store them in a file to be sourced by your shell or if you want them to
+always match your Mago version, simply source them directly. For example:
+
+```sh
+mago generate-completions fish | source
+```
+
+## Command reference
+
+```sh
+Usage: mago generate-completions <SHELL>
+```
+
+### Options
+
+| Flag, Alias(es)           | Description             |
+| :------------------------ | :---------------------- |
+| `-h`, `--help`            | Print help information. |

--- a/src/commands/generate_completions.rs
+++ b/src/commands/generate_completions.rs
@@ -1,0 +1,31 @@
+use std::io;
+use std::process::ExitCode;
+
+use clap::CommandFactory;
+use clap::Parser;
+use clap_complete::Shell;
+use clap_complete::generate;
+
+use crate::commands::CliArguments;
+use crate::error::Error;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "generate-completions",
+    about = "Generate shell completions",
+    long_about = r#"
+The `generate-completions` command generates shell completions for Mago for the given shell.
+"#
+)]
+pub struct GenerateCompletionsCommand {
+    /// Select the shell for which the completions are generated.
+    pub shell: Shell,
+}
+
+impl GenerateCompletionsCommand {
+    pub fn execute(self) -> Result<ExitCode, Error> {
+        generate(self.shell, &mut CliArguments::command(), "mago", &mut io::stdout());
+
+        Ok(ExitCode::SUCCESS)
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -33,6 +33,7 @@
 //! - **`guard`** ([`GuardCommand`]): Enforce architectural rules
 //! - **`ast`** ([`AstCommand`]): Display the abstract syntax tree
 //! - **`self-update`** ([`SelfUpdateCommand`]): Update Mago to the latest version
+//! - **`generate-completions`** ([`GenerateCompletionsCommand`]): Generate shell completions
 //!
 //! # Configuration Hierarchy
 //!
@@ -59,6 +60,7 @@ use crate::commands::analyze::AnalyzeCommand;
 use crate::commands::ast::AstCommand;
 use crate::commands::config::ConfigCommand;
 use crate::commands::format::FormatCommand;
+use crate::commands::generate_completions::GenerateCompletionsCommand;
 use crate::commands::guard::GuardCommand;
 use crate::commands::init::InitCommand;
 use crate::commands::lint::LintCommand;
@@ -72,6 +74,7 @@ pub mod analyze;
 pub mod ast;
 pub mod config;
 pub mod format;
+pub mod generate_completions;
 pub mod guard;
 pub mod init;
 pub mod lint;
@@ -215,6 +218,12 @@ pub enum MagoCommand {
     /// **Usage**: `mago self-update`
     #[command(name = "self-update")]
     SelfUpdate(SelfUpdateCommand),
+
+    /// Generate shell completions for the given shell
+    ///
+    /// **Usage**: `mago generate-completions`
+    #[command(name = "generate-completions")]
+    GenerateCompletions(GenerateCompletionsCommand),
 }
 
 /// Top-level CLI arguments parsed by [`clap`].

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,5 +181,6 @@ pub fn run() -> Result<ExitCode, Error> {
         MagoCommand::SelfUpdate(_) => {
             unreachable!("The self-update command should have been handled before this point.")
         }
+        MagoCommand::GenerateCompletions(cmd) => cmd.execute(),
     }
 }


### PR DESCRIPTION
## 📌 What Does This PR Do?

This adds a new subcommand to generate shell completions for Mago for various shells.

## 🔍 Context & Motivation

Things like `--reporting-format` are annoying to type, shell completions help here XD

## 🛠️ Summary of Changes

- **Feature:** Added a new `generate-completions` command.
- **Docs:** Added docs for the new command.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [x] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [x] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

None

## 📝 Notes for Reviewers

None
