### PR TITLE
chore(prelude): improve `bin2hex` stubs

### DIFF
--- a/crates/analyzer/tests/cases/bin2hex.php
+++ b/crates/analyzer/tests/cases/bin2hex.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @return non-empty-string
+ */
+function test_non_empty_bin2hex(): string
+{
+    return bin2hex('a');
+}
+
+/**
+ * @return ''
+ */
+function test_empty_bin2hex(): string
+{
+    return bin2hex('');
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -44,6 +44,7 @@ test_case!(array_unique_non_empty);
 test_case!(assert_concrete_to_template_type);
 test_case!(assert_generic_array_key_is_array_key);
 test_case!(bare_identifier_in_array_access);
+test_case!(bin2hex);
 test_case!(break_narrowing);
 test_case!(by_reference_invalidation);
 test_case!(callable_template_inference);

--- a/crates/prelude/assets/extensions/standard.php
+++ b/crates/prelude/assets/extensions/standard.php
@@ -1017,6 +1017,8 @@ function constant(string $name): mixed {}
 
 /**
  * @pure
+ * 
+ * @return ($string is non-empty-string ? non-empty-string : '')
  */
 function bin2hex(string $string): string {}
 


### PR DESCRIPTION
## 📌 What Does This PR Do?

Improves bin2hex stubs (in a similar way as psalm)

## 🔍 Context & Motivation

It is not strict enought

## 🛠️ Summary of Changes

```php
bin2hex('') -> literal('')
bin2hex('a') -> non-empty-string
```

## 📂 Affected Areas

- [ ] Analyzer
- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
