### PR TITLE
feat(linter): add fixer for no-trailing-space

### DIFF
--- a/crates/linter/src/rule/consistency/no_trailing_space.rs
+++ b/crates/linter/src/rule/consistency/no_trailing_space.rs
@@ -10,6 +10,7 @@ use mago_span::HasSpan;
 use mago_span::Span;
 use mago_syntax::ast::Node;
 use mago_syntax::ast::NodeKind;
+use mago_text_edit::TextEdit;
 
 use crate::category::Category;
 use crate::context::LintContext;
@@ -119,7 +120,9 @@ impl LintRule for NoTrailingSpaceRule {
                         .with_note("Trailing whitespaces can cause unnecessary diffs and formatting issues.")
                         .with_help("Remove the extra whitespace.");
 
-                    ctx.collector.report(issue);
+                    ctx.collector.propose(issue, |edits| {
+                        edits.push(TextEdit::delete(whitespace_span));
+                    });
                 }
 
                 offset += line.len() + 1;


### PR DESCRIPTION
## 📌 What Does This PR Do?

Adds fixer for no-trailing-space

## 🔍 Context & Motivation

A ton of violations in a legacy code base in which we can't quite run `mago fmt` yet

## 🛠️ Summary of Changes

- **Feature:** Adds fixer for no-trailing-space rule

## 📂 Affected Areas

- [x] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

nope

## 📝 Notes for Reviewers

:white_check_mark: 
