### PR TITLE
fix(formatter): Do not add a line break at the end of an empty array

### DIFF
--- a/crates/formatter/src/internal/format/array.rs
+++ b/crates/formatter/src/internal/format/array.rs
@@ -135,8 +135,6 @@ pub(super) fn print_array_like<'arena>(
     if elements.is_empty() {
         if let Some(dangling_comments) = f.print_dangling_comments(array_like.span(), true) {
             parts.push(dangling_comments);
-        } else {
-            parts.push(Document::Line(Line::soft()));
         }
 
         parts.push(get_right_delimiter(f, &array_like));

--- a/crates/formatter/tests/cases/issue_978/after.php
+++ b/crates/formatter/tests/cases/issue_978/after.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+class A
+{
+    private function a()
+    {
+        $veryVeryVeryVeryLongVariableName = $this->entityManager->getRepository(VeryVeryVeryLongEntityName::class)->findOneBy([], [
+            'id' => 'desc',
+        ]);
+    }
+}

--- a/crates/formatter/tests/cases/issue_978/before.php
+++ b/crates/formatter/tests/cases/issue_978/before.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+class A
+{
+    private function a()
+    {
+        $veryVeryVeryVeryLongVariableName = $this
+            ->entityManager
+            ->getRepository(VeryVeryVeryLongEntityName::class)
+            ->findOneBy([], ['id' => 'desc']);
+    }
+}

--- a/crates/formatter/tests/cases/issue_978/settings.inc
+++ b/crates/formatter/tests/cases/issue_978/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings::default()

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -343,6 +343,7 @@ test_case!(issue_897_anonymous_class_brace_next_line);
 test_case!(issue_897_anonymous_class_brace_always_next_line);
 test_case!(issue_974);
 test_case!(issue_994);
+test_case!(issue_978);
 
 #[test]
 fn test_all_test_cases_are_ran() {


### PR DESCRIPTION
## 📌 What Does This PR Do?

See #978 and the test case  (crates/formatter/tests/cases/issue_978/before.php) in the playground and press format for example https://mago.carthage.software/playground#019c32f3-eb2a-0cf0-e88b-b5022d43aaa5 

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Fixes #978 