### PR TITLE
allow ReflectionProperty constructor to accept key-of<properties-of<T>>

### DIFF
--- a/crates/prelude/assets/extensions/reflection.php
+++ b/crates/prelude/assets/extensions/reflection.php
@@ -572,8 +572,10 @@ class ReflectionProperty implements Reflector
     public string $class;
 
     /**
-     * @param class-string|object $class
-     * @param string $property
+     * @template T of object
+     *
+     * @param class-string<T>|object $class
+     * @param key-of<properties-of<T>>|string $property
      *
      * @throws ReflectionException
      */


### PR DESCRIPTION
this pr allows us to pass key-of<properties-of\<T>> to ReflectionProperty

fixes this issue: https://mago.carthage.software/playground#019b28ed-b476-569a-99b0-a315a3c60667

