### PR TITLE
perf(atom): reduce lock contention around empty atoms

### DIFF
--- a/crates/atom/src/lib.rs
+++ b/crates/atom/src/lib.rs
@@ -71,13 +71,17 @@ pub type AtomSet = HashSet<Atom, BuildHasherDefault<IdentityHasher>>;
 /// The maximum size in bytes for a string to be processed on the stack.
 const STACK_BUF_SIZE: usize = 256;
 
+thread_local! {
+    static EMPTY_ATOM: Atom = atom("");
+}
+
 /// Returns the canonical `Atom` for an empty string.
 ///
 /// This is a very cheap operation.
 #[inline]
 #[must_use]
 pub fn empty_atom() -> Atom {
-    atom("")
+    EMPTY_ATOM.with(|&atom| atom)
 }
 
 /// A macro to concatenate between 2 and 12 string slices into a single `Atom`.


### PR DESCRIPTION
## 📌 What Does This PR Do?

Improve the performance of the analyzer, especially on large project and machines with a high number of cores/thread by reducing contention around the acquisition of the Atom for the empty string.

## 🔍 Context & Motivation

While it looks cheap, atom() actually needs acquire a mutex for the strings bucket, which is always the same for the empty string, and since empty atoms are used quite heavily as a starting point to concatenate longer atoms, this ends up with quite a bit of contention.

## 🛠️ Summary of Changes

- **Feature:** Improved analyzer performance

## 📂 Affected Areas

- [x] Analyzer
- [x] Other (please specify): In theory everything that uses Atoms, in practice I've only seen actual improvements in the analyzer


## 📝 Notes for Reviewers

On a large-ish project (10k analyzed files + dependencies) and a 16c/32t 9950x processor, hyperfine gives these numbers:

```
Benchmark 1: ~/mago-base analyze --retain-code none
  Time (mean ± σ):      3.291 s ±  0.236 s    [User: 20.216 s, System: 4.759 s]
  Range (min … max):    2.961 s …  3.664 s    10 runs
 
Benchmark 2: ~/mago-lazy analyze --retain-code none
  Time (mean ± σ):      2.858 s ±  0.189 s    [User: 18.752 s, System: 3.499 s]
  Range (min … max):    2.588 s …  3.211 s    10 runs
 
Benchmark 3: ~/mago-tlss analyze --retain-code none
  Time (mean ± σ):      2.829 s ±  0.200 s    [User: 18.681 s, System: 3.538 s]
  Range (min … max):    2.585 s …  3.218 s    10 runs
 
Summary
  ~/mago-tlss analyze --retain-code none ran
    1.01 ± 0.10 times faster than ~/mago-lazy analyze --retain-code none
    1.16 ± 0.12 times faster than ~/mago-base analyze --retain-code none
```

mago-tlss is the thread local approach taken here. mago-lazy uses a LazyLock instead, and mago-base is the current upstream version.

For smaller projects or lower thread counts, the gains get noticeably smaller, but I didn't see a regression in any tests.

empty_atom() should now truly be a "very cheap operation" XD
