### PR TITLE
fix(prelude): remove incorrect `@pure` annotations from impure functions

### DIFF
--- a/crates/prelude/assets/extensions/core.php
+++ b/crates/prelude/assets/extensions/core.php
@@ -882,7 +882,6 @@ function enum_exists(string $enum, bool $autoload = true): bool {}
  * @param class-string $class
  * @param non-empty-string $alias
  *
- * @pure
  * @no-named-arguments
  */
 function class_alias(string $class, string $alias, bool $autoload = true): bool {}

--- a/crates/prelude/assets/extensions/standard.php
+++ b/crates/prelude/assets/extensions/standard.php
@@ -1714,8 +1714,6 @@ function printf(string $format, mixed ...$values): int {}
 
 /**
  * @param array<string|int|float|bool|null|Stringable> $values
- *
- * @pure
  */
 function vprintf(string $format, array $values): int {}
 
@@ -1729,16 +1727,12 @@ function vsprintf(string $format, array $values): string {}
 /**
  * @param resource $stream
  * @param string|int|float|bool|null|Stringable ...$values
- *
- * @pure
  */
 function fprintf($stream, string $format, mixed ...$values): int {}
 
 /**
  * @param resource $stream
  * @param array<string|int|float|bool|null|Stringable> $values
- *
- * @pure
  */
 function vfprintf($stream, string $format, array $values): int {}
 


### PR DESCRIPTION
## 📌 What Does This PR Do?

Removes `@pure` from 4 prelude functions that have side effects: `class_alias()` (global state modification) and `vprintf()`/`fprintf()`/`vfprintf()` (I/O output). These were falsely flagged by `unused-statement` when called as statements.

## 🔍 Context & Motivation

JetBrains phpstorm-stubs omit `#[Pure]` from these functions; PHPStan and Psalm both treat them as impure.

## 🛠️ Summary of Changes

**core.php**:

- `class_alias()` — modifies the global class table

**standard.php**:

- `vprintf()`, `fprintf()`, `vfprintf()` — write to stdout/streams

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Analyzer (prelude stubs)

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
