### PR TITLE
fix(analyzer): don't assert that $y is not null on isset($x[$y])

### DIFF
--- a/crates/analyzer/src/assertion.rs
+++ b/crates/analyzer/src/assertion.rs
@@ -113,25 +113,6 @@ pub fn scrape_assertions(
             }
             Construct::Isset(isset_construct) => {
                 for value in isset_construct.values.iter() {
-                    // First, handle assertions for nullable array indices
-                    // For isset($arr[$key]) where $key is nullable, assert that $key is non-null
-                    let mut current_expr = value;
-                    while let Expression::ArrayAccess(array_access) = current_expr {
-                        if let Some(index_id) = get_expression_id(
-                            array_access.index,
-                            assertion_context.this_class_name,
-                            assertion_context.resolved_names,
-                            Some(assertion_context.codebase),
-                        ) && let Some(index_type) = artifacts.get_expression_type(array_access.index)
-                            && index_type.is_nullable()
-                        {
-                            if_types.entry(index_id).or_insert_with(|| vec![vec![Assertion::IsNotType(TAtomic::Null)]]);
-                        }
-
-                        current_expr = array_access.array;
-                    }
-
-                    // Then handle the value itself
                     if let Some(value_id) = get_expression_id(
                         value,
                         assertion_context.this_class_name,

--- a/crates/analyzer/src/utils/expression/array.rs
+++ b/crates/analyzer/src/utils/expression/array.rs
@@ -105,7 +105,7 @@ pub(crate) fn get_array_target_type_given_index<'ctx, 'arena>(
         return get_never();
     }
 
-    if index_type.is_null() {
+    if index_type.is_null() && !index_type.is_keyed_array() {
         context.collector.report_with_code(
             IssueCode::NullArrayIndex,
             Issue::error(format!(
@@ -124,7 +124,7 @@ pub(crate) fn get_array_target_type_given_index<'ctx, 'arena>(
     }
 
     if !block_context.inside_isset {
-        if index_type.is_nullable() && !index_type.ignore_nullable_issues {
+        if index_type.is_nullable() && !index_type.ignore_nullable_issues && !array_like_type.is_keyed_array() {
             context.collector.report_with_code(
                 IssueCode::PossiblyNullArrayIndex,
                 Issue::warning(format!(

--- a/crates/analyzer/tests/cases/issue_362.php
+++ b/crates/analyzer/tests/cases/issue_362.php
@@ -50,7 +50,6 @@ class ArrayCollection implements ArrayAccess, Countable, IteratorAggregate
      * @param TKey|null $offset
      * @param TValue $value
      *
-     * @mago-expect analysis:possibly-null-array-index
      * @mago-expect analysis:invalid-property-assignment-value
      */
     public function offsetSet($offset, $value): void

--- a/crates/analyzer/tests/cases/issue_586.php
+++ b/crates/analyzer/tests/cases/issue_586.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+function gar(?string $y): void
+{
+    $x = ['' => 2];
+
+    if (isset($x[$y])) {
+        echo $x[$y], PHP_EOL;
+        if ($y === null) {
+            echo 123, PHP_EOL;
+        }
+    }
+}
+
+gar(null);

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -263,6 +263,7 @@ test_case!(issue_549);
 test_case!(issue_551);
 test_case!(issue_577);
 test_case!(issue_574);
+test_case!(issue_586);
 test_case!(issue_596);
 test_case!(issue_598);
 test_case!(issue_606);


### PR DESCRIPTION
fixes #586 