### PR TITLE
fix(linter): Recognize EchoTags as useful statements

### DIFF
--- a/crates/linter/src/rule/redundancy/no_redundant_file.rs
+++ b/crates/linter/src/rule/redundancy/no_redundant_file.rs
@@ -145,7 +145,7 @@ fn is_statement_useful<'ast, 'arena>(statement: &'ast Statement<'arena>) -> bool
         | Statement::Break(_)
         | Statement::Switch(_)
         | Statement::If(_) => true,
-        Statement::Echo(_) | Statement::HaltCompiler(_) | Statement::Unset(_) => true,
+        Statement::Echo(_) | Statement::EchoTag(_) | Statement::HaltCompiler(_) | Statement::Unset(_) => true,
         Statement::Class(_) | Statement::Interface(_) | Statement::Trait(_) | Statement::Enum(_) => true,
         Statement::Constant(_) | Statement::Function(_) => true,
         Statement::Return(_) => true,


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fix the no-redundant-files linter rule to recognize echo tags (`<?=`) as useful statements.

## 🔍 Context & Motivation

When using PHP as a templating language, sometimes a template contains nothing but an echo tag.

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed echo tags not being recognized as useful.

## 📂 Affected Areas

- [x] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Fixes #609

## 📝 Notes for Reviewers

None