### PR TITLE
fix(prelude): Fix generic typings for DOMNamedNodeMap and DOMNode::$attributes

### DIFF
--- a/crates/prelude/assets/extensions/dom.php
+++ b/crates/prelude/assets/extensions/dom.php
@@ -355,6 +355,7 @@ namespace {
 
         /**
          * @readonly
+         * @var DOMNamedNodeMap<DOMAttr>
          */
         public null|DOMNamedNodeMap $attributes;
 
@@ -1177,7 +1178,8 @@ namespace {
     }
 
     /**
-     * @implements IteratorAggregate<string, DOMNode>
+     * @template-covariant TNode of DOMNode
+     * @implements IteratorAggregate<string, TNode>
      */
     class DOMNamedNodeMap implements IteratorAggregate, Countable
     {
@@ -1186,10 +1188,12 @@ namespace {
          */
         public int $length;
 
+        /** @return null|TNode */
         public function getNamedItem(string $qualifiedName): null|DOMNode
         {
         }
 
+        /** @return null|TNode */
         public function getNamedItemNS(null|string $namespace, string $localName): null|DOMNode
         {
         }


### PR DESCRIPTION
## 📌 What Does This PR Do?

See https://github.com/JetBrains/phpstorm-stubs/blob/master/dom/dom_c.php#L101 and https://github.com/JetBrains/phpstorm-stubs/blob/master/dom/dom_c.php#L1393 for comparison :+1:
## 🔍 Context & Motivation



## 🛠️ Summary of Changes



## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Analyzer

## 🔗 Related Issues or PRs


## 📝 Notes for Reviewers

