### PR TITLE
perf(syntax): optimize Binary::span edge traversal

### DIFF
--- a/crates/syntax/src/ast/ast/binary.rs
+++ b/crates/syntax/src/ast/ast/binary.rs
@@ -319,6 +319,22 @@ impl HasSpan for BinaryOperator<'_> {
 
 impl HasSpan for Binary<'_> {
     fn span(&self) -> Span {
-        self.lhs.span().join(self.rhs.span())
+        fn left_edge_span(mut expression: &Expression<'_>) -> Span {
+            while let Expression::Binary(binary) = expression {
+                expression = binary.lhs;
+            }
+
+            expression.span()
+        }
+
+        fn right_edge_span(mut expression: &Expression<'_>) -> Span {
+            while let Expression::Binary(binary) = expression {
+                expression = binary.rhs;
+            }
+
+            expression.span()
+        }
+
+        left_edge_span(self.lhs).join(right_edge_span(self.rhs))
     }
 }


### PR DESCRIPTION
## 📌 What Does This PR Do?

Optimizes `Binary::span()` by walking to edge spans directly in nested binary expressions.

## 🔍 Context & Motivation

`Binary::span()` is called frequently during syntax/tree processing. For nested binary trees, repeatedly recomputing spans from intermediate nodes can add avoidable overhead.

This change computes the final span from the true left-most and right-most expression edges directly.

## 🛠️ Summary of Changes

- **Perf:** `Binary::span()` now traverses to the left-most and right-most expression leaves before joining spans.
- **No behavior change:** Returned span still represents the full binary expression range.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): syntax AST span computation

## 🔗 Related Issues or PRs

N/A

## 🧪 Official Benchmarks

### php-toolchain-benchmarks (interleaved ABABAB)
Candidate vs baseline:

- `psl`: `-14.99%`
- `wordpress`: `-15.53%`
- `magento`: `+1.70%` (small regression in short run)

### Magento deepened verification (official benchmark, strict interleaved 20 runs)
To validate the small `magento` signal, we ran a larger strict `ABAB...` series (10x baseline, 10x candidate):

- `delta_avg_pct`: **-5.93%**
- `delta_median_pct`: **-1.74%**

This indicates the earlier small regression was likely run-to-run noise.

## 🔬 In-Repo Microbench (Comparator, warm-only)

Command: `cargo +1.93.0 bench -p mago-codex --bench comparator -- --noplot`

- `binary-span` vs warm baseline: wall `+4.850s` (**+2.97%**), RSS `-704 KB` (**-0.83%**)

Note: compile-contaminated first-pass microbench rows were excluded; only warm comparable rows are reported.

## 📝 Notes for Reviewers

- Change scope is intentionally minimal: one file (`crates/syntax/src/ast/ast/binary.rs`).
- All official benchmark runs completed successfully (`rc=0`).