### PR TITLE
fix(codex): treat `never` as subtype of all types in `extends_or_implements`

### DIFF
--- a/crates/analyzer/tests/cases/issue_1107.php
+++ b/crates/analyzer/tests/cases/issue_1107.php
@@ -1,0 +1,36 @@
+<?php
+
+class AppException extends \Exception
+{
+    /**
+     * @throws AppException
+     */
+    public static function create(string $message): never
+    {
+        throw new self($message);
+    }
+}
+
+/**
+ * @throws \RuntimeException
+ */
+function always_throws(): never
+{
+    throw new \RuntimeException('always');
+}
+
+/**
+ * @throws AppException
+ */
+function test_throw_never_static_method(): void
+{
+    throw AppException::create('error');
+}
+
+/**
+ * @throws \RuntimeException
+ */
+function test_throw_never_function(): void
+{
+    throw always_throws();
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -626,6 +626,7 @@ test_case!(issue_1089);
 test_case!(issue_1096);
 test_case!(issue_1099);
 test_case!(issue_1103);
+test_case!(issue_1107);
 
 #[test]
 fn test_all_test_cases_are_ran() {

--- a/crates/codex/src/ttype/atomic/mod.rs
+++ b/crates/codex/src/ttype/atomic/mod.rs
@@ -347,6 +347,8 @@ impl TAtomic {
 
                 return false;
             }
+            // bottom type: subtype of all types
+            TAtomic::Never => return true,
             _ => return false,
         };
 


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes a false positive `invalid-throw` when a `throw` statement uses the return value of a function declared as returning `never`. Per the [PHP RFC](https://wiki.php.net/rfc/noreturn_type), `never` is a bottom type — a subtype of every other type, including `Throwable`.

```php
class AppException extends \Exception
{
    public static function create(string $message): never
    {
        throw new self($message);
    }
}

// Previously reported: invalid-throw
throw AppException::create('error');
```

## 🛠️ Summary of Changes

- Add `TAtomic::Never => return true` to `extends_or_implements` in `mago-codex`, so the bottom type is recognized as a subtype of any interface
- Add test case covering `throw` with `never`-returning functions and static methods

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Codex (type system), Analyzer (test)

## 🔗 Related Issues or PRs

Fixes #1107

## 📝 Notes for Reviewers

The fix is in `extends_or_implements` rather than the throw-specific code, so it affects all call sites. Each was verified to be correct since `never` can never exist at runtime:

- [`is_countable`](https://github.com/carthage-software/mago/blob/1607cbbdd866614facc47ee198ff2bb2f4cd9a63/crates/codex/src/ttype/atomic/mod.rs#L378) — `Countable` check
- [`is_traversable`](https://github.com/carthage-software/mago/blob/1607cbbdd866614facc47ee198ff2bb2f4cd9a63/crates/codex/src/ttype/atomic/mod.rs#L393) — `Traversable`/`Iterator`/`IteratorAggregate`/`Generator` check
- [`analyze_destructure_assignment`](https://github.com/carthage-software/mago/blob/1607cbbdd866614facc47ee198ff2bb2f4cd9a63/crates/analyzer/src/expression/assignment/mod.rs#L639) — `ArrayAccess` check
- [`TUnion::extends_or_implements`](https://github.com/carthage-software/mago/blob/1607cbbdd866614facc47ee198ff2bb2f4cd9a63/crates/codex/src/ttype/union.rs#L747) — delegates to the atomic version
