### PR TITLE
feat(analyzer): return literal types for enum name and value properties

### DIFF
--- a/crates/analyzer/src/expression/access/property_access.rs
+++ b/crates/analyzer/src/expression/access/property_access.rs
@@ -250,7 +250,7 @@ mod tests {
     }
 
     test_analysis! {
-        name = accessing_enum_properties,
+        name = accessing_string_enum_properties,
         code = indoc! {r"
             <?php
 
@@ -272,6 +272,88 @@ mod tests {
              */
             function get_color_value(Color $color): string {
                 return $color->value;
+            }
+
+            /**
+             * @return 'Red'
+             */
+            function get_specific_case_name(): string {
+                return Color::Red->name;
+            }
+
+            /**
+             * @return 'red'
+             */
+            function get_specific_case_value(): string {
+                return Color::Red->value;
+            }
+        "}
+    }
+
+    test_analysis! {
+        name = accessing_int_enum_properties,
+        code = indoc! {r"
+            <?php
+
+            enum Color: int {
+                case Red = 0;
+                case Green = 1;
+                case Blue = 2;
+            }
+
+            /**
+             * @return 'Red'|'Green'|'Blue'
+             */
+            function get_color_name(Color $color): string {
+                return $color->name;
+            }
+
+            /**
+             * @return 0|1|2
+             */
+            function get_color_value(Color $color): int {
+                return $color->value;
+            }
+
+            /**
+             * @return 'Red'
+             */
+            function get_specific_case_name(): string {
+                return Color::Red->name;
+            }
+
+            /**
+             * @return 0
+             */
+            function get_specific_case_value(): int {
+                return Color::Red->value;
+            }
+        "}
+    }
+
+    test_analysis! {
+        name = accessing_enum_properties,
+        code = indoc! {r"
+            <?php
+
+            enum Color {
+                case Red;
+                case Green;
+                case Blue;
+            }
+
+            /**
+             * @return 'Red'|'Green'|'Blue'
+             */
+            function get_color_name(Color $color): string {
+                return $color->name;
+            }
+
+            /**
+             * @return 'Red'
+             */
+            function get_specific_case_name(): string {
+                return Color::Red->name;
             }
         "}
     }


### PR DESCRIPTION


## 📌 What Does This PR Do?
  When accessing `->name` or `->value` on an enum, the analyzer now returns
  literal types instead of generic `string` or `int|string`:

  - `Foo::Bar->name` returns `'Bar'` instead of `string`
  - `Foo::Bar->value` returns `'bar'` or `123` instead of `int|string`
  - `$color->name` (where `$color: Color`) returns `'Red'|'Green'|'Blue'`



```php
<?php
declare(strict_types=1);

enum Foo : string {
    case Bar = 'bar';
    case Baz = 'baz';
} 

$x = [
    Foo::Bar->value => 'bar',
    Foo::Bar->name => 'Bar',
];


Mago\inspect($x);
Mago\inspect($x[Foo::Bar->name]);
```

## 🔍 Context & Motivation


## 🛠️ Summary of Changes

- **Feature:** Return literal types for enum name and value properties.

## 📂 Affected Areas

- [X] Analyzer
- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

- Closes #952


## 📝 Notes for Reviewers

It's my first PR. Be gentle :)
