### PR TITLE
fix(analyzer): clear safe_symbols before calling incremental analyzer to stop existing errors from being cleared on file update in watch mode

### DIFF
--- a/crates/orchestrator/src/service/incremental_analysis.rs
+++ b/crates/orchestrator/src/service/incremental_analysis.rs
@@ -508,8 +508,8 @@ impl IncrementalAnalysisService {
                 changed_symbols,
             );
 
-            // Clear safe_symbols before analysis — they were needed for populate_codebase_targeted
-            // but must not leak into the analyzer (see non-body-only path for explanation).
+            // Clearing safe_symbols in just_body edits before calling the analyzer makes sure
+            // existing errors aren't cleared.
             merged_codebase.safe_symbols.clear();
             merged_codebase.safe_symbol_members.clear();
 


### PR DESCRIPTION
## 📌 What Does This PR Do?

This is an attempt to fix the issue in https://github.com/carthage-software/mago/issues/1176

<!-- Briefly describe what this PR introduces or fixes. -->

## 🔍 Context & Motivation

I think by having the class_like symbols in safe_symbols of the updated files might be stopping the classes from being analyzed. If this isn't the right solution I'm happy to close this PR but I thought I'd give it a shot, since this seemed to solve the issue for me.

This just affects "body_only" edits.

<!-- Why is this change needed? Is it fixing a bug, adding a feature, or refactoring? -->

## 🛠️ Summary of Changes
- **Bug Fix:** Clear safe_symbols before calling incremental analyzer to stop existing errors from being cleared on file update in watch mode

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Analyzer watch mode 

## 🔗 Related Issues or PRs

<!-- Fixes #1176 , related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
