### PR TITLE
fix(analyzer): suppress redundant-type-comparison for unconditional psalm-assert

### DIFF
--- a/crates/analyzer/tests/cases/issue_831.php
+++ b/crates/analyzer/tests/cases/issue_831.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @psalm-assert non-empty-string $value
+ *
+ * @throws InvalidArgumentException
+ */
+function assert_non_empty_string(mixed $value): void
+{
+    if (!is_string($value) || $value === '') {
+        throw new InvalidArgumentException('Expected non-empty string');
+    }
+}
+
+/**
+ * @psalm-assert !null $value
+ *
+ * @throws InvalidArgumentException
+ */
+function assert_non_null_831(mixed $value): void
+{
+    if ($value === null) {
+        throw new InvalidArgumentException('Value cannot be null');
+    }
+}
+
+/**
+ * @return non-empty-string
+ */
+function get_field(): string
+{
+    return 'field_name';
+}
+
+class SomeEntity
+{
+}
+
+function create_entity(): SomeEntity
+{
+    return new SomeEntity();
+}
+
+/**
+ * @throws InvalidArgumentException
+ */
+function test_unconditional_assert_not_redundant(): void
+{
+    $field = get_field();
+    // $field is already non-empty-string, but assert_non_empty_string() does runtime validation.
+    // So this is NOT redundant.
+    assert_non_empty_string($field);
+
+    $entity = create_entity();
+    // $entity is already SomeEntity(not null), but runtime guard is intentional.
+    assert_non_null_831($entity);
+}

--- a/crates/analyzer/tests/cases/redundant_assert.php
+++ b/crates/analyzer/tests/cases/redundant_assert.php
@@ -36,5 +36,5 @@ function process_value(null|int $value): int
 function other(): void
 {
     $instance = create_some_instance();
-    assert_not_null($instance); // @mago-expect analysis:redundant-type-comparison
+    assert_not_null($instance);
 }

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -547,6 +547,7 @@ test_case!(issue_806);
 test_case!(issue_809);
 test_case!(issue_822);
 test_case!(issue_830);
+test_case!(issue_831);
 test_case!(issue_835);
 test_case!(issue_837);
 test_case!(issue_845);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Suppresses false positive `redundant-type-comparison` warnings for unconditional `@psalm-assert` annotations.

## 🔍 Context & Motivation

`@psalm-assert` describes the type-narrowing side effect of a function, not its full behavior. The annotated function may perform runtime validation beyond what the type system captures:

```php
/** @psalm-assert non-empty-string $value */
function assertNonEmptyString(mixed $value): void {
    if (!is_string($value) || $value === '') {
        throw new InvalidArgumentException('...');
    }
}

$field = getField(); // non-empty-string
assertNonEmptyString($field); // false positive: "Redundant type assertion"
```

The current suggestion "Consider removing this assertion" would remove the runtime safety guard. Conditional assertions (`@psalm-assert-if-true`/`if-false`) are unaffected — their redundancy warnings remain useful for detecting dead branches.

## 🛠️ Summary of Changes

- **Bug Fix:** Added `report_redundancy` parameter to `resolve_invocation_assertion()`, set to `false` for unconditional assertions and `true` for conditional ones.
- **Tests:** Added `issue_831.php` test case and updated `redundant_assert.php` to reflect the new behavior.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Analyzer

## 🔗 Related Issues or PRs

Fixes carthage-software/mago#831

## 📝 Notes for Reviewers

`ImpossibleTypeComparison` is intentionally preserved for unconditional assertions — calling `@psalm-assert Bar $value` with a `Foo` argument is a genuine bug.
