### PR TITLE
fix(analyzer): fix bogus diagnostic when writing an unknown array index

### DIFF
--- a/crates/analyzer/src/utils/expression/array.rs
+++ b/crates/analyzer/src/utils/expression/array.rs
@@ -760,7 +760,7 @@ pub(crate) fn handle_array_access_on_keyed_array<'ctx>(
                     *key_in_other_variant = true;
                 } else {
                     // Key doesn't exist in any variant - report error (only once for union types)
-                    if !*reported_undefined_key {
+                    if !in_assignment && !*reported_undefined_key {
                         *reported_undefined_key = true;
 
                         context.collector.report_with_code(

--- a/crates/analyzer/tests/cases/allow_unknown_array_key_in_assignment.php
+++ b/crates/analyzer/tests/cases/allow_unknown_array_key_in_assignment.php
@@ -1,0 +1,6 @@
+<?php
+
+declare(strict_types=1);
+
+/** @var array{test1: string, test2: string, ...} $x */
+$x['test3'] = 'hello';

--- a/crates/analyzer/tests/cases/issue_360.php
+++ b/crates/analyzer/tests/cases/issue_360.php
@@ -108,7 +108,6 @@ class Data
     public function addItemstoParamsWithExtra(array $params): array
     {
         foreach ($this->items as $item) {
-            // @mago-expect analysis:undefined-string-array-index
             // @mago-expect analysis:mixed-array-assignment
             $params['items'][] = $item;
         }

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -412,6 +412,7 @@ test_case!(possibly_undefined_string_key_in_union, {
     s
 });
 test_case!(only_ascii_is_caseless);
+test_case!(allow_unknown_array_key_in_assignment);
 
 // Github Issues
 test_case!(issue_659);


### PR DESCRIPTION
## 📌 What Does This PR Do?

When allow-possibly-undefined-array-keys is set to false, mago would complain about unknown array keys when writing to them, which is bogus.

## 🔍 Context & Motivation

It's a bug!

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed bogus diagnostic when writing an unknown array index

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): analyzer

## 🔗 Related Issues or PRs

Fixes https://github.com/carthage-software/mago/issues/1168

## 📝 Notes for Reviewers

PHP doesn't care about inner keys when writing to a nested array either, so the existing test had to be fixed.
