### PR TITLE
fix(linter): fix `no-trailing-space` fixer panic on CRLF files with multibyte characters

### DIFF
--- a/crates/linter/src/rule/consistency/no_trailing_space.rs
+++ b/crates/linter/src/rule/consistency/no_trailing_space.rs
@@ -93,10 +93,10 @@ impl LintRule for NoTrailingSpaceRule {
             }
 
             let comment_span = trivia.span();
-            let lines = trivia.value.lines().collect::<Vec<_>>();
+            let value = trivia.value;
 
-            let mut offset = 0;
-            for line in &lines {
+            for line in value.lines() {
+                let offset = (line.as_ptr() as usize) - (value.as_ptr() as usize);
                 let trimmed = line.trim_end();
                 let trimmed_length = trimmed.len();
                 let trailing_whitespace_length = line.len() - trimmed_length;
@@ -124,8 +124,6 @@ impl LintRule for NoTrailingSpaceRule {
                         edits.push(TextEdit::delete(whitespace_span));
                     });
                 }
-
-                offset += line.len() + 1;
             }
         }
     }

--- a/crates/linter/tests/no_trailing_space.rs
+++ b/crates/linter/tests/no_trailing_space.rs
@@ -1,0 +1,43 @@
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use bumpalo::Bump;
+use mago_database::file::File;
+use mago_linter::Linter;
+use mago_linter::registry::RuleRegistry;
+use mago_linter::settings::Settings;
+use mago_names::resolver::NameResolver;
+use mago_syntax::parser::parse_file;
+use mago_text_edit::TextEditor;
+
+fn lint_and_fix(code: &str) -> String {
+    let arena = Bump::new();
+    let file = File::ephemeral(Cow::Owned("test.php".to_string()), Cow::Owned(code.to_string()));
+    let program = parse_file(&arena, &file);
+
+    let resolver = NameResolver::new(&arena);
+    let resolved_names = resolver.resolve(program);
+
+    let settings = Settings::default();
+    let registry = RuleRegistry::build(&settings, Some(&["no-trailing-space".to_string()]), true);
+    let linter = Linter::from_registry(&arena, Arc::new(registry), settings.php_version);
+    let mut issues = linter.lint(&file, program, &resolved_names);
+
+    let mut editor = TextEditor::new(code);
+    for (_, edits) in issues.take_edits() {
+        for edit in edits {
+            editor.apply(edit, None::<fn(&str) -> bool>);
+        }
+    }
+
+    editor.finish()
+}
+
+#[test]
+fn test_fix_with_crlf_multibyte() {
+    let input = "<?php\r\n\r\n/**\r\n * あ \r\n */\r\n";
+    let expected = "<?php\r\n\r\n/**\r\n * あ\r\n */\r\n";
+
+    let result = lint_and_fix(input);
+    assert_eq!(result, expected);
+}


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes a panic in the `no-trailing-space` fixer when applying fixes to CRLF files containing multibyte characters with trailing whitespace in comments.

## 🔍 Context & Motivation

The offset calculation used `offset += line.len() + 1`, assuming `\n` (1 byte) line endings. `str::lines()` strips both `\r\n` and `\n`, so on CRLF files the offset drifts by 1 byte per line, eventually pointing inside a multibyte UTF-8 character:

```
$ printf '<?php\r\n\r\n/**\r\n * 更新日時 \r\n */\r\n' > test.php
$ mago lint --fix test.php
thread 'main' panicked at crates/text-edit/src/lib.rs:405:38:
byte index 28 is not a char boundary; it is inside '時' (bytes 26..29)
```

## 🛠️ Summary of Changes

- **Bug Fix:** Replaced manual offset accumulation with pointer arithmetic (`line.as_ptr() - value.as_ptr()`), matching the existing pattern in `comments/mod.rs`.
- **Tests:** Added an integration test verifying CRLF + multibyte fix application.

## 📂 Affected Areas

- [x] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Related to #971 (same class of UTF-8 boundary panic)
