### PR TITLE
fix(reporter): flush writer buffer to avoid incomplete json when writing to pipes in watch mode

### DIFF
--- a/crates/reporting/src/reporter.rs
+++ b/crates/reporting/src/reporter.rs
@@ -147,6 +147,8 @@ impl Reporter {
 
         // Dispatch to the appropriate formatter
         dispatch_format(self.config.format, &mut *writer, &issues, &self.database, &formatter_config)?;
+        // When writing to pipes, some formatters do not flush the last line of json
+        writer.flush()?;
 
         Ok(ReportStatus {
             baseline_dead_issues: baseline_has_dead_issues,


### PR DESCRIPTION
## 📌 What Does This PR Do?

This adds a call to `writer.flush()` after calling `dispatch_format` in `Reporter.report`.

<!-- Briefly describe what this PR introduces or fixes. -->

## 🔍 Context & Motivation

Hello again 👋 

When using `mago analyze --watch --reporting-format json` and reading the output from a pipe, the last "}" of the JSON document isn't flushed from the buffer, resulting in the reader receiving an incomplete JSON document. This isn't an issue when writing to a TTY or when not using --watch, because writing to a TTY automatically flushes and when not using --watch the process ends, also flushing the buffer.

This fix is particularly helpful for building a vscode extension, which would stream in output from a `mago analyze --watch` process.

<!-- Why is this change needed? Is it fixing a bug, adding a feature, or refactoring? -->

## 🛠️ Summary of Changes

- **Bug Fix:** Flush writer buffer to avoid incomplete json when writing to pipes in watch mode


## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): analyze watch mode JSON reporter

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
