### PR TITLE
fix(codex): resolve false positive `incompatible-parameter-type` with `@inheritDoc` across intermediate classes

### DIFF
--- a/crates/analyzer/tests/cases/issue_1165.php
+++ b/crates/analyzer/tests/cases/issue_1165.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+class Param {}
+
+// Setup: interface has non-nullable @param, base class widens to nullable.
+interface ParamInterface {
+    /** @param Param $x */
+    public function process(Param $x): void;
+}
+
+abstract class Base implements ParamInterface {
+    /** @param Param|null $x */
+    public function process(?Param $x = null): void {}
+}
+
+// gap=0: direct child (regression guard)
+class DirectChild extends Base {
+    /** @inheritDoc */
+    public function process(?Param $x = null): void {}
+}
+
+// gap=1: one non-overriding intermediate (core bug from #1165)
+class Middle extends Base {}
+class GapChild extends Middle {
+    /** @inheritDoc */
+    public function process(?Param $x = null): void {}
+}
+
+// gap=2: two non-overriding intermediates
+class DeepMiddle extends Middle {}
+class DeepGapChild extends DeepMiddle {
+    /** @inheritDoc */
+    public function process(?Param $x = null): void {}
+}
+
+// True positive: real contravariance violation through gap.
+abstract class NullableBase {
+    public function execute(?Param $x): void {}
+}
+class NullableMiddle extends NullableBase {}
+class NarrowingChild extends NullableMiddle {
+    // @mago-expect analysis:incompatible-parameter-type
+    public function execute(Param $x): void {}
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -661,6 +661,7 @@ test_case!(issue_1073);
 test_case!(issue_1150);
 test_case!(issue_1156);
 test_case!(issue_1157);
+test_case!(issue_1165);
 test_case!(issue_1169);
 test_case!(issue_1184);
 test_case!(issue_1184_methods);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes a false positive `incompatible-parameter-type` when a grandchild class uses `@inheritDoc` and the intermediate class does not override the method.

```php
interface ExpressionInterface {
    public function sql(ValueBinder $binder): string;
}

abstract class Query implements ExpressionInterface {
    /** @param ValueBinder|null $binder */
    public function sql(?ValueBinder $binder = null): string { ... }
}

class DbSelectQuery extends Query {}  // no override

class SelectQuery extends DbSelectQuery {
    /** @inheritDoc */
    public function sql(?ValueBinder $binder = null): string { ... }  // false positive
}
```

Reported against CakePHP ([`Cake\ORM\Query\SelectQuery`](https://github.com/cakephp/cakephp/blob/510ce688cc586db1e8f2f9b9387625607f5555c3/src/ORM/Query/SelectQuery.php#L1603)).

## 🔍 Context & Motivation

`collect_inheritance_work` only checked the immediate `direct_parent_class` when looking for a parent method to inherit from. When the intermediate class didn't declare the method, the lookup failed and fell back to the interface's original (non-nullable) type.

## 🛠️ Summary of Changes

- **Bug Fix:** Walk the `direct_parent_class` chain to find the nearest declaring ancestor instead of checking only the immediate parent.
- **Tests:** Add `issue_1165.php` covering gap inheritance variants and a true contravariance violation.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Codex (docblock inheritance), Analyzer (tests)

## 🔗 Related Issues or PRs

Fixes carthage-software/mago#1165

## 📝 Notes for Reviewers

<!-- N/A -->
