### PR TITLE
Use MiMalloc on GNU targets to improve performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,7 @@ mago-prelude = { workspace = true, features = ["build"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 openssl = { workspace = true }
 
-[target.'cfg(any(target_os = "macos", target_os = "windows", target_env = "musl"))'.dependencies]
+[target.'cfg(any(target_os = "macos", target_os = "windows", target_env = "musl", target_env = "gnu"))'.dependencies]
 mimalloc = { version = "0.1.47" }
 
 [features]

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,10 @@ mod macros;
 mod service;
 mod utils;
 
-#[cfg(all(not(feature = "dhat-heap"), any(target_os = "macos", target_os = "windows", target_env = "musl")))]
+#[cfg(all(
+    not(feature = "dhat-heap"),
+    any(target_os = "macos", target_os = "windows", target_env = "musl", target_env = "gnu")
+))]
 #[global_allocator]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 


### PR DESCRIPTION
## 📌 What Does This PR Do?

Enable the MiMalloc allocator, already used for some targets like musl, on GNU targets.

## 🔍 Context & Motivation

I'm seeing a pretty consistent speed up across various workloads that puts the mimalloc version 5-20% ahead of the standard GNU allocator.

## 🛠️ Summary of Changes

- **Feature:** Improve performance on GNU targets by using MiMalloc

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [x] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

None

## 📝 Notes for Reviewers

:package: 
