### PR TITLE
fix(linter): skip inline-variable-return when closure has reference capture

### DIFF
--- a/crates/linter/src/rule/redundancy/inline_variable_return.rs
+++ b/crates/linter/src/rule/redundancy/inline_variable_return.rs
@@ -212,10 +212,10 @@ fn has_reference_capture(expr: &Expression<'_>, var_name: &str) -> bool {
 
     impl<'arena> MutWalker<'_, 'arena, ()> for RefCaptureChecker<'_> {
         fn walk_closure(&mut self, closure: &'_ Closure<'arena>, _: &mut ()) {
-            if let Some(use_clause) = &closure.use_clause {
-                if use_clause.variables.iter().any(|v| v.ampersand.is_some() && v.variable.name == self.var_name) {
-                    self.found = true;
-                }
+            if let Some(use_clause) = &closure.use_clause
+                && use_clause.variables.iter().any(|v| v.ampersand.is_some() && v.variable.name == self.var_name)
+            {
+                self.found = true;
             }
         }
     }


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes a false positive in the `inline-variable-return` rule where it suggests inlining a variable that is reference-captured by a closure in the RHS expression.

## 🔍 Context & Motivation

The `inline-variable-return` rule detects `$var = expr; return $var;` and suggests `return expr;`. However, when the RHS contains a closure that reference-captures the assigned variable via `use(&$var)`, inlining would remove the variable and break the reference.

```php
// Before (correct code)
$callback = function() use (&$callback) { $callback(); };
return $callback;

// After inlining (broken — $callback is undefined)
return function() use (&$callback) { $callback(); };
```

## 🛠️ Summary of Changes

- **Bug Fix:** Added `has_reference_capture()` helper that uses `MutWalker` with a `walk_closure` override to detect `use(&$var)` in the RHS expression tree. The rule now skips the suggestion when a reference capture of the assigned variable is found.
- **Tests:** Added 4 test cases covering reference capture (success), parenthesized closure (success), value capture (failure), and different variable reference capture (failure).

## 📂 Affected Areas

- [x] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Fixes carthage-software/mago#981

## 📝 Notes for Reviewers

- `walk_closure` override intentionally does not descend into the closure body. PHP closures do not auto-capture from the parent scope, so checking only the `use` clause is sufficient.
