### PR TITLE
fix(analyzer): do not report backed properties with only a set hook as write-only

### DIFF
--- a/crates/analyzer/src/visibility/mod.rs
+++ b/crates/analyzer/src/visibility/mod.rs
@@ -136,6 +136,7 @@ pub fn check_property_read_visibility<'ctx>(
     if !property_metadata.hooks.is_empty()
         && property_metadata.hooks.contains_key(&atom("set"))
         && !property_metadata.hooks.contains_key(&atom("get"))
+        && property_metadata.flags.is_virtual_property()
     {
         let class_name = &declaring_class_metadata.original_name;
 

--- a/crates/analyzer/tests/cases/issue_1226.php
+++ b/crates/analyzer/tests/cases/issue_1226.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+class Code
+{
+    public function __construct(
+        public string $value {
+            set {
+                $this->value = strtoupper($value);
+            }
+        },
+    ) {}
+}
+
+$e = new Code('example');
+
+echo $e->value;
+
+// @mago-expect analysis:missing-constructor
+class BackedSetOnly
+{
+    public string $name = '';
+
+    public string $upper {
+        set {
+            $this->upper = strtoupper($value);
+            $this->name = $value;
+        }
+    }
+}
+
+$b = new BackedSetOnly();
+$b->upper = 'hello';
+echo $b->upper;
+
+class VirtualSetOnly
+{
+    private string $_data = '';
+
+    public string $data {
+        set {
+            $this->_data = strtoupper($value);
+        }
+    }
+
+    // @mago-expect analysis:invalid-property-read,never-return
+    public function getData(): string
+    {
+        return $this->data;
+    }
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -692,6 +692,7 @@ test_case!(issue_1230_simple, {
     s.strict_list_index_checks = true;
     s
 });
+test_case!(issue_1226);
 
 #[test]
 fn test_all_test_cases_are_ran() {


### PR DESCRIPTION
closes #1226
