### PR TITLE
fix(analyzer): report class names as written instead of normalized

### DIFF
--- a/crates/analyzer/src/statement/try.rs
+++ b/crates/analyzer/src/statement/try.rs
@@ -504,18 +504,18 @@ fn get_caught_classes<'arena>(context: &mut Context<'_, 'arena>, hint: &Hint<'ar
             context.collector.report_with_code(
                 IssueCode::CatchTypeNotThrowable,
                 Issue::error(format!(
-                    "The type `{lowercase_caught_type}` caught in a catch block must implement the `Throwable` interface.",
+                    "The type `{caught_type}` caught in a catch block must implement the `Throwable` interface.",
                 ))
                 .with_annotation(
                     Annotation::primary(caught_span)
-                        .with_message(format!("`{lowercase_caught_type}` is not an instance of `Throwable`")),
+                        .with_message(format!("`{caught_type}` is not an instance of `Throwable`")),
                 )
                 .with_annotation(
                     Annotation::secondary(class_like_metadata.name_span.unwrap_or(class_like_metadata.span))
-                        .with_message(format!("`{lowercase_caught_type}` defined here does not implement `Throwable`")),
+                        .with_message(format!("`{caught_type}` defined here does not implement `Throwable`")),
                 )
                 .with_note("In PHP, only objects that implement the `Throwable` interface (this includes `Exception` and `Error` classes and their children) can be caught in a `catch` block.")
-                .with_help(format!("Ensure that `{lowercase_caught_type}` implements the `Throwable` interface, or catch a more general exception type like `Exception` or `Throwable` itself.")),
+                .with_help(format!("Ensure that `{caught_type}` implements the `Throwable` interface, or catch a more general exception type like `Exception` or `Throwable` itself.")),
             );
 
             continue;


### PR DESCRIPTION
## 📌 What Does This PR Do?

The diagnostics for catch-type-not-throwable reports the class name in all lowercase which can be confusing because it likely doesn't match the casing in the code. This makes it show the name in its original casing.

## 🔍 Context & Motivation

It's confusing to see `myclass` in the diagnostic when the code says `catch (MyClass $mc)`.

## 🛠️ Summary of Changes

- **Bug Fix:** Show class names in catch-type-not-throwable as written

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): analyzer

## 🔗 Related Issues or PRs

none

## 📝 Notes for Reviewers

lOwErCaSe
