### PR TITLE
feat: add .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,15 @@
+---
+
+ - id: mago-lint
+   name: mago lint
+   description: An extremely fast PHP linter, formatter, and static analyzer, written in Rust.
+   entry: mago lint
+   language: rust
+   types: [php]
+
+ - id: mago-fmt
+   name: mago fmt
+   description: An extremely fast PHP linter, formatter, and static analyzer, written in Rust.
+   entry: mago fmt
+   language: rust
+   types: [php]


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR introduces a yaml file that allows mago to easily be used by users of pre-commit.com style of pre-commit hooks.

## 🔍 Context & Motivation

pre-commit allows the user to run a large set of hooks that help in maintaining a git repo and git managed code base. Ensuring that integrating `mago` is easy to do, only helps `mago` and the users of pre-commit hooks

## 🛠️ Summary of Changes

- **Feature:** Allow mago-lint and mago-fmt to be used in pre-commit hooks

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Integration

## 🔗 Related Issues or PRs
Fixes: #833 


## 📝 Notes for Reviewers

N/A
<!-- Any extra context, concerns, or breaking changes? -->
