### PR TITLE
fix(analyzer): fix detection of possibly undefined keys in unions of sealed/unsealed arrays

### DIFF
--- a/crates/analyzer/src/utils/expression/array.rs
+++ b/crates/analyzer/src/utils/expression/array.rs
@@ -732,11 +732,15 @@ pub(crate) fn handle_array_access_on_keyed_array<'ctx>(
                 let key_exists_in_other_variant = if array_like_type.types.len() > 1 {
                     array_like_type.types.iter().any(|atomic_type| {
                         if let TAtomic::Array(TArray::Keyed(other_keyed)) = atomic_type {
-                            if let Some(other_known_items) = other_keyed.get_known_items() {
+                            // Array with generic parameters might have any key
+                            if context.settings.allow_possibly_undefined_array_keys
+                                && other_keyed.get_generic_parameters().is_some()
+                            {
+                                true
+                            } else if let Some(other_known_items) = other_keyed.get_known_items() {
                                 other_known_items.contains_key(&array_key)
                             } else {
-                                // Array with generic parameters might have any key
-                                other_keyed.get_generic_parameters().is_some()
+                                false
                             }
                         } else {
                             false
@@ -790,11 +794,13 @@ pub(crate) fn handle_array_access_on_keyed_array<'ctx>(
                     // This is a union type - check if any other atomic type has this key
                     !array_like_type.types.iter().any(|atomic_type| {
                         if let TAtomic::Array(TArray::Keyed(other_keyed)) = atomic_type {
-                            if let Some(other_known_items) = other_keyed.get_known_items() {
+                            // Array with generic parameters might have any key
+                            if other_keyed.get_generic_parameters().is_some() {
+                                true
+                            } else if let Some(other_known_items) = other_keyed.get_known_items() {
                                 other_known_items.contains_key(&array_key)
                             } else {
-                                // Array with generic parameters might have any key
-                                other_keyed.get_generic_parameters().is_some()
+                                false
                             }
                         } else {
                             false

--- a/crates/analyzer/tests/cases/possibly_undefined_string_key_in_union.php
+++ b/crates/analyzer/tests/cases/possibly_undefined_string_key_in_union.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+/** @var array{foo: int, ...}|array{foo: int} $x */
+
+// @mago-expect analysis:possibly-undefined-string-array-index
+var_dump($x['bar']);

--- a/crates/analyzer/tests/cases/undefined_string_key_in_union.php
+++ b/crates/analyzer/tests/cases/undefined_string_key_in_union.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+/** @var array{foo: int, ...}|array{foo: int} $x */
+
+// @mago-expect analysis:undefined-string-array-index,undefined-string-array-index
+var_dump($x['bar']);
+
+// This used to produce a bogus impossible-nonnull-entry-check
+isset($x['bar']);

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -405,6 +405,12 @@ test_case!(abstract_method_inheritance);
 test_case!(variadic_array_type);
 test_case!(parse_str);
 test_case!(assertion_after_side_effect);
+test_case!(undefined_string_key_in_union);
+test_case!(possibly_undefined_string_key_in_union, {
+    let mut s = crate::framework::default_test_settings();
+    s.allow_possibly_undefined_array_keys = true;
+    s
+});
 
 // Github Issues
 test_case!(issue_659);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes a bug where an unsealed array is not considered to be able to contain an unknown key, because the unsealed-ness is only considered when there are no known keys at all.

## 🔍 Context & Motivation

Fixes possibly undefined keys being reported as definitely undefined.

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed detection of possibly undefined keys in unions of sealed/unsealed arrays

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [x] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Nyet

## 📝 Notes for Reviewers

It's a me, dotdashio
