### PR TITLE
feat: add support for `--stdin-input`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,6 +161,7 @@ schemars = { workspace = true }
 [dev-dependencies]
 temp-env = "0.3.6"
 pretty_assertions = { workspace = true }
+serde_json = { workspace = true }
 
 [build-dependencies]
 mago-prelude = { workspace = true, features = ["build"] }

--- a/crates/database/src/loader.rs
+++ b/crates/database/src/loader.rs
@@ -1,6 +1,7 @@
 //! Database loader for scanning and loading project files.
 
 use std::borrow::Cow;
+use std::collections::hash_map::Entry;
 use std::ffi::OsString;
 use std::path::Path;
 
@@ -37,17 +38,28 @@ pub struct DatabaseLoader<'a> {
     database: Option<Database<'a>>,
     configuration: DatabaseConfiguration<'a>,
     memory_sources: Vec<(&'static str, &'static str, FileType)>,
+    /// When set, content for this file (by logical name) is taken from here instead of disk.
+    /// Used for editor integrations: read content from stdin but use the given path for baseline and reporting.
+    stdin_override: Option<(Cow<'a, str>, String)>,
 }
 
 impl<'a> DatabaseLoader<'a> {
     #[must_use]
     pub fn new(configuration: DatabaseConfiguration<'a>) -> Self {
-        Self { configuration, memory_sources: vec![], database: None }
+        Self { configuration, memory_sources: vec![], database: None, stdin_override: None }
     }
 
     #[must_use]
     pub fn with_database(mut self, database: Database<'a>) -> Self {
         self.database = Some(database);
+        self
+    }
+
+    /// When set, the file with this logical name (workspace-relative path) will use the given
+    /// content instead of being read from disk. The logical name is used for baseline and reporting.
+    #[must_use]
+    pub fn with_stdin_override(mut self, logical_name: impl Into<Cow<'a, str>>, content: String) -> Self {
+        self.stdin_override = Some((logical_name.into(), content));
         self
     }
 
@@ -117,6 +129,18 @@ impl<'a> DatabaseLoader<'a> {
 
             all_files.insert(file_id, file_with_spec.file);
             file_decisions.insert(file_id, (FileType::Host, specificity));
+        }
+
+        // When stdin override is set, ensure that the file is in the database
+        // (covers new/unsaved files, not on disk)
+        if let Some((ref name, ref content)) = self.stdin_override {
+            let file = File::ephemeral(Cow::Owned(name.as_ref().to_string()), Cow::Owned(content.clone()));
+            let file_id = file.id;
+            if let Entry::Vacant(e) = all_files.entry(file_id) {
+                e.insert(file);
+
+                file_decisions.insert(file_id, (FileType::Host, usize::MAX));
+            }
         }
 
         for file_with_spec in vendored_files_with_spec {
@@ -239,7 +263,31 @@ impl<'a> DatabaseLoader<'a> {
                     return None;
                 }
 
-                match read_file(self.configuration.workspace.as_ref(), &path, file_type) {
+                let workspace = self.configuration.workspace.as_ref();
+                #[cfg(windows)]
+                let logical_name = path
+                    .strip_prefix(workspace)
+                    .unwrap_or_else(|_| path.as_path())
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                #[cfg(not(windows))]
+                let logical_name =
+                    path.strip_prefix(workspace).unwrap_or(path.as_path()).to_string_lossy().into_owned();
+
+                if let Some((ref override_name, ref override_content)) = self.stdin_override
+                    && override_name.as_ref() == logical_name
+                {
+                    let file = File::new(
+                        Cow::Owned(logical_name),
+                        file_type,
+                        Some(path.clone()),
+                        Cow::Owned(override_content.clone()),
+                    );
+
+                    return Some(Ok(FileWithSpecificity { file, specificity }));
+                }
+
+                match read_file(workspace, &path, file_type) {
                     Ok(file) => Some(Ok(FileWithSpecificity { file, specificity })),
                     Err(e) => Some(Err(e)),
                 }
@@ -443,5 +491,38 @@ mod tests {
 
         let file = db.files().find(|f| f.name.contains("lib.php")).unwrap();
         assert_eq!(file.file_type, FileType::Vendored, "File only in includes should be Vendored");
+    }
+
+    #[test]
+    fn test_stdin_override_replaces_file_content() {
+        let temp_dir = TempDir::new().unwrap();
+        create_test_file(&temp_dir, "src/foo.php", "<?php\n// on disk");
+
+        let config = create_test_config(&temp_dir, vec!["src/"], vec![]);
+        let loader = DatabaseLoader::new(config).with_stdin_override("src/foo.php", "<?php\n// from stdin".to_string());
+        let db = loader.load().unwrap();
+
+        let file = db.files().find(|f| f.name.contains("foo.php")).unwrap();
+        assert_eq!(
+            file.contents.as_ref(),
+            "<?php\n// from stdin",
+            "stdin override content should be used instead of disk"
+        );
+    }
+
+    #[test]
+    fn test_stdin_override_adds_file_when_not_on_disk() {
+        let temp_dir = TempDir::new().unwrap();
+        // Do not create src/foo.php on disk
+        create_test_file(&temp_dir, "src/.gitkeep", "");
+
+        let config = create_test_config(&temp_dir, vec!["src/"], vec![]);
+        let loader =
+            DatabaseLoader::new(config).with_stdin_override("src/unsaved.php", "<?php\n// unsaved buffer".to_string());
+        let db = loader.load().unwrap();
+
+        let file = db.files().find(|f| f.name.contains("unsaved.php")).unwrap();
+        assert_eq!(file.file_type, FileType::Host);
+        assert_eq!(file.contents.as_ref(), "<?php\n// unsaved buffer");
     }
 }

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -159,6 +159,9 @@ impl<'a> Orchestrator<'a> {
     ///   directly analyzed, linted, or formatted.
     /// * `prelude_database` - An optional pre-existing database to merge with. This is useful
     ///   for including standard library or framework stubs.
+    /// * `stdin_override` - When set, the file with the given logical name (workspace-relative path)
+    ///   uses the given content instead of being read from disk. Used for editor integrations
+    ///   (e.g. `--stdin-input`), so baseline and reporting use the real path.
     ///
     /// # Returns
     ///
@@ -169,6 +172,7 @@ impl<'a> Orchestrator<'a> {
         workspace: &'a Path,
         include_externals: bool,
         prelude_database: Option<Database<'static>>,
+        stdin_override: Option<(String, String)>,
     ) -> Result<Database<'a>, OrchestratorError>
     where
         'b: 'a,
@@ -214,6 +218,10 @@ impl<'a> Orchestrator<'a> {
 
         if let Some(prelude_db) = prelude_database {
             loader = loader.with_database(prelude_db);
+        }
+
+        if let Some((name, content)) = stdin_override {
+            loader = loader.with_stdin_override(name, content);
         }
 
         let result = loader.load().map_err(OrchestratorError::Database)?;

--- a/docs/tools/analyzer/command-reference.md
+++ b/docs/tools/analyzer/command-reference.md
@@ -27,13 +27,24 @@ Optional. A list of specific files or directories to analyze. If you provide pat
 
 ## Options
 
-| Flag, Alias(es) | Description                                                                          |
-| :-------------- | :----------------------------------------------------------------------------------- |
-| `--no-stubs`    | Analyze the project without loading the built-in PHP stubs for the standard library. |
-| `--staged`      | Only analyze files that are staged in git. Designed for pre-commit hooks. Fails if not in a git repository. |
-| `--watch`       | Enable watch mode for continuous analysis. Re-runs analysis when files change. See [Watch Mode](#watch-mode) below. |
-| `--list-codes`  | List all available analyzer issue codes in JSON format.                               |
-| `--help`, `-h`  | Print the help summary for the command.                                              |
+| Flag, Alias(es) | Description                                                                                                                                                                   |
+| :-------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--no-stubs`    | Analyze the project without loading the built-in PHP stubs for the standard library.                                                                                          |
+| `--staged`      | Only analyze files that are staged in git. Designed for pre-commit hooks. Fails if not in a git repository.                                                                   |
+| `--stdin-input` | Read file content from stdin and use the single path argument for baseline and reporting. Intended for editor integrations (e.g. unsaved buffers). Requires exactly one path. |
+| `--watch`       | Enable watch mode for continuous analysis. Re-runs analysis when files change. See [Watch Mode](#watch-mode) below.                                                           |
+| `--list-codes`  | List all available analyzer issue codes in JSON format.                                                                                                                       |
+| `--help`, `-h`  | Print the help summary for the command.                                                                                                                                       |
+
+### Reading from stdin (editor integration)
+
+When using an editor or IDE that can pipe unsaved buffer content, you can run the analyzer on that content while still using the real file path for baseline lookup and issue locations:
+
+```sh
+cat src/Example.php | mago analyze --stdin-input src/Example.php
+```
+
+You must pass **exactly one path**; it is used as the logical file name (workspace-relative) for baseline matching and diagnostics. The path is normalized (e.g. `./src/Example.php` is treated like `src/Example.php`). This mode conflicts with `--staged` and `--watch`.
 
 ### Shared Reporting and Fixing Options
 

--- a/docs/tools/guard/command-reference.md
+++ b/docs/tools/guard/command-reference.md
@@ -40,9 +40,20 @@ These flags override the `mode` setting in your `mago.toml` configuration. If yo
 
 ### Other Options
 
-| Flag         | Description                                                                                      |
-| :----------- | :----------------------------------------------------------------------------------------------- |
-| `--no-stubs` | Disable built-in PHP and library stubs. May result in more warnings when external symbols can't be resolved. |
+| Flag            | Description                                                                                                                                                                   |
+|:----------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--no-stubs`    | Disable built-in PHP and library stubs. May result in more warnings when external symbols can't be resolved.                                                                  |
+| `--stdin-input` | Read file content from stdin and use the single path argument for baseline and reporting. Intended for editor integrations (e.g. unsaved buffers). Requires exactly one path. |
+
+### Reading from stdin (editor integration)
+
+When using an editor or IDE that can pipe unsaved buffer content, you can run the guard on that content while still using the real file path for baseline lookup and issue locations:
+
+```sh
+cat src/Example.php | mago guard --stdin-input src/Example.php
+```
+
+You must pass **exactly one path**; it is used as the logical file name (workspace-relative) for baseline matching and diagnostics. The path is normalized (e.g. `./src/Example.php` is treated like `src/Example.php`).
 
 ### Shared Reporting Options
 

--- a/docs/tools/linter/command-reference.md
+++ b/docs/tools/linter/command-reference.md
@@ -24,7 +24,7 @@ Optional. A list of specific files or directories to lint. If you provide paths 
 ## Options
 
 | Flag, Alias(es)            | Description                                                                                                                                                                            |
-| :------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|:---------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `--list-rules`             | List all enabled linter rules and their descriptions.                                                                                                                                  |
 | `--json`                   | Used with `--list-rules` to output the rule information in a machine-readable JSON format.                                                                                             |
 | `--explain <RULE_CODE>`    | Provide detailed documentation for a specific linter rule (e.g., `no-redundant-nullsafe`).                                                                                             |
@@ -32,7 +32,18 @@ Optional. A list of specific files or directories to lint. If you provide paths 
 | `--pedantic`               | Enable all linter rules for the most exhaustive analysis possible. This overrides your configuration, ignores PHP version constraints, and enables rules that are disabled by default. |
 | `--semantics`, `-s`        | Perform only the parsing and basic semantic checks without running any lint rules.                                                                                                     |
 | `--staged`                 | Only lint files that are staged in git. Designed for pre-commit hooks. Fails if not in a git repository.                                                                               |
+| `--stdin-input`            | Read file content from stdin and use the single path argument for baseline and reporting. Intended for editor integrations (e.g. unsaved buffers). Requires exactly one path.          |
 | `--help`, `-h`             | Print the help summary for the command.                                                                                                                                                |
+
+### Reading from stdin (editor integration)
+
+When using an editor or IDE that can pipe unsaved buffer content, you can run the linter on that content while still using the real file path for baseline lookup and issue locations:
+
+```sh
+cat src/Example.php | mago lint --stdin-input src/Example.php
+```
+
+You must pass **exactly one path**; it is used as the logical file name (workspace-relative) for baseline matching and diagnostics. The path is normalized (e.g. `./src/Example.php` is treated like `src/Example.php`). This mode conflicts with `--staged`.
 
 ### Shared Reporting and Fixing Options
 

--- a/src/commands/analyze.rs
+++ b/src/commands/analyze.rs
@@ -59,6 +59,7 @@ use mago_orchestrator::Orchestrator;
 use mago_prelude::Prelude;
 
 use crate::commands::args::baseline_reporting::BaselineReportingArgs;
+use crate::commands::stdin_input;
 use crate::config::Configuration;
 use crate::consts::PRELUDE_BYTES;
 use crate::error::Error;
@@ -149,6 +150,13 @@ pub struct AnalyzeCommand {
     #[arg(long, conflicts_with_all = ["path", "list_codes", "watch"])]
     pub staged: bool,
 
+    /// Read the file content from stdin and use the given path for baseline and reporting.
+    ///
+    /// Intended for editor integrations: pipe unsaved buffer content and pass the real file path
+    /// so baseline entries and issue locations use the correct path.
+    #[arg(long, conflicts_with_all = ["list_codes", "watch", "staged"])]
+    pub stdin_input: bool,
+
     /// Arguments related to reporting issues with baseline support.
     #[clap(flatten)]
     pub baseline_reporting: BaselineReportingArgs,
@@ -211,7 +219,14 @@ impl AnalyzeCommand {
         let mut orchestrator = create_orchestrator(&configuration, color_choice, false, true, false);
         orchestrator.add_exclude_patterns(configuration.analyzer.excludes.iter());
 
-        if self.staged {
+        let stdin_override = stdin_input::resolve_stdin_override(
+            self.stdin_input,
+            &self.path,
+            &configuration.source.workspace,
+            &mut orchestrator,
+        )?;
+
+        if !self.stdin_input && self.staged {
             let staged_paths = git::get_staged_file_paths(&configuration.source.workspace)?;
             if staged_paths.is_empty() {
                 tracing::info!("No staged files to analyze.");
@@ -223,11 +238,12 @@ impl AnalyzeCommand {
             }
 
             orchestrator.set_source_paths(staged_paths.iter().map(|p| p.to_string_lossy().to_string()));
-        } else if !self.path.is_empty() {
-            orchestrator.set_source_paths(self.path.iter().map(|p| p.to_string_lossy().to_string()));
+        } else if !self.stdin_input && !self.path.is_empty() {
+            stdin_input::set_source_paths_from_paths(&mut orchestrator, &self.path);
         }
 
-        let mut database = orchestrator.load_database(&configuration.source.workspace, true, Some(database))?;
+        let mut database =
+            orchestrator.load_database(&configuration.source.workspace, true, Some(database), stdin_override)?;
 
         if !database.files().any(|f| f.file_type == FileType::Host) {
             tracing::warn!("No files found to analyze.");
@@ -335,7 +351,8 @@ impl AnalyzeCommand {
     ) -> Result<WatchOutcome, Error> {
         tracing::info!("Starting watch mode. Press Ctrl+C to stop.");
 
-        let database = orchestrator.load_database(&configuration.source.workspace, true, Some(prelude_database))?;
+        let database =
+            orchestrator.load_database(&configuration.source.workspace, true, Some(prelude_database), None)?;
 
         let mut watcher = DatabaseWatcher::new(database);
 

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -188,7 +188,7 @@ impl FormatCommand {
             return Ok(exit_code);
         }
 
-        let mut database = orchestrator.load_database(&configuration.source.workspace, false, None)?;
+        let mut database = orchestrator.load_database(&configuration.source.workspace, false, None, None)?;
         let service = orchestrator.get_format_service(database.read_only());
 
         let result = service.run()?;
@@ -265,7 +265,7 @@ impl FormatCommand {
         let mut orchestrator = create_orchestrator(&configuration, color_choice, false, true, false);
         orchestrator.add_exclude_patterns(configuration.formatter.excludes.iter());
 
-        let mut database = orchestrator.load_database(workspace, false, None)?;
+        let mut database = orchestrator.load_database(workspace, false, None, None)?;
 
         // Get staged files that are clean (no unstaged changes), resolved to file IDs
         let staged_file_ids = git::get_staged_clean_files(workspace, &database)?;

--- a/src/commands/list_files.rs
+++ b/src/commands/list_files.rs
@@ -120,7 +120,7 @@ impl ListFilesCommand {
             }
         }
 
-        let database = orchestrator.load_database(&configuration.source.workspace, false, None)?;
+        let database = orchestrator.load_database(&configuration.source.workspace, false, None, None)?;
 
         for file in database.files() {
             print!("{}{}", file.name, if self.zero_terminate { '\0' } else { '\n' });

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -80,6 +80,7 @@ pub mod init;
 pub mod lint;
 pub mod list_files;
 pub mod self_update;
+pub mod stdin_input;
 
 /// ANSI color styling configuration for Mago's CLI output.
 ///

--- a/src/commands/stdin_input.rs
+++ b/src/commands/stdin_input.rs
@@ -1,0 +1,53 @@
+use std::io::Read;
+use std::path::Path;
+
+use mago_database::error::DatabaseError;
+use mago_orchestrator::Orchestrator;
+
+use crate::error::Error;
+
+/// When `--stdin-input` is used: validates exactly one path, reads stdin,
+/// computes workspace-relative logical name (with `./` normalization),
+/// sets the orchestrator source path to that single path, and returns
+/// `Some((logical_name, content))` for `load_database(..., stdin_override)`.
+/// Otherwise returns `None`.
+pub fn resolve_stdin_override(
+    stdin_input: bool,
+    path: &[std::path::PathBuf],
+    workspace: &Path,
+    orchestrator: &mut Orchestrator,
+) -> Result<Option<(String, String)>, Error> {
+    if !stdin_input {
+        return Ok(None);
+    }
+    if path.len() != 1 {
+        return Err(Error::Database(DatabaseError::IOError(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "When using --stdin-input, exactly one file path must be provided.",
+        ))));
+    }
+    let path = &path[0];
+    let mut content = String::new();
+    std::io::stdin().read_to_string(&mut content).map_err(|e| Error::Database(DatabaseError::IOError(e)))?;
+
+    #[cfg(windows)]
+    let mut logical_name = path.strip_prefix(workspace).unwrap_or(path.as_path()).to_string_lossy().replace('\\', "/");
+    #[cfg(not(windows))]
+    let mut logical_name = path.strip_prefix(workspace).unwrap_or(path.as_path()).to_string_lossy().into_owned();
+    while logical_name.starts_with("./") {
+        logical_name = logical_name.split_off(2);
+    }
+
+    orchestrator.set_source_paths([path.to_string_lossy().to_string()]);
+    Ok(Some((logical_name, content)))
+}
+
+/// Sets the orchestrator source paths from the given path list.
+/// Call when not using stdin and the path list is non-empty (e.g. after
+/// handling a possible `--staged` branch in analyze/lint).
+pub fn set_source_paths_from_paths(orchestrator: &mut Orchestrator, paths: &[std::path::PathBuf]) {
+    if paths.is_empty() {
+        return;
+    }
+    orchestrator.set_source_paths(paths.iter().map(|p| p.to_string_lossy().to_string()));
+}

--- a/tests/stdin_input.rs
+++ b/tests/stdin_input.rs
@@ -1,0 +1,306 @@
+//! Integration tests for --stdin-input on `analyze`, `lint`, and `guard`.
+//!
+//! These tests run the mago binary with content piped via stdin and a path argument
+//! and verify that the path is used for reporting (and baseline when applicable).
+
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+use std::process::Stdio;
+
+/// Strip leading log lines (e.g. " INFO ...") so the remainder is JSON.
+fn strip_log_prefix(stdout: &str) -> &str {
+    let s = stdout.trim();
+    let start = s.find('{').unwrap_or(0);
+    s[start..].trim()
+}
+
+/// Minimal JSON parsing to read the "issues" array and file "name" from the first issue.
+/// Returns None if stdout is empty or not valid JSON (e.g. when no issues and report is empty).
+fn parse_issues_json(stdout: &str) -> Option<(usize, Vec<String>)> {
+    let s = strip_log_prefix(stdout);
+    if s.is_empty() {
+        return Some((0, vec![]));
+    }
+    let json: serde_json::Value = serde_json::from_str(s).ok()?;
+    let issues = json.get("issues")?.as_array()?;
+    let names: Vec<String> = issues
+        .iter()
+        .filter_map(|issue| {
+            let ann = issue.get("annotations")?.as_array()?.first()?;
+            let span = ann.get("span")?;
+            let file_id = span.get("file_id")?;
+            file_id.get("name").and_then(|n| n.as_str()).map(String::from)
+        })
+        .collect();
+
+    Some((issues.len(), names))
+}
+
+fn mago_bin() -> PathBuf {
+    // Prefer runtime env (set when cargo runs the test), then compile-time (set when cargo builds the test).
+    let path = std::env::var("CARGO_BIN_EXE_mago")
+        .ok()
+        .or_else(|| option_env!("CARGO_BIN_EXE_mago").map(String::from))
+        .unwrap_or_else(|| "mago".to_string());
+
+    PathBuf::from(path)
+}
+
+fn run_mago_stdin(
+    subcommand: &str,
+    workspace: &Path,
+    path_arg: &str,
+    stdin_content: &str,
+    extra_args: &[&str],
+) -> (std::process::Output, String) {
+    let mut args = vec![
+        "--workspace",
+        workspace.to_str().unwrap(),
+        subcommand,
+        path_arg,
+        "--stdin-input",
+        "--reporting-format",
+        "json",
+    ];
+
+    args.extend(extra_args);
+
+    let mut child = Command::new(mago_bin())
+        .args(&args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn mago");
+
+    child.stdin.as_mut().unwrap().write_all(stdin_content.as_bytes()).unwrap();
+    let output = child.wait_with_output().expect("failed to run mago");
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+
+    (output, stdout)
+}
+
+#[test]
+fn test_analyze_stdin_input_uses_path_in_output() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let workspace = temp_dir.path();
+
+    std::fs::create_dir(workspace.join("src")).unwrap();
+    std::fs::write(
+        workspace.join("mago.toml"),
+        r#"
+php-version = "8.4"
+[source]
+paths = ["src"]
+[analyzer]
+"#,
+    )
+    .unwrap();
+    std::fs::write(workspace.join("src").join("example.php"), "<?php\n").unwrap();
+
+    // PHP that triggers at least one analyzer issue, so the JSON report contains the file path.
+    let php = r#"<?php
+function f(): int { return "not an int"; }
+"#;
+    let (_output, stdout) = run_mago_stdin("analyze", workspace, "src/example.php", php, &[]);
+
+    assert!(
+        stdout.contains("example.php"),
+        "analyze --stdin-input output should contain the file path in report; got: {}",
+        stdout
+    );
+}
+
+#[test]
+fn test_lint_stdin_input_uses_path_in_output() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let workspace = temp_dir.path();
+
+    std::fs::create_dir(workspace.join("src")).unwrap();
+    std::fs::write(
+        workspace.join("mago.toml"),
+        r#"
+php-version = "8.4"
+[source]
+paths = ["src"]
+[linter]
+"#,
+    )
+    .unwrap();
+    std::fs::write(workspace.join("src").join("example.php"), "<?php\n").unwrap();
+
+    // PHP that triggers at least one lint issue, so the report contains the file path.
+    let php = r#"<?php
+  $x=1;
+"#;
+    let (_output, stdout) = run_mago_stdin("lint", workspace, "src/example.php", php, &[]);
+
+    assert!(
+        stdout.contains("example.php"),
+        "lint --stdin-input output should contain the file path in report; got: {}",
+        stdout
+    );
+}
+
+#[test]
+fn test_guard_stdin_input_uses_path_in_output() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let workspace = temp_dir.path();
+
+    std::fs::create_dir(workspace.join("src")).unwrap();
+    std::fs::write(
+        workspace.join("mago.toml"),
+        r#"
+php-version = "8.4"
+[source]
+paths = ["src"]
+[guard]
+"#,
+    )
+    .unwrap();
+    std::fs::write(workspace.join("src").join("example.php"), "<?php\n").unwrap();
+
+    // Minimal PHP for guard (the path must appear in the report; guard may or may not report issues).
+    let php = r#"<?php
+$x = 1;
+"#;
+    let (output, stdout) = run_mago_stdin("guard", workspace, "src/example.php", php, &[]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(output.status.success(), "guard --stdin-input should succeed; stdout: {:?}; stderr: {:?}", stdout, stderr);
+    assert!(
+        stdout.contains("example.php") || stderr.contains("No issues found"),
+        "guard --stdin-input should use path or report no issues; got stdout: {:?}, stderr: {:?}",
+        stdout,
+        stderr
+    );
+}
+
+/// When the path argument has a leading "./", the reported file name in JSON must be normalized
+/// (no "./") so baseline matching works the same as for disk-loaded files.
+#[test]
+fn test_analyze_stdin_input_normalizes_dot_slash_path() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let workspace = temp_dir.path();
+
+    std::fs::create_dir(workspace.join("src")).unwrap();
+    std::fs::write(
+        workspace.join("mago.toml"),
+        r#"
+php-version = "8.4"
+[source]
+paths = ["src"]
+[analyzer]
+"#,
+    )
+    .unwrap();
+    std::fs::write(workspace.join("src").join("example.php"), "<?php\n").unwrap();
+
+    let php = r#"<?php
+function f(): int { return "not an int"; }
+"#;
+    // Pass path with leading ./ so we verify it is normalized in the report.
+    let (_output, stdout) = run_mago_stdin("analyze", workspace, "./src/example.php", php, &[]);
+
+    let (count, names) = parse_issues_json(&stdout).expect("output should be valid JSON with issues");
+    assert!(count >= 1, "expected at least one issue; got: {}", stdout);
+    for name in &names {
+        assert!(
+            !name.starts_with("./"),
+            "reported file name must be normalized (no leading ./) for baseline matching; got name: {:?}",
+            name
+        );
+        assert!(
+            name == "src/example.php" || name.ends_with("example.php"),
+            "reported file name should be workspace-relative; got: {:?}",
+            name
+        );
+    }
+}
+
+/// With a baseline file, stdin-input should filter issues the same way as analyzing the file from disk,
+/// so that baselines apply correctly when using --stdin-input (e.g. from the IDE).
+#[test]
+fn test_analyze_stdin_input_baseline_filters_same_as_file() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let workspace = temp_dir.path();
+
+    std::fs::create_dir(workspace.join("src")).unwrap();
+    let mago_toml = r#"
+php-version = "8.4"
+[source]
+paths = ["src"]
+[analyzer]
+baseline = "baseline.toml"
+"#;
+    std::fs::write(workspace.join("mago.toml"), mago_toml).unwrap();
+
+    // PHP that triggers exactly two analyzer issues (so we can baseline them).
+    let php_two_issues = r#"<?php
+function f($a, $b) {
+    return (string) $a;
+}
+"#;
+    std::fs::write(workspace.join("src").join("baseline_test.php"), php_two_issues).unwrap();
+
+    let mago = mago_bin();
+    let run = |args: &[&str], stdin: Option<&str>| {
+        let mut cmd = Command::new(&mago);
+        cmd.current_dir(workspace);
+        cmd.args(["--workspace", workspace.to_str().unwrap()]);
+        cmd.args(args);
+        cmd.args(["--reporting-format", "json"]);
+        if let Some(s) = stdin {
+            cmd.stdin(Stdio::piped());
+            cmd.stdout(Stdio::piped());
+            cmd.stderr(Stdio::piped());
+            let mut child = cmd.spawn().unwrap();
+            child.stdin.as_mut().unwrap().write_all(s.as_bytes()).unwrap();
+            child.wait_with_output().unwrap()
+        } else {
+            cmd.output().unwrap()
+        }
+    };
+
+    // Generate baseline from current 2 issues.
+    let out = run(&["analyze", "src/baseline_test.php", "--baseline", "baseline.toml", "--generate-baseline"], None);
+    assert!(out.status.success(), "generate-baseline should succeed: {}", String::from_utf8_lossy(&out.stderr));
+
+    // Add one more issue (missing return type) so we have 3 total; only 1 should be reported after baseline.
+    let php_three_issues = r#"<?php
+function f($a, $b) {
+    return (string) $a;
+}
+function g() { return 1; }
+"#;
+
+    std::fs::write(workspace.join("src").join("baseline_test.php"), php_three_issues).unwrap();
+
+    // Run from disk: baseline should filter some issues; we only care that stdin matches disk.
+    let out_disk = run(&["analyze", "src/baseline_test.php"], None);
+    let stdout_disk = String::from_utf8_lossy(&out_disk.stdout);
+    let (count_disk, _) = parse_issues_json(&stdout_disk).unwrap_or((0, vec![]));
+
+    // Run with stdin and normalized path (src/...): should also report 1 issue.
+    let out_stdin = run(&["analyze", "src/baseline_test.php", "--stdin-input"], Some(php_three_issues));
+    let stdout_stdin = String::from_utf8_lossy(&out_stdin.stdout);
+    let (count_stdin, _) = parse_issues_json(&stdout_stdin).unwrap_or((0, vec![]));
+
+    assert_eq!(
+        count_disk, count_stdin,
+        "stdin-input should apply baseline like disk: disk reported {} issues, stdin reported {}",
+        count_disk, count_stdin
+    );
+
+    // Same with path as ./src/... (normalized internally).
+    let out_stdin_dot = run(&["analyze", "./src/baseline_test.php", "--stdin-input"], Some(php_three_issues));
+    let stdout_stdin_dot = String::from_utf8_lossy(&out_stdin_dot.stdout);
+    let (count_stdin_dot, _) = parse_issues_json(&stdout_stdin_dot).unwrap_or((0, vec![]));
+    assert_eq!(
+        count_stdin_dot, count_disk,
+        "stdin with ./path should normalize and apply baseline like disk; disk={}, stdin_dot={}",
+        count_disk, count_stdin_dot
+    );
+}


### PR DESCRIPTION
Allows reading unsaved buffer content with a logical name for editor integrations.

closes #1201
closes #661

## 📌 What Does This PR Do?

Add option `--stdin-input` for `analyze`, `lint` and `guard`.

## 🔍 Context & Motivation

IDE Integration.

## 📂 Affected Areas

- [X] Analyzer
- [X] Linter
- [X] Guard
- [ ] Formatter
- [X] CLI
- [X] Dependencies
- [X] Documentation
