### PR TITLE
fix(analyzer): report non existent classes in functions/methods/prope…

### DIFF
--- a/crates/analyzer/tests/cases/issue_891.php
+++ b/crates/analyzer/tests/cases/issue_891.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace X\Z {
+    class ExistingClass2 {}
+}
+
+namespace X {
+    class ExistingClass {}
+
+    function existingFunction(Z\ExistingClass2 $_existingClass): void
+    {
+    }
+}
+
+namespace Y {
+    use X\ExistingClass;
+
+    function existingFunction(ExistingClass $_existingClass): void
+    {
+    }
+
+    interface TestInterface {}
+}
+
+namespace {
+    use Y\TestInterface;
+
+    class A
+    {
+        public TestInterface $testInterface = null;
+        /** @mago-expect analysis: non-existent-class-like */
+        public ?X $x = null;
+
+        /** @mago-expect analysis: non-existent-class-like */
+        public X $x2 = null;
+
+        public function __construct(/** @mago-expect analysis: non-existent-class-like */ B $_x) {}
+    }
+
+    function foo(/** @mago-expect analysis: non-existent-class-like */ Z $_z): void
+    {
+    }
+
+    function bar(/** @mago-expect analysis: non-existent-class-like */ ?Z $_z): void
+    {
+    }
+
+    function z(\X\ExistingClass $_existingClass): void
+    {
+    }
+}
+

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -531,6 +531,7 @@ test_case!(issue_863);
 test_case!(issue_870);
 test_case!(issue_871);
 test_case!(issue_872);
+test_case!(issue_891);
 
 #[test]
 fn test_all_test_cases_are_ran() {


### PR DESCRIPTION
fixes #891 

It's just a basic functionality. It should probably get extended to support arrays and shaped objects in the future.