### PR TITLE
fix(composer): add function stubs for runtime compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,10 @@
   "autoload": {
     "psr-4": {
       "Mago\\": "composer/"
-    }
+    },
+    "files": [
+      "composer/functions.php"
+    ]
   },
   "require": {
     "php": "~8.1 || ~8.2 || ~8.3 || ~8.4 || ~8.5 || ~8.6",

--- a/composer/functions.php
+++ b/composer/functions.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mago;
+
+if (!\function_exists('Mago\inspect')) {
+    /**
+     * @mago-ignore analysis:unused-parameter
+     *
+     * Inspect the type of the given value.
+     *
+     * This function is used for debugging purposes to output the type of a variable.
+     *
+     * @param mixed ...$value The value(s) whose type(s) will be dumped.
+     *
+     * @return void This function does not return a value.
+     */
+    function inspect(mixed ...$value): void {}
+}
+
+if (!\function_exists('Mago\confirm')) {
+    /**
+     * @mago-ignore analysis:unused-parameter
+     *
+     * Confirms that the given value is of the specified type statically.
+     *
+     * This function is used to ensure that the value conforms to the expected type
+     * during static analysis. It does not perform any runtime checks or throw exceptions.
+     *
+     * @param mixed $value The value to check.
+     * @param literal-string $type The expected type of the value.
+     *
+     * @return void This function does not return a value.
+     */
+    function confirm(mixed $value, string $type): void {}
+}


### PR DESCRIPTION
## 📌 What Does This PR Do?

Add stub implementations of Mago's inspect() and confirm() functions through Composer's files autoloader. These functions are used for static analysis but need to exist at runtime to prevent undefined function errors when code is executed outside of Mago's analyzer.

The stubs are no-op implementations that allow user code containing Mago\inspect() and Mago\confirm() calls to run without breaking.

## 🛠️ Summary of Changes

- **Feature:** Make mago internal stubs autoloadable so that they can be autocompleted by IDEs and don't crash in runtime.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [x] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
