### PR TITLE
chore: update .gitattributes to exclude more files from export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,16 +8,10 @@ stubs/** linguist-vendored
 .rustfmt.toml export-ignore
 .typos.toml export-ignore
 .github/ export-ignore
-CODE_OF_CONDUCT.md export-ignore
-CONTRIBUTING.md export-ignore
-SECURITY.md export-ignore
-SPONSORS.md export-ignore
 Justfile export-ignore
-README.md export-ignore
 build.rs export-ignore
 Cargo.toml export-ignore
 Cargo.lock export-ignore
-composer.lock export-ignore
 corpus/ export-ignore
 crates/ export-ignore
 docs/ export-ignore


### PR DESCRIPTION
## 📌 What Does This PR Do?

Ignore more files for composer based installs.

<img width="599" height="280" alt="image" src="https://github.com/user-attachments/assets/2937eb0f-46d6-4d8c-bf13-98b16e6a707f" />

I wondered why it takes so long to install 😂 
