### PR TITLE
Update nix flake to rust 1.91.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1756542300,
-        "narHash": "sha256-tlOn88coG5fzdyqz6R93SQL5Gpq+m/DsWpekNFhqPQk=",
+        "lastModified": 1769018530,
+        "narHash": "sha256-MJ27Cy2NtBEV5tsK+YraYr2g851f3Fl1LpNHDzDX15c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d7600c775f877cd87b4f5a831c28aa94137377aa",
+        "rev": "88d3861acdd3d2f0e361767018218e51810df8a1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Mago - devshell using rustup (stable 1.89.0 + nightly) and php 8.4 + composer";
+  description = "Mago - devshell using rustup (stable 1.91.1 + nightly) and php 8.4 + composer";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
@@ -13,7 +13,8 @@
         isDarwin = pkgs.stdenv.isDarwin;
         php = pkgs.php84;
         composer = pkgs.php84Packages.composer;
-      in {
+      in
+      {
         devShells.default = pkgs.mkShell {
           buildInputs = [
             pkgs.cargo
@@ -42,9 +43,9 @@
           shellHook = ''
             export PATH="$HOME/.cargo/bin:$PATH"
             if ! command -v rustc >/dev/null 2>&1; then
-              rustup toolchain install 1.89.0 --profile minimal
+              rustup toolchain install 1.91.1 --profile minimal
               rustup toolchain install nightly --profile minimal
-              rustup default 1.89.0
+              rustup default 1.91.1
             fi
             echo "[mago] rustc:     $(rustc --version)"
             echo "[mago] nightly:   $(rustup run nightly rustc --version)"


### PR DESCRIPTION
## 📌 What Does This PR Do?

Bump the nix flake's lock to use rustc 1.91.1

## 🔍 Context & Motivation

The current setup uses 1.89.0 which is incompatible with the project since all crates require at least 1.91.0

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Nix flake devshell