### PR TITLE
fix(analyzer): detect `JSON_THROW_ON_ERROR` in bitwise OR flag expressions

### DIFF
--- a/crates/analyzer/src/plugin/libraries/stdlib/json/json_encode.rs
+++ b/crates/analyzer/src/plugin/libraries/stdlib/json/json_encode.rs
@@ -6,6 +6,9 @@ use mago_codex::ttype::atomic::scalar::bool::TBool;
 use mago_codex::ttype::atomic::scalar::string::TString;
 use mago_codex::ttype::get_non_empty_string;
 use mago_codex::ttype::union::TUnion;
+use mago_syntax::ast::Binary;
+use mago_syntax::ast::BinaryOperator;
+use mago_syntax::ast::Expression;
 
 use crate::plugin::context::InvocationInfo;
 use crate::plugin::context::ProviderContext;
@@ -47,9 +50,13 @@ impl FunctionReturnTypeProvider for JsonEncodeProvider {
     ) -> Option<TUnion> {
         let flags_argument = invocation.get_argument(1, &["flags"])?;
         let flags_type = context.get_expression_type(flags_argument)?;
-        let flags_value = flags_type.get_single_literal_int_value()?;
 
-        Some(if flags_value & JSON_THROW_ON_ERROR > 0 {
+        let throws = match flags_type.get_single_literal_int_value() {
+            Some(value) => value & JSON_THROW_ON_ERROR > 0,
+            None => flags_contain_throw_on_error(context, flags_argument),
+        };
+
+        Some(if throws {
             get_non_empty_string()
         } else {
             TUnion::from_vec(vec![
@@ -57,5 +64,18 @@ impl FunctionReturnTypeProvider for JsonEncodeProvider {
                 TAtomic::Scalar(TScalar::Bool(TBool::r#false())),
             ])
         })
+    }
+}
+
+fn flags_contain_throw_on_error(context: &ProviderContext<'_, '_, '_>, expr: &Expression<'_>) -> bool {
+    match expr {
+        Expression::Binary(Binary { lhs, operator: BinaryOperator::BitwiseOr(_), rhs }) => {
+            flags_contain_throw_on_error(context, lhs) || flags_contain_throw_on_error(context, rhs)
+        }
+        Expression::Parenthesized(parenthesized) => flags_contain_throw_on_error(context, parenthesized.expression),
+        _ => context
+            .get_expression_type(expr)
+            .and_then(|ty| ty.get_single_literal_int_value())
+            .is_some_and(|value| value & JSON_THROW_ON_ERROR > 0),
     }
 }

--- a/crates/analyzer/tests/cases/issue_886.php
+++ b/crates/analyzer/tests/cases/issue_886.php
@@ -1,0 +1,21 @@
+<?php
+
+function encodeOrThrowWithConstants(mixed $input): string {
+    return json_encode($input, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT);
+}
+
+function encodeOrThrowWithVariable(mixed $input, int $flags): string {
+    return json_encode($input, JSON_THROW_ON_ERROR | $flags);
+}
+
+function encodeOrThrowWithVariableFirst(mixed $input, int $flags): string {
+    return json_encode($input, $flags | JSON_THROW_ON_ERROR);
+}
+
+function encodeOrThrowWithNumericLiteral(mixed $input, int $flags): string {
+    return json_encode($input, $flags | 4194304);
+}
+
+function encodeWithUnknownFlags(mixed $input, int $flags): string|false {
+    return json_encode($input, $flags);
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -547,6 +547,7 @@ test_case!(issue_870);
 test_case!(issue_871);
 test_case!(issue_872);
 test_case!(issue_880);
+test_case!(issue_886);
 test_case!(issue_900);
 test_case!(issue_912);
 test_case!(issue_923);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes false positives from `json_encode()` when `JSON_THROW_ON_ERROR` is combined with other flags via bitwise OR.

## 🔍 Context & Motivation

```php
// False positive: inferred string|false, but should be non-empty-string
function encode(mixed $v, int $flags): string {
    return json_encode($v, JSON_THROW_ON_ERROR | $flags);
}
```

The type of `JSON_THROW_ON_ERROR | $flags` becomes `Literal | Unspecified → Unspecified`, losing the literal value and making `JSON_THROW_ON_ERROR` undetectable.

## 🛠️ Summary of Changes

- **Bug Fix:** Added fallback that recursively walks the flags expression tree and checks each sub-expression's type for `JSON_THROW_ON_ERROR`.
- **Tests:** Added `issue_886.php` covering bitwise OR with constants, variables, numeric literals, and unknown-flags baseline.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Analyzer

## 🔗 Related Issues or PRs

Fixes carthage-software/mago#886

## 📝 Notes for Reviewers

The fix inspects sub-expression types rather than comparing constant names, so it handles fully-qualified names, aliases, and numeric literals (`4194304 | $flags`) without special-casing.
