### PR TITLE
fix: fix case folding to always match PHP's behaviour

### DIFF
--- a/crates/analyzer/tests/cases/only_ascii_is_caseless.php
+++ b/crates/analyzer/tests/cases/only_ascii_is_caseless.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+class Unicöde {}
+
+// @mago-expect analysis:non-existent-class
+new UnicÖde();

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -411,6 +411,7 @@ test_case!(possibly_undefined_string_key_in_union, {
     s.allow_possibly_undefined_array_keys = true;
     s
 });
+test_case!(only_ascii_is_caseless);
 
 // Github Issues
 test_case!(issue_659);


### PR DESCRIPTION
## 📌 What Does This PR Do?

PHP just lowercases all ASCII chars and keeps everything else as is. We already do that in the stack based path, but the slow path calls to_lowercase() instead of to_ascii_lowercase(), so non-ASCII chars are also lowercased.

Since we only modify ASCII characters and they're a strict subset of UTF-8, we can safely drop the is_ascii check. The result will be valid UTF-8 either way, so we can use the as-is fast path and the stack based conversion for any input string, not just pure ASCII.

## 🔍 Context & Motivation

mago fails to properly detect errors that result from case differences in non-ASCII chars e.g. class `MÖp` vs. `Möp`.

## 🛠️ Summary of Changes

- **Bug Fix:** Fix improper case folding for non-ASCII characters.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): everything dealing with case insensitive items

## 🔗 Related Issues or PRs

nope

## 📝 Notes for Reviewers

cAsE InSenSiTivE
