### PR TITLE
fix(linter): Fix --only being ignored when linting

### DIFF
--- a/crates/orchestrator/src/service/lint.rs
+++ b/crates/orchestrator/src/service/lint.rs
@@ -76,12 +76,12 @@ impl LintService {
     /// # Returns
     ///
     /// A `Result` containing the final `IssueCollection` or an `OrchestratorError`.
-    pub fn lint(self, mode: LintMode) -> Result<IssueCollection, OrchestratorError> {
+    pub fn lint(self, mode: LintMode, only: Option<&[String]>) -> Result<IssueCollection, OrchestratorError> {
         const PROGRESS_BAR_THEME: &str = "🧹 Linting";
 
         let context = LintContext {
             php_version: self.settings.php_version,
-            registry: Arc::new(self.create_registry(None, false)),
+            registry: Arc::new(self.create_registry(only, false)),
             mode,
         };
 

--- a/crates/wasm/src/analysis.rs
+++ b/crates/wasm/src/analysis.rs
@@ -55,7 +55,7 @@ pub fn analyze_code(code: String, settings: WasmSettings) -> WasmAnalysisResults
         false, // no progress bars in WASM
     );
 
-    let lint_issues = lint_service.lint(LintMode::Full).unwrap_or_else(|_| IssueCollection::new());
+    let lint_issues = lint_service.lint(LintMode::Full, None).unwrap_or_else(|_| IssueCollection::new());
 
     // For WASM, we'll put all lint issues together
     let parse_error = None;

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -223,7 +223,10 @@ impl LintCommand {
             return Ok(ExitCode::SUCCESS);
         }
 
-        let issues = service.lint(if self.semantics { LintMode::SemanticsOnly } else { LintMode::Full })?;
+        let issues = service.lint(
+            if self.semantics { LintMode::SemanticsOnly } else { LintMode::Full },
+            if self.only.is_empty() { None } else { Some(self.only.as_slice()) },
+        )?;
 
         let baseline = configuration.linter.baseline.as_deref();
         let processor = self.baseline_reporting.get_processor(orchestrator, database, color_choice, baseline);


### PR DESCRIPTION
Commit b119ee5f "refactor: introduce orchestrator crate and restructure architecture for 1.0.0-rc.1" broke the `--only` flag for linting, it only works for --list-rules and --explain since then.

## 📌 What Does This PR Do?

Fixes the `--only` flag for the linter.

## 🔍 Context & Motivation

It broke recently 😂 

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed handling of the `--only` option when linting

## 📂 Affected Areas

- [x] Linter
- [ ] Formatter
- [x] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

None

## 📝 Notes for Reviewers

Is it actually useful to have `--only` take effect in combination with `--explain`? The only effect I can imagine is that instead of getting a rule explanation, you get a "no such rule" error.
