### PR TITLE
fix(analyzer): deduplicate signature compatibility checks in diamond inheritance

### DIFF
--- a/crates/analyzer/tests/cases/method_signature_parameter_names.php
+++ b/crates/analyzer/tests/cases/method_signature_parameter_names.php
@@ -76,3 +76,35 @@ class StringValidator extends BaseValidator
         return is_string($input);
     }
 }
+
+// Test 6: Parameter name change with diamond inheritance (WARNING)
+interface Logger
+{
+    public function log(string $message): void;
+}
+
+interface FileLogger extends Logger {}
+interface DatabaseLogger extends Logger {}
+
+class CompositeLogger implements FileLogger, DatabaseLogger
+{
+    // @mago-expect analysis:incompatible-parameter-name
+    public function log(string $entry): void {}
+}
+
+// Test 7: Parameter name change with indirect interface (WARNING)
+interface Serializer
+{
+    public function serialize(mixed $data): string;
+}
+
+interface JsonSerializer extends Serializer {}
+
+class DefaultJsonSerializer implements JsonSerializer
+{
+    // @mago-expect analysis:incompatible-parameter-name
+    public function serialize(mixed $payload): string
+    {
+        return '';
+    }
+}


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes duplicate `incompatible-parameter-name` (and other signature compatibility) diagnostics when a class implements multiple interfaces sharing a common ancestor.

## 🔍 Context & Motivation

In diamond inheritance, signature compatibility checks run once per inheritance path and again in `check_abstract_method_signatures`:

```php
interface Logger {
    public function log(string $message): void;
}
interface FileLogger extends Logger {}
interface DatabaseLogger extends Logger {}

class CompositeLogger implements FileLogger, DatabaseLogger {
    public function log(string $entry): void {}
    // `incompatible-parameter-name` reported 3 times instead of 1
}
```

This affects all `SignatureCompatibilityIssue` variants. In Symfony HttpFoundation, 80+ of ~90 reported issues were duplicates from `SessionHandlerInterface` diamond implementations.

## 🛠️ Summary of Changes

- **Bug Fix:** Track checked `(declaring_class, method_name)` pairs in a shared `HashSet` across `check_interface_method_signatures` and `check_abstract_method_signatures`, skipping duplicates. Removed the now-subsumed `direct_parent_interfaces` skip condition.
- **Tests:** Added 3 `test_analysis!` tests (direct, diamond, indirect) and 2 PHP regression test cases.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Analyzer

## 🔗 Related Issues or PRs

<!-- N/A -->

## 📝 Notes for Reviewers

<!-- N/A -->
