### PR TITLE
perf(analyzer): add fast paths in TUnion::eq

### DIFF
--- a/crates/codex/src/ttype/union.rs
+++ b/crates/codex/src/ttype/union.rs
@@ -1374,6 +1374,10 @@ impl TType for TUnion {
 
 impl PartialEq for TUnion {
     fn eq(&self, other: &TUnion) -> bool {
+        if std::ptr::eq(self, other) {
+            return true;
+        }
+
         const SEMANTIC_FLAGS: UnionFlags = UnionFlags::HAD_TEMPLATE
             .union(UnionFlags::BY_REFERENCE)
             .union(UnionFlags::REFERENCE_FREE)
@@ -1390,6 +1394,12 @@ impl PartialEq for TUnion {
         let len = self.types.len();
         if len != other.types.len() {
             return false;
+        }
+
+        // Fast path: unions are commonly constructed in stable type order.
+        // When order already matches, this keeps comparison linear.
+        if self.types == other.types {
+            return true;
         }
 
         // Check self ⊆ other


### PR DESCRIPTION
## 📌 What Does This PR Do?

Adds two fast paths in `TUnion::eq` to avoid expensive subset matching when equality can be decided immediately.

## 🔍 Context & Motivation

`TUnion::eq` is a hot path during analyzer type comparisons.  
The current implementation always falls back to O(n²)-style matching once semantic flags match, even in common cases where unions are trivially equal.

This change introduces early returns for:
1. pointer identity (`std::ptr::eq(self, other)`)
2. exact ordered type list equality (`self.types == other.types`)

Both paths preserve semantics and only short-circuit when equality is already guaranteed.

## 🛠️ Summary of Changes

- **Perf:** Added `std::ptr::eq(self, other)` early return in `TUnion::eq`.
- **Perf:** Added `self.types == other.types` early return in `TUnion::eq`.
- **No behavior change:** Existing semantic flag checks and fallback subset comparison remain unchanged.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): analyzer performance (`mago-codex` type comparison)

## 🔗 Related Issues or PRs

N/A

## 🧪 Benchmarks

### Official php-toolchain-benchmarks (interleaved ABABAB, analyzer/cold, runs=3 each)
Candidate vs baseline:

- `psl`: `0.385s -> 0.359s` (**-6.75%**), memory `-0.44%`
- `wordpress`: `5.323s -> 5.131s` (**-3.62%**), memory `+1.87%`
- `magento`: `8.573s -> 7.814s` (**-8.86%**), memory `+1.31%`

### In-repo benchmark
`cargo +1.93.0 bench -p mago-codex --bench comparator -- --noplot`  
(interleaved ABABAB):

- wall time: `162.573s -> 169.880s` (**+4.49%**)
- RSS: `85205.3 KB -> 85325.3 KB` (**+0.14%**)

## 📝 Notes for Reviewers

- Change scope is intentionally minimal: one function (`TUnion::eq`) in one file.
- All measured runs completed successfully (no timeouts, no non-zero exits).
- Benchmark results are mixed between macro analyzer workloads (win) and in-repo comparator microbench (loss).
