### PR TITLE
Add caching mechanism for includes to optimize repetitive scans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,6 +1609,8 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 name = "mago"
 version = "1.1.0"
 dependencies = [
+ "bincode",
+ "blake3",
  "bumpalo",
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,6 +138,8 @@ clap = { workspace = true }
 clap_complete = { workspace = true }
 termtree = { workspace = true }
 serde_json = { workspace = true }
+blake3 = { workspace = true }
+bincode = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 self_update = { workspace = true }


### PR DESCRIPTION
## 📌 What Does This PR Do?

This adds a caching mechanism for includes.

## 🔍 Context & Motivation

We have a lot of vendor files and running the command on a single file takes ~5 seconds with optimizations (like `threads` and `stack-size`). Why do we run it on single files? We don't, the Mago IDE plugin (PhpStorm) does this. When running it with the `--cache-includes` flag, it reduces the time to ~2 seconds. This is a huge performance boost.

BUT: this is just a draft, I don't have the time to implement it cleanly, but this should be enough for someone to do it.

## 📂 Affected Areas

- [X] Analyzer
- [ ] Linter
- [ ] Formatter
- [X] CLI
- [ ] Composer Plugin
- [X] Dependencies
- [ ] Documentation
- [ ] Other

Also thanks for this awesome tool :)