### PR TITLE
fix(analyzer): fix `arvc` typo in `$_SERVER` array shape

### DIFF
--- a/crates/analyzer/src/common/global.rs
+++ b/crates/analyzer/src/common/global.rs
@@ -55,7 +55,7 @@ std::thread_local! {
 
         map.insert("$GLOBALS", Rc::new({
             let mut known_items = BTreeMap::new();
-            known_items.insert(ArrayKey::String(atom("arvc")), (true, get_positive_int()));
+            known_items.insert(ArrayKey::String(atom("argc")), (true, get_positive_int()));
             known_items.insert(
                 ArrayKey::String(atom("argv")),
                 (true, TUnion::from_atomic(TAtomic::Array(TArray::List(TList::new_non_empty(Box::new(get_string())))))),
@@ -207,7 +207,7 @@ std::thread_local! {
             known_items.insert(ArrayKey::String(atom("DB_USERNAME")), (true, get_non_empty_string()));
             known_items.insert(ArrayKey::String(atom("DB_PASSWORD")), (true, get_string()));
 
-            known_items.insert(ArrayKey::String(atom("arvc")), (true, get_positive_int()));
+            known_items.insert(ArrayKey::String(atom("argc")), (true, get_positive_int()));
             known_items.insert(
                 ArrayKey::String(atom("argv")),
                 (true, TUnion::from_atomic(TAtomic::Array(TArray::List(TList::new_non_empty(Box::new(get_string())))))),


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fix a typo in the `$_SERVER` superglobal array shape definition: `arvc` → `argc`.

## 🔍 Context & Motivation

The `$_SERVER['argc']` key is misspelled as `arvc` in the analyzer's global variable definitions, causing `$_SERVER['argc']` accesses to not be recognized by the type checker.

## 🛠️ Summary of Changes

- **Bug Fix:** Corrected `arvc` to `argc` in two locations in `global.rs` (`$GLOBALS` and `$_SERVER` definitions).

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Analyzer

## 🔗 Related Issues or PRs

Fixes carthage-software/mago#972

## 📝 Notes for Reviewers

One-character fix in two locations. The `argv` key next to it is spelled correctly, confirming this is a typo.
