### PR TITLE
fix(formatter): account for indentation with print-width

### DIFF
--- a/crates/formatter/tests/cases/issue_993_print_width_with_indentation/after.php
+++ b/crates/formatter/tests/cases/issue_993_print_width_with_indentation/after.php
@@ -1,0 +1,73 @@
+<?php
+
+final readonly class OrderPlacedWorkflow
+{
+    public function waitForFulfillment(InFulfillment $event): void
+    {
+        $this->parcelService->createFromShipment(
+            $event->order->getShipmentEntityId(),
+        );
+
+        $dto->setMarket(
+            $this->marketConfig->getByType(
+                $dto->shippingMethodType->getMarketType(),
+            ),
+        );
+        $dto->setShippingZone(
+            $this->shippingZoneConfig->getByType(
+                $dto->shippingMethodType->getShippingZoneType(),
+            ),
+        );
+
+        if (true) {
+            $this->parcelService->createFromShipment(
+                $event->order->getShipmentEntityId(),
+            );
+            if (true) {
+                $this->parcelService->createFromShipment(
+                    $event->order->getShipmentEntityId(),
+                );
+                if (true) {
+                    $this->parcelService->createFromShipment(
+                        $event->order->getShipmentEntityId(),
+                    );
+                    if (true) {
+                        $this->parcelService->createFromShipment(
+                            $event->order->getShipmentEntityId(),
+                        );
+                        if (true) {
+                            $this->parcelService->createFromShipment(
+                                $event->order->getShipmentEntityId(),
+                            );
+                            if (true) {
+                                $this->parcelService->createFromShipment(
+                                    $event->order->getShipmentEntityId(),
+                                );
+                                if (true) {
+                                    $this->parcelService->createFromShipment(
+                                        $event->order->getShipmentEntityId(),
+                                    );
+                                    if (true) {
+                                        $this->parcelService->createFromShipment(
+                                            $event->order->getShipmentEntityId(),
+                                        );
+                                        if (true) {
+                                            $this->parcelService->createFromShipment(
+                                                $event->order->getShipmentEntityId(),
+                                            );
+                                            if (true) {
+                                                $this->parcelService->createFromShipment(
+                                                    $event->order->getShipmentEntityId(),
+                                                );
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/formatter/tests/cases/issue_993_print_width_with_indentation/before.php
+++ b/crates/formatter/tests/cases/issue_993_print_width_with_indentation/before.php
@@ -1,0 +1,43 @@
+<?php
+
+final readonly class OrderPlacedWorkflow
+{
+    public function waitForFulfillment(InFulfillment $event): void
+    {
+        $this->parcelService->createFromShipment($event->order->getShipmentEntityId());
+
+        $dto->setMarket($this->marketConfig->getByType($dto->shippingMethodType->getMarketType()));
+        $dto->setShippingZone($this->shippingZoneConfig->getByType($dto->shippingMethodType->getShippingZoneType()));
+
+        if (true) {
+            $this->parcelService->createFromShipment($event->order->getShipmentEntityId());
+            if (true) {
+                $this->parcelService->createFromShipment($event->order->getShipmentEntityId());
+                if (true) {
+                    $this->parcelService->createFromShipment($event->order->getShipmentEntityId());
+                    if (true) {
+                        $this->parcelService->createFromShipment($event->order->getShipmentEntityId());
+                        if (true) {
+                            $this->parcelService->createFromShipment($event->order->getShipmentEntityId());
+                            if (true) {
+                                $this->parcelService->createFromShipment($event->order->getShipmentEntityId());
+                                if (true) {
+                                    $this->parcelService->createFromShipment($event->order->getShipmentEntityId());
+                                    if (true) {
+                                        $this->parcelService->createFromShipment($event->order->getShipmentEntityId());
+                                        if (true) {
+                                            $this->parcelService->createFromShipment($event->order->getShipmentEntityId());
+                                            if (true) {
+                                                $this->parcelService->createFromShipment($event->order->getShipmentEntityId());
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/formatter/tests/cases/issue_993_print_width_with_indentation/settings.inc
+++ b/crates/formatter/tests/cases/issue_993_print_width_with_indentation/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings { print_width: 80, ..Default::default() }

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -348,6 +348,7 @@ test_case!(issue_994);
 test_case!(issue_978);
 test_case!(issue_1082);
 test_case!(issue_1091);
+test_case!(issue_993_print_width_with_indentation);
 
 #[test]
 fn test_all_test_cases_are_ran() {


### PR DESCRIPTION
## 📌 What Does This PR Do?
See issue

## 🛠️ Summary of Changes

Calls whose single argument is a zero-arg call (like `foo(bar())`) were being "hugged" and inlined, preventing them from breaking even when indentation pushed them past `print_width`.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Fix #993 

## 📝 Notes for Reviewers
I'm not sure of the fixes; I tried a bunch of fixes before
