### PR TITLE
feat(linter): highlight which code was not matched in mago-{ignore,expect}

### DIFF
--- a/crates/collector/src/lib.rs
+++ b/crates/collector/src/lib.rs
@@ -360,6 +360,7 @@ impl<'ctx, 'arena> Collector<'ctx, 'arena> {
                                 Annotation::primary(pragma.span)
                                     .with_message("This ignore pragma does not match any reported issue."),
                             )
+                            .with_annotation(Annotation::secondary(pragma.code_span).with_message("...for this code"))
                             .with_annotation(
                                 Annotation::secondary(pragma.trivia_span).with_message("...within this comment."),
                             ),
@@ -378,6 +379,7 @@ impl<'ctx, 'arena> Collector<'ctx, 'arena> {
                             .with_annotation(
                                 Annotation::primary(pragma.span).with_message("This expect pragma was not fulfilled."),
                             )
+                            .with_annotation(Annotation::secondary(pragma.code_span).with_message("...for this code"))
                             .with_annotation(
                                 Annotation::secondary(pragma.trivia_span).with_message("...within this comment."),
                             ),


### PR DESCRIPTION
## 📌 What Does This PR Do?

Improves the linter output for unused pragmas by highlighting the exact code that is unused

## 🔍 Context & Motivation

With pragmas that specify multiple codes, one is currently clueless as to which code is affected.

## 🛠️ Summary of Changes

- **Feature:** Added highlighting for the exact code missing in mago-ignore/mago-expect

## 📂 Affected Areas

- [x] Linter

## 🔗 Related Issues or PRs

discord

## 📝 Notes for Reviewers

Go Go Power Rangers!
