### PR TITLE
refactor(formatter): use if let to fix unnecessary_unwrap warning

### DIFF
--- a/crates/formatter/src/internal/printer/mod.rs
+++ b/crates/formatter/src/internal/printer/mod.rs
@@ -494,8 +494,8 @@ impl<'arena> Printer<'arena> {
                 }
                 Document::Group(group) => {
                     let group_mode = if *group.should_break.borrow() { Mode::Break } else { mode };
-                    if group.expanded_states.is_some() && group_mode.is_break() {
-                        if let Some(last_state) = group.expanded_states.as_ref().unwrap().last() {
+                    if let Some(expanded_states) = group.expanded_states.as_ref() {
+                        if let Some(last_state) = expanded_states.last() {
                             stack.push((group_mode, last_state));
                         }
                     } else {


### PR DESCRIPTION
## 📌 What Does This PR Do?

The printer logic was using `is_some()` followed by `unwrap()`, which triggered a `clippy::unnecessary_unwrap` warning.

## 🔍 Context & Motivation

`just check` raises below error.

```
error: called `unwrap` on `group.expanded_states` after checking its variant with `is_some`
   --> crates/formatter/src/internal/printer/mod.rs:498:51
    |
497 |                     if group.expanded_states.is_some() && group_mode.is_break() {
    |                        ------------------------------- the check is happening here
498 |                         if let Some(last_state) = group.expanded_states.as_ref().unwrap().last() {
    |                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: try using `if let` or `match`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_unwrap
    = note: `-D clippy::unnecessary-unwrap` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_unwrap)]`

error: could not compile `mago-formatter` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `mago-formatter` (lib test) due to 1 previous error
```

## 🛠️ Summary of Changes

- **Refactor:** refactors the code to use `if let` for safe and idiomatic pattern matching on the `Option` type.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
