### PR TITLE
fix(formatter): preserve parentheses in non-associative comparison chains

### DIFF
--- a/crates/formatter/src/internal/format/binaryish.rs
+++ b/crates/formatter/src/internal/format/binaryish.rs
@@ -436,6 +436,10 @@ fn should_flatten<'arena>(operator: &BinaryishOperator<'arena>, parent_op: &Bina
         return false;
     }
 
+    if self_precedence.is_non_associative() {
+        return false;
+    }
+
     operator.is_same_as(parent_op)
 }
 

--- a/crates/formatter/tests/precedence.rs
+++ b/crates/formatter/tests/precedence.rs
@@ -129,4 +129,7 @@ mod precedence {
     test_expression_format!(complex_11_messy, "($a = (- ($b ** $c)))", "$a = -$b ** $c");
     test_expression_format!(error_control_include, "$a = (@include $b) === $c", "$a = (@include $b) === $c");
     test_expression_format!(error_control_new, "$a = (@(new Foo($x))) === $c", "$a = @new Foo($x) === $c");
+    test_expression_format!(nonassoc_identical_parens_left, "($a === 'b') === $c", "($a === 'b') === $c");
+    test_expression_format!(nonassoc_less_than_parens_left, "($a < $b) < $c", "($a < $b) < $c");
+    test_expression_format!(nonassoc_identical_parens_right, "$a === ($b === $c)", "$a === ($b === $c)");
 }


### PR DESCRIPTION
## 📌 What Does This PR Do?

Prevents the formatter from stripping parentheses that disambiguate non-associative comparison chains, which would produce invalid PHP.

## 🔍 Context & Motivation

PHP declares comparison operators (`===`, `==`, `<`, `>=`, etc.) as `%nonassoc` — chaining them without parentheses is a parse error. The formatter's `should_flatten()` did not account for this, so `($a === 'b') === $c` was flattened into `$a === 'b' === $c`.

```php
// Input (valid PHP):
return ($operator === 'is') === in_array($value, $systemTags);

// After `mago fmt` (invalid PHP):
return $operator === 'is' === in_array($value, $systemTags);
```

## 🛠️ Summary of Changes

- **Bug Fix:** `should_flatten()` now returns `false` for non-associative precedence levels
- **Tests:** Added 3 formatter tests for parenthesis preservation (equality, comparison, right-side)

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

<!-- N/A -->

## 📝 Notes for Reviewers

<!-- N/A -->
