### PR TITLE
fix(docblock): fix UTF-8 boundary panic on multi-byte whitespace

### DIFF
--- a/crates/docblock/src/internal/parser.rs
+++ b/crates/docblock/src/internal/parser.rs
@@ -234,7 +234,9 @@ fn parse_indented_code<'arena>(
                     break;
                 }
 
-                let line_content = &content[indent_len..];
+                // Calculate byte offset from original indent character count
+                let current_indent_bytes: usize = content.chars().take(indent_len).map(|c| c.len_utf8()).sum();
+                let line_content = &content[current_indent_bytes..];
                 if !code_content.is_empty() {
                     code_content.push('\n');
                 }


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes panic when parsing PHP docblocks containing multi-byte whitespace characters (e.g., full-width space `U+3000`).

## 🔍 Context & Motivation

This is a follow-up fix to #456 which addressed the same issue in `parse_tag` function. Two additional locations with the same bug pattern were missed:

1. `parse_indented_code` function in `parser.rs`
2. `consume_whitespace` function in `tag.rs`

Both functions use `chars().count()` (character count) as byte indices for string slicing, which causes panic on multi-byte characters.

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed `parse_indented_code` function to use byte offsets instead of character counts for string slicing
- **Bug Fix:** Fixed `consume_whitespace` function to return byte count instead of character count
- **Test:** Added test cases for multi-byte whitespace handling with content verification
- **Test:** Updated `test_code_indent_using_non_ascii_chars` expectations to match correct behavior

## 📂 Affected Areas

- [x] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other

## 🔗 Related Issues or PRs

Fixes #967

Related to #456 (prior fix for `parse_tag`)

## 📝 Notes for Reviewers

The fix follows the same pattern established in #456:

```rust
// Before: character count used as byte index
let count = content.chars().take_while(|c| c.is_whitespace()).count();
let slice = &content[count..];  // PANIC on multi-byte chars

// After: convert to byte offset
let char_count = content.chars().take_while(|c| c.is_whitespace()).count();
let byte_offset: usize = content.chars().take(char_count).map(|c| c.len_utf8()).sum();
let slice = &content[byte_offset..];  // Safe
```

`consume_whitespace` was also updated to count bytes directly instead of characters, as its return value is used for both slicing and span calculations.