### PR TITLE
feat(linter): add a fixer for the braced-string-interpolation rule

### DIFF
--- a/crates/linter/src/rule/consistency/braced_string_interpolation.rs
+++ b/crates/linter/src/rule/consistency/braced_string_interpolation.rs
@@ -12,6 +12,7 @@ use mago_syntax::ast::Node;
 use mago_syntax::ast::NodeKind;
 use mago_syntax::ast::StringPart;
 use mago_syntax::ast::Variable;
+use mago_text_edit::TextEdit;
 
 use crate::category::Category;
 use crate::context::LintContext;
@@ -136,6 +137,11 @@ impl LintRule for BracedStringInterpolationRule {
         issue = issue.with_note("Using curly braces around variables in interpolated strings improves readability and prevents potential parsing issues.")
             .with_help("Wrap the variable in curly braces, e.g., `{$variable}`.");
 
-        ctx.collector.report(issue);
+        ctx.collector.propose(issue, |edits| {
+            for (span, _) in &unbraced_expressions {
+                edits.push(TextEdit::insert(span.start_offset(), "{"));
+                edits.push(TextEdit::insert(span.end_offset(), "}"));
+            }
+        });
     }
 }


### PR DESCRIPTION
## 📌 What Does This PR Do?

feat(linter): Add a fixer for the braced-string-interpolation rule

## 🔍 Context & Motivation

I had a metric ton of violations for this rule and no interest in manually fixing them.

## 🛠️ Summary of Changes

- **Feature:** Add a fixer for the braced-string-interpolation rule

## 📂 Affected Areas

- [x] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

nada

## 📝 Notes for Reviewers

:soap: 
