### PR TITLE
Add return type to ReflectionNamedType::getName method

### DIFF
--- a/crates/prelude/assets/extensions/reflection.php
+++ b/crates/prelude/assets/extensions/reflection.php
@@ -231,7 +231,7 @@ class ReflectionNamedType extends ReflectionType
     /**
      * @pure
      */
-    public function getName()
+    public function getName(): string
     {
     }
 


### PR DESCRIPTION
## 📌 What Does This PR Do?

Adds return type to `ReflectionNamedType::getName` method

## 🔍 Context & Motivation

`ReflectionNamedType::getName` is analyzed as returning `mixed` when it actually returns `string`.
https://www.php.net/manual/en/reflectionnamedtype.getname.php

## 🛠️ Summary of Changes

- **Bug Fix:** Fix missing return type on `ReflectionNamedType::getName` method

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify):

Just affects `mago analyze` I believe.
## 🔗 Related Issues or PRs

I can't see an issue for this.

## 📝 Notes for Reviewers

I am not familiar with this project or Rust, but I think I have edited this in the correct place.
