### PR TITLE
chore(prelude): improve `array_map` signature for non-empty array

### DIFF
--- a/crates/analyzer/tests/cases/array_map_non_empty_array.php
+++ b/crates/analyzer/tests/cases/array_map_non_empty_array.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * @param non-empty-array<string, string> $arr
+ * @return non-empty-array<string, int>
+ */
+function takesNonEmptyArray(array $arr): array
+{
+    return array_map(strlen(...), $arr);
+}

--- a/crates/analyzer/tests/cases/array_map_non_empty_list.php
+++ b/crates/analyzer/tests/cases/array_map_non_empty_list.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * @param non-empty-list<string> $list
+ * @return non-empty-list<int>
+ */
+function takesNonEmptyList(array $list): array
+{
+    return array_map(strlen(...), $list);
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -34,6 +34,8 @@ macro_rules! test_case {
 test_case!(accessing_undefined_class_constant);
 test_case!(argument_count);
 test_case!(array_list_reconciliation);
+test_case!(array_map_non_empty_array);
+test_case!(array_map_non_empty_list);
 test_case!(array_shape_fields);
 test_case!(array_unique_non_empty);
 test_case!(assert_concrete_to_template_type);

--- a/crates/prelude/assets/extensions/standard.php
+++ b/crates/prelude/assets/extensions/standard.php
@@ -4711,7 +4711,9 @@ function array_filter(array $array, null|callable $callback = null, int $mode = 
  * @param array<K, V> $array
  * @param array<S> ...$arrays
  *
- * @return ($array is list<V> ? list<U> : array<K, U>)
+ * @return ($array is list<V>
+ *     ? ($array is non-empty-list<V> ? non-empty-list<U> : list<U>)
+ *     : ($array is non-empty-array<K, V> ? non-empty-array<K, U> : array<K, U>))
  */
 function array_map(null|callable $callback, array $array, array ...$arrays): array
 {


### PR DESCRIPTION
## 📌 What Does This PR Do?

Passing a `non-empty-list` or `non-empty-array` to `array_map` should return a non-empty array.

## 🛠️ Summary of Changes

- **Feature:** Improves the signature of the `array_map` function

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Analyzer