### PR TITLE
fix(formatter): correct pint preset `space_around_assignment_in_declare` to `false`

### DIFF
--- a/crates/formatter/src/presets.rs
+++ b/crates/formatter/src/presets.rs
@@ -333,7 +333,7 @@ const PINT_PRESET: FormatSettings = FormatSettings {
     space_after_decrement_unary_prefix_operator: false,
     space_after_additive_unary_prefix_operator: false,
     space_around_concatenation_binary_operator: false,
-    space_around_assignment_in_declare: true,
+    space_around_assignment_in_declare: false,
     space_within_grouping_parenthesis: true,
     empty_line_after_control_structure: false,
     empty_line_after_opening_tag: true,

--- a/crates/formatter/tests/cases/issue_974/after.php
+++ b/crates/formatter/tests/cases/issue_974/after.php
@@ -1,0 +1,3 @@
+<?php
+
+declare(strict_types=1);

--- a/crates/formatter/tests/cases/issue_974/before.php
+++ b/crates/formatter/tests/cases/issue_974/before.php
@@ -1,0 +1,3 @@
+<?php
+
+declare(strict_types = 1);

--- a/crates/formatter/tests/cases/issue_974/settings.inc
+++ b/crates/formatter/tests/cases/issue_974/settings.inc
@@ -1,0 +1,1 @@
+mago_formatter::presets::FormatterPreset::Pint.settings()

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -341,6 +341,7 @@ test_case!(issue_897_closure_brace_always_next_line);
 test_case!(issue_897_anonymous_class_brace_same_line);
 test_case!(issue_897_anonymous_class_brace_next_line);
 test_case!(issue_897_anonymous_class_brace_always_next_line);
+test_case!(issue_974);
 
 #[test]
 fn test_all_test_cases_are_ran() {


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes the pint formatter preset to produce `declare(strict_types=1)`, matching Laravel Pint's actual behavior.

## 🔍 Context & Motivation

The pint preset had `space_around_assignment_in_declare: true`, but Laravel Pint outputs `declare(strict_types=1)` without spaces. This mismatch caused files to be reformatted every time when using mago and pint together.

## 🛠️ Summary of Changes

- **Bug Fix:** Changed `space_around_assignment_in_declare` from `true` to `false` in `PINT_PRESET`.
- **Tests:** Added `issue_974` test case verifying that the pint preset formats `declare(strict_types = 1)` into `declare(strict_types=1)`.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Fixes carthage-software/mago#974

## 📝 Notes for Reviewers

The underlying merge logic issue (user overrides that match default values are ignored) affects all settings fields and is tracked in #1010.
