### PR TITLE
fix: report invalid-extend when a readonly class extends a non-readon…

### DIFF
--- a/crates/analyzer/src/statement/class_like/mod.rs
+++ b/crates/analyzer/src/statement/class_like/mod.rs
@@ -901,6 +901,15 @@ fn check_class_like_extends<'ctx, 'arena>(
                         .with_note("A `readonly` class can only be extended by another `readonly` class.")
                         .with_help(format!("To resolve this, either make the `{using_name}` class `readonly`, or extend a different, non-readonly class.")),
                 );
+            } else if !extended_class_metadata.flags.is_readonly() && class_like_metadata.flags.is_readonly() {
+                context.collector.report_with_code(
+                    IssueCode::InvalidExtend,
+                    Issue::error(format!("Readonly class `{using_name}` cannot extend non-readonly class `{extended_name}`"))
+                        .with_annotation(Annotation::primary(using_class_span).with_message("This class is `readonly`..."))
+                        .with_annotation(Annotation::secondary(extended_class_span).with_message(format!("...but it extends `{extended_name}`, which is not `readonly`")))
+                        .with_note("A non-`readonly` class can only be extended by another non-`readonly` class.")
+                        .with_help(format!("To resolve this, either make the `{using_name}` class non-`readonly`, or extend a different, readonly class.")),
+                );
             }
 
             if let Some(required_interface) =

--- a/crates/analyzer/tests/cases/issue_872.php
+++ b/crates/analyzer/tests/cases/issue_872.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types = 1);
+
+class A {}
+
+/** @mago-expect analysis: invalid-extend */
+readonly class B extends A {}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -525,6 +525,7 @@ test_case!(issue_845);
 test_case!(issue_849);
 test_case!(issue_861);
 test_case!(issue_863);
+test_case!(issue_872);
 
 #[test]
 fn test_all_test_cases_are_ran() {


### PR DESCRIPTION
## 📌 What Does This PR Do?
fixes #872 

## 🛠️ Summary of Changes

- **Bug Fix:** Report an error when extending a readonly class with a non readonly class
 
## 🔗 Related Issues or PRs
fixes #872 

## 📝 Notes for Reviewers
:heart: 

