### PR TITLE
Implement formatter playground

### DIFF
--- a/docs/.vitepress/theme/composables/useMagoTasks.js
+++ b/docs/.vitepress/theme/composables/useMagoTasks.js
@@ -1,0 +1,49 @@
+import { useMagoWasm } from './useMagoWasm.js';
+
+export function useMagoTasks() {
+  const { analyze: doAnalyze, format: doFormat, loadWasm, isReady } = useMagoWasm();
+
+  async function ensureReady() {
+    await loadWasm();
+    return isReady.value;
+  }
+
+  async function withTiming(fn) {
+    const start = performance.now();
+    try {
+      const result = await fn();
+      const end = performance.now();
+      return { result, timeMs: end - start, error: null };
+    } catch (e) {
+      const end = performance.now();
+      return { result: null, timeMs: end - start, error: e?.message || 'Task failed' };
+    }
+  }
+
+  async function analyze(code, settings) {
+    await ensureReady();
+    const { result, timeMs, error } = await withTiming(() => doAnalyze(code, settings));
+    if (error) {
+      return { issues: [], analysisTimeMs: timeMs, error };
+    }
+    return {
+      issues: result?.issues || [],
+      analysisTimeMs: timeMs ?? null,
+      error: null,
+    };
+  }
+
+  async function format(code, phpVersion) {
+    await ensureReady();
+    const { result, timeMs, error } = await withTiming(() => doFormat(code, phpVersion));
+    if (error) {
+      return { code, timeMs, error };
+    }
+    return { code: result, timeMs, error: null };
+  }
+  
+  return {
+    analyze,
+    format,
+  };
+}

--- a/docs/.vitepress/theme/composables/usePlaygroundState.js
+++ b/docs/.vitepress/theme/composables/usePlaygroundState.js
@@ -54,10 +54,11 @@ export function createPlaygroundState(initialCode = DEFAULT_CODE) {
         disabledRules: [],
       },
     },
-    results: null,
+    analyzerResults: null,
+    formatterResults: { code: "", timeMs: null, error: null },
     isLoading: false,
     wasmReady: false,
-    activeTab: "linter",
+    activeTab: "issues",
     settingsOpen: false,
     availableRules: [],
   });
@@ -97,8 +98,12 @@ export function createPlaygroundState(initialCode = DEFAULT_CODE) {
       state.availableRules = rules;
     },
 
-    setResults(results) {
-      state.results = results;
+    setAnalyzerResults(results) {
+      state.analyzerResults = results;
+    },
+
+    setFormatterResults(result) {
+      state.formatterResults = result;
     },
 
     setLoading(loading) {

--- a/docs/.vitepress/theme/composables/useUrlState.js
+++ b/docs/.vitepress/theme/composables/useUrlState.js
@@ -54,10 +54,14 @@ export function useUrlState() {
       }
 
       const { uuid } = await response.json();
-      shareUrl.value = `${window.location.origin}${window.location.pathname}#${uuid}`;
+      const params = new URLSearchParams(window.location.search);
+      const tab = state.t || params.get('tab') || 'issues';
+      params.set('tab', tab);
+      const query = `?${params.toString()}`;
+      shareUrl.value = `${window.location.origin}${window.location.pathname}${query}#${uuid}`;
       lastStateHash = stateHash;
 
-      window.history.replaceState(null, '', `#${uuid}`);
+      window.history.replaceState(null, '', `${query}#${uuid}`);
 
       return shareUrl.value;
     } catch (e) {

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
             pkgs.openssl
             pkgs.just
             pkgs.wasm-pack
+            pkgs.lld
             php
             composer
           ] ++ pkgs.lib.optionals isDarwin [


### PR DESCRIPTION
## 📌 What Does This PR Do?

Very simple implementation of a formatter playground. It doesn't support any configuration for now but definitely doable (would require server side changes though)

## 🔍 Context & Motivation

I'm working on integrating the formatter in my codebases and it would be easier to have a playground link to easily isolate, reproduce, and demonstrate the bugs I'd want to report.

## 🛠️ Summary of Changes

- Add a new (sub)tabs system to the playground
- Implement the formatter tab separately from the linter+analyzer one
- Added `lld` to the nix flake, since it's required to build the mago wasm binary

<img width="2864" height="1469" alt="image" src="https://github.com/user-attachments/assets/81349fc2-0fcf-437f-a762-db5a4b29d36a" />


## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [x] Documentation
- [ ] Other (please specify):


## 📝 Notes for Reviewers

The code was mostly generated through AI to be honest since I have very few experience with vue, however I did re-read it, refactor, and tested it locally :+1: