### PR TITLE
perf(codex): add pointer-equality fastpath in atomic comparator

### DIFF
--- a/crates/codex/src/ttype/comparator/atomic_comparator.rs
+++ b/crates/codex/src/ttype/comparator/atomic_comparator.rs
@@ -35,6 +35,10 @@ pub fn is_contained_by(
     inside_assertion: bool,
     atomic_comparison_result: &mut ComparisonResult,
 ) -> bool {
+    if std::ptr::eq(input_type_part, container_type_part) {
+        return true;
+    }
+
     if input_type_part == container_type_part {
         return true;
     }


### PR DESCRIPTION
## 📌 What Does This PR Do?

Adds a small fast path in the codex atomic comparator by checking pointer identity before structural equality.

## 🔍 Context & Motivation

Profiling for `mago-mre.8` on a real single-file analyze run showed atomic type equality as the top hotspot (`TAtomic::eq`).

This PR tests an isolated optimization (`mago-mre.9`) with no semantic behavior changes.

## 🛠️ Summary of Changes

- Add `std::ptr::eq(input_type_part, container_type_part)` early return in `atomic_comparator::is_contained_by`.
- Keep existing structural `==` fallback unchanged.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [x] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): codex type comparator hot path

## 🔗 Related Issues or PRs

- Related: `mago-mre.8` (hotspot mapping)
- Related: `mago-mre.9` (isolated candidate)

## 📈 Benchmarks (Official, final run set only)

Source: `/tmp/bench-v2-mre9-ptr-111533/summary-clean.md`

| project | before mean (s) | after mean (s) | delta mean (s) | delta mean (%) | parity |
|---|---:|---:|---:|---:|---|
| magento | 4.816250 | 4.746250 | -0.070000 | -1.45% | ok |
| psl | 0.308750 | 0.281250 | -0.027500 | -8.91% | ok |
| wordpress | 2.848750 | 2.713750 | -0.135000 | -4.74% | ok |

Decision: **GO** (official wins `3/3`, required `2/3`).

## 🧪 Microbenchmark (targeted comparator)

`cargo bench -p mago-codex --bench comparator -- is_contained_by_same_type --sample-size 60 --warm-up-time 1`

- Base: `time: [9.0941 ns 9.2702 ns 9.4815 ns]`
- Candidate: `time: [9.2688 ns 9.4636 ns 9.7007 ns]`

This targeted synthetic case shows a small regression, while the official macro benchmark suite shows consistent wins across all projects.

## ✅ Validation

- `cargo test -p mago-codex --locked comparator` (25 passed, 0 failed)

## 📝 Notes for Reviewers

This PR intentionally keeps scope minimal (single fast-path branch) to keep follow-up bisects and rollback trivial.
