### PR TITLE
fix(prelude): fix generic templates of `array_walk`

### DIFF
--- a/crates/analyzer/tests/cases/issue_1045.php
+++ b/crates/analyzer/tests/cases/issue_1045.php
@@ -14,6 +14,17 @@ function multiply_by(array $integers, int|float $by): array
 }
 
 /**
+ * @param array<string, int> $integers
+ * @return array<string, string>
+ */
+function multiply_assoc_by(array $integers, int|float $by): array
+{
+    array_walk($integers, fn(int $value, string $key, int|float $x): string => 'The value of ' . $key . ' is: ' . ($value * $x), $by);
+
+    return $integers;
+}
+
+/**
  * @param non-empty-list<int> $integers
  * @return non-empty-list<int>
  */

--- a/crates/prelude/assets/extensions/standard.php
+++ b/crates/prelude/assets/extensions/standard.php
@@ -5544,7 +5544,7 @@ function metaphone(string $string, int $max_phonemes = 0): string
  * @template O
  *
  * @param object|array<K, V> $array
- * @param (callable(V, T): O) $callback
+ * @param (callable(V, K, T): O) $callback
  * @param T|null $arg
  *
  * @param-out ($array is object ? object : (


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes the generic templates on `array_walk()`.

## 🔍 Context & Motivation

The generic template is slightly wrong. The second argument of the callback should be the key/index, not the optional third argument of `array_walk`.

## 📂 Affected Areas

- [x] Analyzer
- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

https://github.com/carthage-software/mago/commit/45a8ab4c992d3c2dadf759183870aa6057b916a1

_This is my first PR, hope I did everything by the book 😅_