### PR TITLE
fix(formatter): preserve parentheses around  in ternary/elvis expressions

### DIFF
--- a/crates/formatter/src/internal/parens.rs
+++ b/crates/formatter/src/internal/parens.rs
@@ -334,10 +334,19 @@ impl<'arena> FormatterState<'_, 'arena> {
                 )
             );
 
-            if is_include_like && let Some(Node::Binary(parent_bin)) = self.nth_parent_kind(2) {
-                let is_lhs = node.end_position() < parent_bin.operator.start_position();
-                if is_lhs {
-                    return true;
+            if is_include_like {
+                if let Some(Node::Binary(parent_bin)) = self.nth_parent_kind(2) {
+                    let is_lhs = node.end_position() < parent_bin.operator.start_position();
+                    if is_lhs {
+                        return true;
+                    }
+                }
+
+                if let Some(Node::Conditional(parent_cond)) = self.nth_parent_kind(2) {
+                    let is_condition = node.end_position() < parent_cond.question_mark.start_position();
+                    if is_condition {
+                        return true;
+                    }
                 }
             }
         }

--- a/crates/formatter/tests/cases/issue_1231/after.php
+++ b/crates/formatter/tests/cases/issue_1231/after.php
@@ -1,0 +1,13 @@
+<?php
+
+array_merge($map, (@include base_path('file.php')) ?: []);
+
+$a = (@include base_path('file.php')) ?: [];
+
+$b = (@require base_path('file.php')) ?: [];
+
+$c = (@include_once base_path('file.php')) ?: [];
+
+$d = (@require_once base_path('file.php')) ?: [];
+
+$e = (@include base_path('file.php')) ? true : false;

--- a/crates/formatter/tests/cases/issue_1231/before.php
+++ b/crates/formatter/tests/cases/issue_1231/before.php
@@ -1,0 +1,16 @@
+<?php
+
+array_merge(
+    $map,
+    (@include base_path("file.php")) ?: []
+);
+
+$a = (@include base_path("file.php")) ?: [];
+
+$b = (@require base_path("file.php")) ?: [];
+
+$c = (@include_once base_path("file.php")) ?: [];
+
+$d = (@require_once base_path("file.php")) ?: [];
+
+$e = (@include base_path("file.php")) ? true : false;

--- a/crates/formatter/tests/cases/issue_1231/settings.inc
+++ b/crates/formatter/tests/cases/issue_1231/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings::default()

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -358,6 +358,7 @@ test_case!(issue_1149);
 test_case!(issue_1153);
 test_case!(issue_1198);
 test_case!(issue_1221);
+test_case!(issue_1231);
 
 #[test]
 fn test_all_test_cases_are_ran() {


### PR DESCRIPTION
closes #1231
