### PR TITLE
fix(orchestrator): use 4-byte emoji for analysis progress bar

### DIFF
--- a/crates/orchestrator/src/service/analysis.rs
+++ b/crates/orchestrator/src/service/analysis.rs
@@ -169,7 +169,7 @@ impl AnalysisService {
     pub fn run(&mut self) -> Result<AnalysisResult, OrchestratorError> {
         #[cfg(not(target_arch = "wasm32"))]
         const ANALYSIS_DURATION_THRESHOLD: Duration = Duration::from_millis(5000);
-        const ANALYSIS_PROGRESS_PREFIX: &str = "🕵️  Analyzing";
+        const ANALYSIS_PROGRESS_PREFIX: &str = "🔬 Analyzing";
 
         // Temporarily take ownership of fields to pass to pipeline
         let database = std::mem::replace(&mut self.database, ReadDatabase::empty());
@@ -262,7 +262,7 @@ impl AnalysisService {
     pub fn run_incremental(&mut self) -> Result<AnalysisResult, OrchestratorError> {
         #[cfg(not(target_arch = "wasm32"))]
         const ANALYSIS_DURATION_THRESHOLD: Duration = Duration::from_millis(5000);
-        const ANALYSIS_PROGRESS_PREFIX: &str = "🕵️  Analyzing";
+        const ANALYSIS_PROGRESS_PREFIX: &str = "🔬 Analyzing";
 
         // Temporarily take ownership of fields to pass to pipeline
         let database = std::mem::replace(&mut self.database, ReadDatabase::empty());


### PR DESCRIPTION
## 📌 What Does This PR Do?

Replaces the detective emoji (🕵️) with a microscope emoji (🔬) in the analysis progress bar.

## 🔍 Context & Motivation

The detective emoji (🕵️) uses variation selectors and ZWJ sequences (7 bytes, 2 chars), which causes rendering issues in some terminal emulators like PHPStorm. Simple 4-byte emojis render correctly across all terminals.

## 🛠️ Summary of Changes

- **Bug Fix:** Changed progress bar emoji from 🕵️ (7 bytes) to 🔬 (4 bytes) in both `run()` and `run_incremental()` methods.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [x] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

<!-- None -->

## 📝 Notes for Reviewers

Alternative 4-byte emoji options if microscope isn't preferred: 🔍 🔎 🧪 📊 📈 🎯