### PR TITLE
fix(analyzer): prevent false possibly-undefined keys when building arrays in loops with conditional branches

### DIFF
--- a/crates/analyzer/src/expression/assignment/array_assignment.rs
+++ b/crates/analyzer/src/expression/assignment/array_assignment.rs
@@ -359,6 +359,14 @@ fn update_array_assignment_child_type<'ctx>(
                         })));
                     }
                     TArray::Keyed(keyed_array) => {
+                        if keyed_array.get_known_items().is_none()
+                            && keyed_array.get_generic_parameters().is_none()
+                            && root_type.types.len() > 1
+                            && root_type.types.iter().any(|t| matches!(t, TAtomic::Array(TArray::List(_))))
+                        {
+                            continue;
+                        }
+
                         collection_types.push(TAtomic::Array(TArray::Keyed(TKeyedArray {
                             parameters: Some((Arc::new((*key_type).clone()), Arc::new(value_type.clone()))),
                             known_items: keyed_array.get_known_items().map(|known_items| {

--- a/crates/analyzer/tests/cases/issue_1230.php
+++ b/crates/analyzer/tests/cases/issue_1230.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @param list<array{fileId: int, pageNumber: int}> $pages
+ *
+ * @return list<array{fileId: int, pageNumbers: list<int>}>
+ */
+function groupConsecutivePages(array $pages): array
+{
+    $groups = [];
+
+    foreach ($pages as $page) {
+        $last = \array_key_last($groups);
+
+        if (null !== $last && $groups[$last]['fileId'] === $page['fileId']) {
+            $groups[$last]['pageNumbers'][] = $page['pageNumber'];
+        } else {
+            $groups[] = [
+                'fileId' => $page['fileId'],
+                'pageNumbers' => [$page['pageNumber']],
+            ];
+        }
+    }
+
+    return $groups;
+}

--- a/crates/analyzer/tests/cases/issue_1230_simple.php
+++ b/crates/analyzer/tests/cases/issue_1230_simple.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @param list<int> $items
+ *
+ * @return list<array{name: string, value: int}>
+ */
+function simpleLoop(array $items): array
+{
+    $result = [];
+
+    foreach ($items as $item) {
+        $result[] = [
+            'name' => 'test',
+            'value' => $item,
+        ];
+    }
+
+    return $result;
+}
+
+/**
+ * @param list<array{id: int, value: int}> $items
+ *
+ * @return list<array{id: int, values: list<int>}>
+ */
+function loopWithBranching(array $items): array
+{
+    $result = [];
+
+    foreach ($items as $item) {
+        $last = \array_key_last($result);
+
+        if (null !== $last && $result[$last]['id'] === $item['id']) {
+            $result[$last]['values'][] = $item['value'];
+        } else {
+            $result[] = [
+                'id' => $item['id'],
+                'values' => [$item['value']],
+            ];
+        }
+    }
+
+    return $result;
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -680,6 +680,18 @@ test_case!(issue_1223, {
     s.check_missing_type_hints = true;
     s
 });
+test_case!(issue_1230, {
+    let mut s = crate::framework::default_test_settings();
+    s.allow_possibly_undefined_array_keys = false;
+    s.strict_list_index_checks = true;
+    s
+});
+test_case!(issue_1230_simple, {
+    let mut s = crate::framework::default_test_settings();
+    s.allow_possibly_undefined_array_keys = false;
+    s.strict_list_index_checks = true;
+    s
+});
 
 #[test]
 fn test_all_test_cases_are_ran() {


### PR DESCRIPTION
closes #1230
