### PR TITLE
feat(analyzer): add PSR-11 container support via plugin

### DIFF
--- a/crates/analyzer/src/plugin/libraries/mod.rs
+++ b/crates/analyzer/src/plugin/libraries/mod.rs
@@ -1,14 +1,16 @@
-//! Library-specific providers for PHP stdlib, PSL, and Flow-PHP.
+//! Library-specific providers for PHP stdlib, PSL, Flow-PHP, and PSR-11 Container.
 
 pub mod flow_php;
 pub mod psl;
+pub mod psr_container;
 pub mod stdlib;
 
 use crate::plugin::Plugin;
 
 pub use flow_php::FlowPhpPlugin;
 pub use psl::PslPlugin;
+pub use psr_container::PsrContainerPlugin;
 pub use stdlib::StdlibPlugin;
 
 /// All available analyzer plugins.
-pub static ALL_PLUGINS: &[&dyn Plugin] = &[&StdlibPlugin, &PslPlugin, &FlowPhpPlugin];
+pub static ALL_PLUGINS: &[&dyn Plugin] = &[&StdlibPlugin, &PslPlugin, &FlowPhpPlugin, &PsrContainerPlugin];

--- a/crates/analyzer/src/plugin/libraries/psr_container/get.rs
+++ b/crates/analyzer/src/plugin/libraries/psr_container/get.rs
@@ -1,0 +1,64 @@
+//! `Psr\Container\ContainerInterface::get()` return type provider.
+
+use mago_codex::ttype::atomic::TAtomic;
+use mago_codex::ttype::atomic::object::TObject;
+use mago_codex::ttype::atomic::object::named::TNamedObject;
+use mago_codex::ttype::union::TUnion;
+
+use crate::plugin::context::InvocationInfo;
+use crate::plugin::context::ProviderContext;
+use crate::plugin::provider::Provider;
+use crate::plugin::provider::ProviderMeta;
+use crate::plugin::provider::method::MethodReturnTypeProvider;
+use crate::plugin::provider::method::MethodTarget;
+
+static META: ProviderMeta = ProviderMeta::new(
+    "psr::container::get",
+    "ContainerInterface::get",
+    "Returns the object type matching the class-string argument",
+);
+
+// Use wildcard for class since many classes implement ContainerInterface
+static TARGETS: [MethodTarget; 1] = [MethodTarget::any_class("get")];
+
+/// Provider for the `Psr\Container\ContainerInterface::get()` method.
+///
+/// When called with a class-string argument like `SomeService::class`,
+/// returns the object type of that class instead of `mixed`.
+#[derive(Default)]
+pub struct ContainerGetProvider;
+
+impl Provider for ContainerGetProvider {
+    fn meta() -> &'static ProviderMeta {
+        &META
+    }
+}
+
+impl MethodReturnTypeProvider for ContainerGetProvider {
+    fn targets() -> &'static [MethodTarget] {
+        &TARGETS
+    }
+
+    fn get_return_type(
+        &self,
+        context: &ProviderContext<'_, '_, '_>,
+        class_name: &str,
+        _method_name: &str,
+        invocation: &InvocationInfo<'_, '_, '_>,
+    ) -> Option<TUnion> {
+        // Only handle classes that implement ContainerInterface
+        if !context.is_instance_of(class_name, "Psr\\Container\\ContainerInterface") {
+            return None;
+        }
+
+        // Get the first argument (the service ID)
+        let id_arg = invocation.get_argument(0, &["id"])?;
+        let id_type = context.get_expression_type(id_arg)?;
+
+        // Extract class-string value (handles SomeClass::class)
+        let service_class = id_type.get_single_class_string_value()?;
+
+        // Return object type of that class
+        Some(TUnion::from_atomic(TAtomic::Object(TObject::Named(TNamedObject::new(service_class)))))
+    }
+}

--- a/crates/analyzer/src/plugin/libraries/psr_container/mod.rs
+++ b/crates/analyzer/src/plugin/libraries/psr_container/mod.rs
@@ -1,0 +1,30 @@
+//! PSR-11 Container providers.
+
+mod get;
+
+pub use get::ContainerGetProvider;
+
+use crate::plugin::Plugin;
+use crate::plugin::PluginMeta;
+use crate::plugin::PluginRegistry;
+
+/// Plugin providing type inference for psr/container interface.
+pub struct PsrContainerPlugin;
+
+static META: PluginMeta = PluginMeta::new(
+    "psr-container",
+    "PSR-11 Container",
+    "Type providers for PSR-11 container interface",
+    &["psr-11"],
+    false,
+);
+
+impl Plugin for PsrContainerPlugin {
+    fn meta(&self) -> &'static PluginMeta {
+        &META
+    }
+
+    fn register(&self, registry: &mut PluginRegistry) {
+        registry.register_method_provider(ContainerGetProvider);
+    }
+}

--- a/crates/analyzer/tests/cases/psr_container_get.php
+++ b/crates/analyzer/tests/cases/psr_container_get.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psr\Container;
+
+/**
+ * PSR-11 ContainerInterface stub for testing.
+ */
+interface ContainerInterface
+{
+    /**
+     * @param string $id
+     * @return mixed
+     */
+    public function get(string $id): mixed;
+
+    public function has(string $id): bool;
+}
+
+class Example
+{
+    public function doWork(): string
+    {
+        return 'working';
+    }
+}
+
+function accepts_example(Example $service): void
+{
+    $service->doWork();
+}
+
+function test_container_get(ContainerInterface $container): void
+{
+    $container->get(Example::class)
+        ->doWork();
+
+    $example = $container->get(Example::class);
+    accepts_example($example);
+}
+
+function test_non_class_string(ContainerInterface $container, string $serviceId): void
+{
+    /** @mago-expect analysis:mixed-argument */
+    accepts_example($container->get('some.service.id'));
+
+    /** @mago-expect analysis:mixed-method-access */
+    $container->get('some.service.id')->doWork();
+
+    /** @mago-expect analysis:mixed-argument */
+    accepts_example($container->get($serviceId));
+
+    /** @mago-expect analysis:mixed-method-access */
+    $container->get($serviceId)->doWork();
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -76,6 +76,7 @@ test_case!(non_empty_string_magic_constant);
 test_case!(numeric_reconciliation);
 test_case!(priority_queue_implementation);
 test_case!(psl_integration);
+test_case!(psr_container_get);
 test_case!(flow_php_integration);
 test_case!(reconcile_array_index_type);
 test_case!(reconcile_empty_string);

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -120,6 +120,7 @@ pub struct OrchestratorConfiguration<'a> {
     /// - `stdlib` (aliases: `standard`, `std`, `php-stdlib`)
     /// - `psl` (aliases: `php-standard-library`, `azjezz-psl`)
     /// - `flow-php` (aliases: `flow`, `flow-etl`)
+    /// - `psr-container` (aliases: `psr-11`)
     pub analyzer_plugins: Vec<String>,
 
     /// Whether to display progress bars during long-running operations.

--- a/docs/.vitepress/theme/components/playground/PlaygroundSettings.vue
+++ b/docs/.vitepress/theme/components/playground/PlaygroundSettings.vue
@@ -60,6 +60,12 @@ const availablePlugins = [
     description: 'Type providers for flow-php/etl package',
     defaultEnabled: false,
   },
+  {
+    id: 'psr-container',
+    name: 'PSR-11 Container',
+    description: 'Type providers for psr/container package',
+    defaultEnabled: false,
+  },
 ];
 
 const analyzerOptions = [

--- a/docs/tools/analyzer/configuration-reference.md
+++ b/docs/tools/analyzer/configuration-reference.md
@@ -68,8 +68,8 @@ These flags control specific, powerful analysis capabilities.
 
 These options control how the analyzer checks property initialization.
 
-| Option                           | Type       | Default | Description                                                                         |
-| :------------------------------- | :--------- | :------ | :---------------------------------------------------------------------------------- |
+| Option                           | Type       | Default | Description                                                                          |
+| :------------------------------- | :--------- | :------ | :----------------------------------------------------------------------------------- |
 | `check-property-initialization`  | `bool`     | `false` | Enable/disable property initialization checking entirely.                            |
 | `class-initializers`             | `string[]` | `[]`    | Method names treated as class initializers (like `__construct`).                     |
 
@@ -176,11 +176,12 @@ Plugins extend the analyzer with specialized type information for libraries and 
 
 ### Available plugins
 
-| Plugin ID   | Aliases                                    | Default | Description                                                    |
-| :---------- | :----------------------------------------- | :------ | :------------------------------------------------------------- |
-| `stdlib`    | `standard`, `std`, `php-stdlib`            | Enabled | Type providers for PHP built-in functions (`strlen`, `array_*`, `json_*`, etc.) |
-| `psl`       | `php-standard-library`, `azjezz-psl`       | Disabled| Type providers for [azjezz/psl](https://github.com/azjezz/psl) package |
-| `flow-php`  | `flow`, `flow-etl`                         | Disabled| Type providers for [flow-php/etl](https://github.com/flow-php/etl) package |
+| Plugin ID       | Aliases                                    | Default  | Description                                                                      |
+| :-------------- | :----------------------------------------- | :------- | :------------------------------------------------------------------------------- |
+| `stdlib`        | `standard`, `std`, `php-stdlib`            | Enabled  | Type providers for PHP built-in functions (`strlen`, `array_*`, `json_*`, etc.)  |
+| `psl`           | `php-standard-library`, `azjezz-psl`       | Disabled | Type providers for [azjezz/psl](https://github.com/azjezz/psl) package           |
+| `flow-php`      | `flow`, `flow-etl`                         | Disabled | Type providers for [flow-php/etl](https://github.com/flow-php/etl) package       |
+| `psr-container` | `psr-11`                                   | Disabled | Type providers for [psr/container](https://github.com/php-fig/container) package |
 
 ### How plugins work
 
@@ -207,7 +208,7 @@ By default, the `stdlib` plugin is enabled:
 
 ```toml
 [analyzer]
-plugins = ["psl", "flow-php"]
+plugins = ["psl", "flow-php", "psr-container"]
 ```
 
 #### Disabling all plugins

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -67,6 +67,8 @@ enum AnalyzerPlugin {
     Psl,
     /// Type providers for flow-php/etl package
     FlowPhp,
+    /// Type providers for psr/container package
+    PsrContainer,
 }
 
 impl std::fmt::Display for AnalyzerPlugin {
@@ -74,6 +76,7 @@ impl std::fmt::Display for AnalyzerPlugin {
         match self {
             Self::Psl => write!(f, "psl"),
             Self::FlowPhp => write!(f, "flow-php"),
+            Self::PsrContainer => write!(f, "psr-container"),
         }
     }
 }
@@ -84,6 +87,7 @@ impl AnalyzerPlugin {
         match self {
             Self::Psl => "PSL - Type providers for azjezz/psl package",
             Self::FlowPhp => "Flow-PHP - Type providers for flow-php/etl package",
+            Self::PsrContainer => "PSR-11 Container - Type providers for psr/container package",
         }
     }
 }
@@ -884,7 +888,7 @@ fn prompt_for_integrations(theme: &ColorfulTheme) -> Result<Vec<Integration>, Er
 }
 
 fn prompt_for_analyzer_plugins(theme: &ColorfulTheme) -> Result<Vec<AnalyzerPlugin>, Error> {
-    let items = &[AnalyzerPlugin::Psl, AnalyzerPlugin::FlowPhp];
+    let items = &[AnalyzerPlugin::Psl, AnalyzerPlugin::FlowPhp, AnalyzerPlugin::PsrContainer];
 
     let descriptions: Vec<&str> = items.iter().map(|p| p.description()).collect();
 
@@ -990,7 +994,7 @@ mod tests {
     #[test]
     fn test_generated_config_parses_with_all_options() {
         let settings = InitializationAnalyzerSettings {
-            plugins: vec![AnalyzerPlugin::Psl, AnalyzerPlugin::FlowPhp],
+            plugins: vec![AnalyzerPlugin::Psl, AnalyzerPlugin::FlowPhp, AnalyzerPlugin::PsrContainer],
             find_unused_definitions: true,
             find_unused_expressions: true,
             analyze_dead_code: true,
@@ -1097,12 +1101,15 @@ mod tests {
     fn test_analyzer_plugin_display() {
         assert_eq!(AnalyzerPlugin::Psl.to_string(), "psl");
         assert_eq!(AnalyzerPlugin::FlowPhp.to_string(), "flow-php");
+        assert_eq!(AnalyzerPlugin::PsrContainer.to_string(), "psr-container");
     }
 
     #[test]
     fn test_generated_config_with_analyzer_plugins() {
-        let settings =
-            InitializationAnalyzerSettings { plugins: vec![AnalyzerPlugin::Psl], ..create_default_analyzer_settings() };
+        let settings = InitializationAnalyzerSettings {
+            plugins: vec![AnalyzerPlugin::Psl, AnalyzerPlugin::PsrContainer],
+            ..create_default_analyzer_settings()
+        };
         let formatter_config = "[formatter]\nprint-width = 120\ntab-width = 4\nuse-tabs = false";
 
         let content = generate_config_content(
@@ -1115,7 +1122,7 @@ mod tests {
             &settings,
         );
 
-        assert!(content.contains(r#"plugins = ["psl"]"#));
+        assert!(content.contains(r#"plugins = ["psl", "psr-container"]"#));
 
         let result: Result<Configuration, _> = toml::from_str(&content);
         assert!(result.is_ok(), "Generated config should parse. Error: {:?}\n\nConfig:\n{}", result.err(), content);

--- a/src/config/analyzer.rs
+++ b/src/config/analyzer.rs
@@ -58,6 +58,7 @@ pub struct AnalyzerConfiguration {
     /// - `stdlib` (aliases: `standard`, `std`, `php-stdlib`)
     /// - `psl` (aliases: `php-standard-library`, `azjezz-psl`)
     /// - `flow-php` (aliases: `flow`, `flow-etl`)
+    /// - `psr-container` (aliases: `psr-11`)
     ///
     /// Example: `plugins = ["stdlib", "psl"]`
     pub plugins: Vec<String>,


### PR DESCRIPTION
## 📌 What Does This PR Do?

Adds PSR-11 container plugin that infers types from class-string arguments.

## 🔍 Context & Motivation

Our organization makes heavy use of the PSR-11 container composer package for dependency injection.

PSR standard: https://www.php-fig.org/psr/psr-11/
Composer package: https://packagist.org/packages/psr/container

As it stands, our code that uses this container does not infer the type from the class-string, which causes `mixed-method-access` and `mixed-argument` errors.

Playground: https://mago.carthage.software/playground#019c2137-03e0-23ac-7921-f8edaa7e77ae

## 🛠️ Summary of Changes

- **Feature:** Added PSR-11 container plugin to correctly infer from class strings for dependency injection.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [x] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [x] Documentation
- [x] Other (please specify): Analyzer, Playground

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
