### PR TITLE
feat(linter): allow up to N statements before recommending early continue

### DIFF
--- a/docs/tools/linter/rules/best-practices.md
+++ b/docs/tools/linter/rules/best-practices.md
@@ -471,6 +471,7 @@ This improves code readability by reducing nesting and making the control flow m
 | :--- | :--- | :--- |
 | `enabled` | `boolean` | `true` |
 | `level` | `string` | `"help"` |
+| `max_allowed_statements` | `integer` | `0` |
 
 ### Examples
 


### PR DESCRIPTION
## 📌 What Does This PR Do?

For a single statement in an if statement inside a loop, the code is
arguably less clear when using an early continue. As this comes down to
personal preference, add a config option to make it configurable how
many statements should be allowed in the if-body before recommending the
early continue.

## 🔍 Context & Motivation

I strongly dislike the 5-line variant with the continue compared to the 3-line version that just uses the if.

## 🛠️ Summary of Changes

- **Feature:** allow up to N statements before recommending early continue

## 📂 Affected Areas

- [x] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Fixes #975

## 📝 Notes for Reviewers

I chose the cfg option to make this less controversial, personally, I'd be happy to just have it fixed at allowing up to one statement inside the if body.
