### PR TITLE
fix(analyzer): resolve false positive redundant-condition for is_float on int|float union

### DIFF
--- a/crates/analyzer/src/invocation/post_process.rs
+++ b/crates/analyzer/src/invocation/post_process.rs
@@ -486,7 +486,7 @@ fn resolve_invocation_assertion<'ctx, 'arena>(
                                 &resolved_assertion_type,
                                 false,
                                 false,
-                                false,
+                                true,
                                 &mut comparison_result,
                             );
 

--- a/crates/analyzer/src/invocation/resolver.rs
+++ b/crates/analyzer/src/invocation/resolver.rs
@@ -230,7 +230,7 @@ fn resolve_atomic<'ctx, 'arena>(
             &target,
             false,
             false,
-            false,
+            true,
             &mut comparison_result,
         );
 

--- a/crates/analyzer/tests/cases/scalar_types_reconciliation.php
+++ b/crates/analyzer/tests/cases/scalar_types_reconciliation.php
@@ -61,3 +61,21 @@ function format_any(string|int|float|bool $element): string
         return $element ? 'true' : 'false';
     }
 }
+
+function narrow_int_or_float_to_float(int|float $value): float
+{
+    if (is_float($value)) {
+        return $value;
+    } else {
+        return 0.0;
+    }
+}
+
+function narrow_int_or_float_to_int(int|float $value): int
+{
+    if (is_float($value)) {
+        return 0;
+    } else {
+        return $value;
+    }
+}

--- a/crates/codex/src/ttype/comparator/scalar_comparator.rs
+++ b/crates/codex/src/ttype/comparator/scalar_comparator.rs
@@ -29,7 +29,7 @@ pub fn is_contained_by(
         (TAtomic::Scalar(TScalar::Integer(ci)), TAtomic::Scalar(TScalar::Integer(ii))) if ci.contains(*ii) => {
             return true;
         }
-        (TAtomic::Scalar(TScalar::Float(TFloat::Float)), TAtomic::Scalar(TScalar::Float(_) | TScalar::Integer(_))) => {
+        (TAtomic::Scalar(TScalar::Float(TFloat::Float)), TAtomic::Scalar(TScalar::Integer(_))) if !inside_assertion => {
             return true;
         }
         (TAtomic::Scalar(TScalar::Float(container_float)), TAtomic::Scalar(TScalar::Float(input_float)))


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes false positive `redundant-condition` and `redundant-type-comparison` diagnostics when `is_float()` or `is_double()` is called on a variable with type `int|float`, and corrects type narrowing in the else branch.

```php
function format_value(int|float $value): string
{
    if (is_float($value)) { // FP: redundant-condition + redundant-type-comparison
        return number_format($value, 2);
    }
    return (string) $value;
}

function extract_int(int|float $value): int
{
    if (is_float($value)) {
        return 0;
    } else {
        return $value; // should narrow to int, was incorrectly removed
    }
}
```

Reproduction: [Playground](https://mago.carthage.software/playground#019c7ee5-8d66-ba79-c937-0717c0e61d66)

## 🔍 Context & Motivation

The scalar comparator unconditionally treated `int` as contained by `float`, which is correct for type coercion (PHP implicitly converts `int` to `float`) but incorrect for assertion contexts where runtime type identity matters (`is_float(42)` returns `false` in PHP). A common source of `int|float` is integer division (`$a / $b`), where PHP returns `int` when divisible and `float` otherwise.

## 🛠️ Summary of Changes

- **Bug Fix:** Guard the `int ⊂ float` containment rule with `!inside_assertion` and pass `inside_assertion=true` at assertion-context call sites (`post_process.rs`, `resolver.rs`).
- **Tests:** Add two test cases to `scalar_types_reconciliation.php` verifying `is_float()` narrows `int|float` correctly in both branches.

## 📂 Affected Areas

- [x] Analyzer
- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Composer Plugin
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

<!-- N/A -- self-discovered during narrowing edge case verification -->

## 📝 Notes for Reviewers

<!-- N/A -->
