### PR TITLE
chore: Specify rust edition in .rustfmt.toml

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,3 +1,4 @@
+edition = "2024"
 indent_style = "Block"
 reorder_imports = true
 imports_granularity = "Item"


### PR DESCRIPTION
## 📌 What Does This PR Do?

Specifies the Rust edition in .rustfmt.toml in addition to Cargo.toml

## 🔍 Context & Motivation

This allows to use rustfmt standalone without Cargo which is required for Jujutsu's "fix" command.

## 🛠️ Summary of Changes

Made rustfmt usable as a standalone tool.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): dev tooling

## 🔗 Related Issues or PRs

nope

## 📝 Notes for Reviewers

pretty please :sparkles: 
