### PR TITLE
fix(member_access): Fix multi line indentation in if clause

### DIFF
--- a/crates/formatter/tests/cases/if_multiline_operator/after.php
+++ b/crates/formatter/tests/cases/if_multiline_operator/after.php
@@ -1,0 +1,23 @@
+<?php
+
+if (!$this->windows && !$this->getSession()
+    ->getDriver() instanceof BrowserKitDriver) {
+    if (!$this->getSession()->isStarted()) {
+        $this->getSession()->start();
+    }
+
+    $this->windows = $this->getSession()->getWindowNames();
+}
+
+if (!$this->windows && !$this
+    ->getSession()
+    ->getDriver()
+    ->exampleCall()
+    ->gimmeMore()
+    ->andAnother() instanceof BrowserKitDriver) {
+    if (!$this->getSession()->isStarted()) {
+        $this->getSession()->start();
+    }
+
+    $this->windows = $this->getSession()->getWindowNames();
+}

--- a/crates/formatter/tests/cases/if_multiline_operator/after.php
+++ b/crates/formatter/tests/cases/if_multiline_operator/after.php
@@ -21,3 +21,27 @@ if (!$this->windows && !$this
 
     $this->windows = $this->getSession()->getWindowNames();
 }
+
+if (
+    $node->bundle() == 'organization_profile'
+    && \Drupal::service('example_recruiter_verification.example_recruiter_verification_helper')
+        ->isRecruiterVerificationEnabled()
+) {
+    $a = $b;
+}
+
+if (
+    $node->bundle() == 'organization_profile'
+    && \Drupal::service('example_recruiter_verification.example_recruiter_verification_helper')
+        ->somePublicProperty
+) {
+    $a = $b;
+}
+
+if (
+    $node->bundle() == 'organization_profile'
+    && $object->method('example_recruiter_verification.example_recruiter_verification_helper')
+        ->somePublicProperty
+) {
+    $a = $b;
+}

--- a/crates/formatter/tests/cases/if_multiline_operator/before.php
+++ b/crates/formatter/tests/cases/if_multiline_operator/before.php
@@ -1,0 +1,23 @@
+<?php
+
+if (!$this->windows && !$this->getSession()
+    ->getDriver() instanceof BrowserKitDriver) {
+    if (!$this->getSession()->isStarted()) {
+        $this->getSession()->start();
+    }
+
+    $this->windows = $this->getSession()->getWindowNames();
+}
+
+if (!$this->windows && !$this
+    ->getSession()
+    ->getDriver()
+    ->exampleCall()
+    ->gimmeMore()
+    ->andAnother() instanceof BrowserKitDriver) {
+    if (!$this->getSession()->isStarted()) {
+        $this->getSession()->start();
+    }
+
+    $this->windows = $this->getSession()->getWindowNames();
+}

--- a/crates/formatter/tests/cases/if_multiline_operator/before.php
+++ b/crates/formatter/tests/cases/if_multiline_operator/before.php
@@ -21,3 +21,18 @@ if (!$this->windows && !$this
 
     $this->windows = $this->getSession()->getWindowNames();
 }
+
+if ($node->bundle() == 'organization_profile' && \Drupal::service('example_recruiter_verification.example_recruiter_verification_helper')
+    ->isRecruiterVerificationEnabled()) {
+    $a = $b;
+}
+
+if ($node->bundle() == 'organization_profile' && \Drupal::service('example_recruiter_verification.example_recruiter_verification_helper')
+    ->somePublicProperty) {
+    $a = $b;
+}
+
+if ($node->bundle() == 'organization_profile' && $object->method('example_recruiter_verification.example_recruiter_verification_helper')
+    ->somePublicProperty) {
+    $a = $b;
+}

--- a/crates/formatter/tests/cases/if_multiline_operator/settings.inc
+++ b/crates/formatter/tests/cases/if_multiline_operator/settings.inc
@@ -1,0 +1,5 @@
+FormatSettings {
+  preserve_breaking_conditional_expression: true,
+  preserve_breaking_member_access_chain: true,
+  ..Default::default()
+}

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -237,6 +237,7 @@ test_case!(idempotent_chain_with_array);
 test_case!(match_idempotency);
 test_case!(heredoc_indentation);
 test_case!(heredoc_indentation_disabled);
+test_case!(if_multiline_operator);
 
 // A special test case for regressions in the Psl codebase
 test_case!(psl_regressions);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes an issue where chained method calls inside control structure conditions (like `if` statements) were being formatted with incorrect indentation (double indent).

## 🔍 Context & Motivation

When a method chain (e.g., `$this->foo()->bar()`) appeared inside an `if` condition, the formatter was applying two levels of indentation: one from the condition wrapper and one from the chain formatter itself. Additionally, heuristics for "short chains" were preventing proper inlining, causing readable code to break awkwardly across multiple lines.

This change ensures that chains inside conditions respect the parent indentation context and inline short chains appropriately, matching the expected output in the `if_multiline_operator` test case and general PHP coding standards.

This test code:
```php
if (!$this->windows && !$this->getSession()
    ->getDriver() instanceof BrowserKitDriver) {
    if (!$this->getSession()->isStarted()) {
        $this->getSession()->start();
    }

    $this->windows = $this->getSession()->getWindowNames();
}
```
with settings
```toml
preserve-breaking-conditional-expression = true
preserve-breaking-member-access-chain = true
```
is wrongly formatted to:
```php
if (!$this->windows && !$this->getSession()
        ->getDriver() instanceof BrowserKitDriver) {
    if (!$this->getSession()->isStarted()) {
        $this->getSession()->start();
    }

    $this->windows = $this->getSession()->getWindowNames();
}
```

## 🛠️ Summary of Changes

- **Bug Fix:** Prevented double indentation for member access chains when they appear inside a condition context.
- **Bug Fix:** Adjusted `is_already_broken` logic to allow short chains (length <= 3) to be formatted as chains when inside conditions.
- **Bug Fix:** Updated `print_member_access_chain` to force inlining of the first access for short chains in conditions, ensuring `$object->method()` stays together on the first line where possible.

## 📂 Affected Areas

- [x] Formatter

## 🔗 Related Issues or PRs

-

## 📝 Notes for Reviewers

- The logic specifically checks `FormatterState.in_condition` to apply these relaxations only where appropriate (inside `if(...)`, `while(...)`, etc.).
- Verified that all formatter tests pass without regressions.
- Not sure about the approach, let me know if there is a better way.