### PR TITLE
fix(codex): handle unknown classes in type identity comparison

### DIFF
--- a/crates/analyzer/tests/cases/instanceof_unresolved_class.php
+++ b/crates/analyzer/tests/cases/instanceof_unresolved_class.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+class Foo {}
+class Bar {}
+
+function known_interface(\Throwable $e): void {
+    if ($e instanceof \RuntimeException) {}
+}
+
+function incompatible_classes(Foo $e): void {
+    if ($e instanceof Bar) {} // @mago-expect analysis:impossible-condition
+}
+
+function unresolved_rhs(Foo $e): void {
+    if ($e instanceof \Vendor\Package\SomeException) {}
+}
+
+function catch_unresolved(): void {
+    try {
+        throw new \Exception("test");
+    } catch (\Throwable $e) {
+        if ($e instanceof \Vendor\Package\SomeException) {}
+    }
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -348,6 +348,7 @@ test_case!(enum_empty_check);
 test_case!(optional_chain_method);
 test_case!(compound_condition);
 test_case!(instanceof_assertion);
+test_case!(instanceof_unresolved_class);
 test_case!(type_narrowing_external);
 test_case!(post_narrowing_check);
 test_case!(data_transformer_type);

--- a/crates/codex/src/ttype/comparator/atomic_comparator.rs
+++ b/crates/codex/src/ttype/comparator/atomic_comparator.rs
@@ -14,6 +14,7 @@ use crate::ttype::atomic::mixed::TMixed;
 use crate::ttype::atomic::object::TObject;
 use crate::ttype::atomic::object::r#enum::TEnum;
 use crate::ttype::atomic::object::named::TNamedObject;
+use crate::ttype::atomic::reference::TReference;
 use crate::ttype::atomic::scalar::TScalar;
 use crate::ttype::comparator::ComparisonResult;
 use crate::ttype::comparator::array_comparator;
@@ -744,9 +745,21 @@ pub(crate) fn can_be_identical<'a>(
 
     if let (TAtomic::Object(first_object), TAtomic::Object(second_object)) = (first_part, second_part)
         && let (Some(first_name), Some(second_name)) = (first_object.get_name(), second_object.get_name())
-        && let (Some(c1), Some(c2)) = (codebase.get_class_like(first_name), codebase.get_class_like(second_name))
-        && (c1.kind.is_interface() || c2.kind.is_interface())
     {
+        return match (codebase.get_class_like(first_name), codebase.get_class_like(second_name)) {
+            (Some(c1), Some(c2)) => c1.kind.is_interface() || c2.kind.is_interface(),
+            _ => true,
+        };
+    }
+
+    if matches!(
+        (first_part, second_part),
+        (TAtomic::Object(_), TAtomic::Reference(TReference::Symbol { .. }))
+            | (
+                TAtomic::Reference(TReference::Symbol { .. }),
+                TAtomic::Object(_) | TAtomic::Reference(TReference::Symbol { .. })
+            )
+    ) {
         return true;
     }
 


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes a false positive `impossible-condition` when `instanceof` references a class not in the codebase metadata (e.g. an unscanned third-party class).

[Playground reproduction](https://mago.carthage.software/playground#019c61d4-8853-75b8-2c62-ec76f7422e15)

```php
function handle(\Throwable $e): void {
    if ($e instanceof \Vendor\Package\SomeException) { ... }
    // Previously: warning[impossible-condition]: type `false` always evaluates to false
    // After this PR: no diagnostic
}
```

## 🔍 Context & Motivation

`can_be_identical` required both classes to be in the codebase to check if either is an interface. If one was missing, it fell through to `false`, causing `compute_instanceof_type` to return `false` — triggering `impossible-condition`. "Not in the codebase" does not mean "does not exist at runtime." Both PHPStan and Psalm only report "class not found" for the unresolved class, without cascading it into a dead-code diagnostic.

## 🛠️ Summary of Changes

Two cases at the end of `can_be_identical` now conservatively return `true` instead of falling through to `false`:

1. **`(Object::Named, Object::Named)` — one/both missing from codebase**: `get_class_like` lookup now uses a `match`; both-known preserves the existing interface check, one-or-both-unknown returns `true`.
2. **`(TReference::Symbol, Object | Symbol)` / `(Object, TReference::Symbol)`**: Unresolved classes in type hints remain as `TReference::Symbol` and had no handling. Now explicitly returns `true`.

## 📂 Affected Areas

- [x] Analyzer
- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

<!-- N/A — self-discovered via dogfooding -->

## 📝 Notes for Reviewers

The CLI does not report `non-existent-class-like` for `instanceof` RHS (PHPStan reports `class.notFound`, Psalm reports `UndefinedClass` there). This is a pre-existing gap unrelated to this PR.
