### PR TITLE
feat: add support for `only` and `only-in` filtering in analyzer and linter configuration

### DIFF
--- a/docs/tools/linter/command-reference.md
+++ b/docs/tools/linter/command-reference.md
@@ -24,11 +24,11 @@ Optional. A list of specific files or directories to lint. If you provide paths 
 ## Options
 
 | Flag, Alias(es)            | Description                                                                                                                                                                            |
-| :------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|:---------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `--list-rules`             | List all enabled linter rules and their descriptions.                                                                                                                                  |
 | `--json`                   | Used with `--list-rules` to output the rule information in a machine-readable JSON format.                                                                                             |
 | `--explain <RULE_CODE>`    | Provide detailed documentation for a specific linter rule (e.g., `no-redundant-nullsafe`).                                                                                             |
-| `--only <RULE_CODE>`, `-o` | Run only a specific, comma-separated list of rules, overriding the configuration file.                                                                                                 |
+| `--only <RULE_CODE>`, `-o` | Run only a specific, comma-separated list of rules. When omitted, the `only` list from `[linter]` in `mago.toml` is used (if set). Command-line `--only` overrides the config.         |
 | `--pedantic`               | Enable all linter rules for the most exhaustive analysis possible. This overrides your configuration, ignores PHP version constraints, and enables rules that are disabled by default. |
 | `--semantics`, `-s`        | Perform only the parsing and basic semantic checks without running any lint rules.                                                                                                     |
 | `--staged`                 | Only lint files that are staged in git. Designed for pre-commit hooks. Fails if not in a git repository.                                                                               |

--- a/docs/tools/linter/configuration-reference.md
+++ b/docs/tools/linter/configuration-reference.md
@@ -11,6 +11,7 @@ title: Linter configuration reference
 [linter]
 integrations = ["symfony", "phpunit"]
 excludes = ["src/Generated/"]
+only = ["strict-types"]   # Run only these rules (same path-scoped formats as analyzer only)
 baseline = "linter-baseline.toml"
 
 [linter.rules]
@@ -29,12 +30,14 @@ prefer-static-closure = { exclude = ["tests/"] }
 
 ## `[linter]`
 
-| Option             | Type       | Default   | Description                                                                  |
-| :----------------- | :--------- | :-------- | :--------------------------------------------------------------------------- |
-| `excludes`         | `string[]` | `[]`      | A list of paths or glob patterns to exclude from linting.                    |
-| `integrations`     | `string[]` | `[]`      | A list of framework integrations to enable (e.g., `"symfony"`, `"laravel"`). |
-| `baseline`         | `string`   | `null`    | Path to a baseline file to ignore listed issues. When specified, the linter will use this file as the default baseline, eliminating the need to pass `--baseline` on every run. Command-line `--baseline` arguments will override this setting. |
-| `baseline-variant` | `string`   | `"loose"` | The baseline format variant to use when generating new baselines. Options: `"loose"` (count-based, resilient to line changes) or `"strict"` (exact line matching). See [Baseline Variants](/fundamentals/baseline#baseline-variants) for details. |
+| Option             | Type                   | Default   | Description                                                                                                                                                                                                                                       |
+|:-------------------|:-----------------------|:----------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `excludes`         | `string[]`             | `[]`      | A list of paths or glob patterns to exclude from linting.                                                                                                                                                                                         |
+| `only`             | `(string \| object)[]` | `[]`      | Run only these rule codes; same path-scoped formats as analyzer `only`. See [Path-scoped only](#path-scoped-only). Command-line `--only` overrides this when present.                                                                             |
+| `only-in`          | `object[]`             | `[]`      | In the given paths, run only the specified rule; other paths are unaffected. See [Only-in (scoped-only)](#only-in-scoped-only).                                                                                                                   |
+| `integrations`     | `string[]`             | `[]`      | A list of framework integrations to enable (e.g., `"symfony"`, `"laravel"`).                                                                                                                                                                      |
+| `baseline`         | `string`               | `null`    | Path to a baseline file to ignore listed issues. When specified, the linter will use this file as the default baseline, eliminating the need to pass `--baseline` on every run. Command-line `--baseline` arguments will override this setting.   |
+| `baseline-variant` | `string`               | `"loose"` | The baseline format variant to use when generating new baselines. Options: `"loose"` (count-based, resilient to line changes) or `"strict"` (exact line matching). See [Baseline Variants](/fundamentals/baseline#baseline-variants) for details. |
 
 :::tip Tool-Specific Excludes
 The `excludes` option here is **additive** to the global `source.excludes` defined in the `[source]` section of your configuration. Files excluded globally will always be excluded from linting, and this option allows you to exclude additional files from the linter specifically.
@@ -86,6 +89,40 @@ Per-rule `exclude` is different from the top-level `[linter].excludes`:
 - `[linter].excludes` removes files from **all** lint rules.
 - A rule's `exclude` removes files from **that specific rule** only — other rules still apply to those files.
 :::
+
+### Path-scoped only
+
+The `only` option restricts which rules run and which issues are reported. It uses the same formats as the analyzer's `only` (and `ignore`):
+
+**Plain string** — run only this rule everywhere:
+```toml
+[linter]
+only = ["strict-types"]
+```
+
+**Object with path(s)** — run this rule only in specific paths:
+```toml
+[linter]
+only = [
+  { code = "strict-types", in = "src/" },
+  { code = "no-empty", in = ["tests/", "docs/"] },
+]
+```
+
+When `only` is non-empty, only the listed rules run and only issues matching an entry (and, for scoped entries, the file path) are reported. Paths are prefix-matched against relative file paths from the project root. Command-line `--only` overrides the config when provided.
+
+### Only-in (scoped-only)
+
+Use `only-in` when you want to **run a specific rule only in certain paths**, without restricting other files. Each entry is `{ code = "...", in = "path/" }` or `in = ["a/", "b/"]`. Files that match an entry's path only report that rule in that path; files that do not match any entry are unchanged.
+
+```toml
+[linter]
+only-in = [
+  { code = "strict-types", in = ["src/"] },
+]
+```
+
+This is different from `only`: `only` is a global allowlist. `only-in` restricts only inside the listed paths; elsewhere, all rules still run.
 
 ### Rule-specific options
 

--- a/src/commands/analyze.rs
+++ b/src/commands/analyze.rs
@@ -232,6 +232,12 @@ impl AnalyzeCommand {
         issues.filter_out_ignored(&configuration.analyzer.ignore, |file_id| {
             read_db.get_ref(&file_id).ok().map(|f| f.name.to_string())
         });
+        issues.filter_retain_only(&configuration.analyzer.only, |file_id| {
+            read_db.get_ref(&file_id).ok().map(|f| f.name.to_string())
+        });
+        issues.filter_retain_only_in(&configuration.analyzer.only_in, |file_id| {
+            read_db.get_ref(&file_id).ok().map(|f| f.name.to_string())
+        });
 
         let baseline = configuration.analyzer.baseline.as_deref();
         let baseline_variant = configuration.analyzer.baseline_variant;
@@ -295,6 +301,12 @@ impl AnalyzeCommand {
         issues.filter_out_ignored(&configuration.analyzer.ignore, |file_id| {
             read_db.get_ref(&file_id).ok().map(|f| f.name.to_string())
         });
+        issues.filter_retain_only(&configuration.analyzer.only, |file_id| {
+            read_db.get_ref(&file_id).ok().map(|f| f.name.to_string())
+        });
+        issues.filter_retain_only_in(&configuration.analyzer.only_in, |file_id| {
+            read_db.get_ref(&file_id).ok().map(|f| f.name.to_string())
+        });
         let baseline = configuration.analyzer.baseline.as_deref();
         let baseline_variant = configuration.analyzer.baseline_variant;
 
@@ -326,6 +338,12 @@ impl AnalyzeCommand {
             let mut issues = analysis_result.issues;
             let read_db = watcher.read_only_database();
             issues.filter_out_ignored(&configuration.analyzer.ignore, |file_id| {
+                read_db.get_ref(&file_id).ok().map(|f| f.name.to_string())
+            });
+            issues.filter_retain_only(&configuration.analyzer.only, |file_id| {
+                read_db.get_ref(&file_id).ok().map(|f| f.name.to_string())
+            });
+            issues.filter_retain_only_in(&configuration.analyzer.only_in, |file_id| {
                 read_db.get_ref(&file_id).ok().map(|f| f.name.to_string())
             });
 

--- a/src/config/analyzer.rs
+++ b/src/config/analyzer.rs
@@ -14,6 +14,8 @@ use mago_codex::ttype::combiner::DEFAULT_INTEGER_COMBINATION_THRESHOLD;
 use mago_codex::ttype::combiner::DEFAULT_STRING_COMBINATION_THRESHOLD;
 use mago_php_version::PHPVersion;
 use mago_reporting::IgnoreEntry;
+use mago_reporting::OnlyEntry;
+use mago_reporting::OnlyInEntry;
 use mago_reporting::baseline::BaselineVariant;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -30,6 +32,19 @@ pub struct AnalyzerConfiguration {
 
     /// Ignore specific issues based on their code, optionally scoped to paths.
     pub ignore: Vec<IgnoreEntry>,
+
+    /// Report only specific issue codes, optionally scoped to paths.
+    ///
+    /// Same formats as `ignore`: plain string (everywhere), or `{ code = "...", in = "path/" }` / `in = ["a/", "b/"]`.
+    /// When non-empty, only matching issues are reported; all others are filtered out.
+    pub only: Vec<OnlyEntry>,
+
+    /// In the given paths, report only the specified code; other paths are not restricted.
+    ///
+    /// Each entry is `{ code = "...", in = "path/" }` or `in = ["a/", "b/"]`. Files outside any entry's paths
+    /// are unaffected. Use this to enable a check only in specific files or directories.
+    #[serde(rename = "only-in")]
+    pub only_in: Vec<OnlyInEntry>,
 
     /// Path to a baseline file to ignore listed issues.
     pub baseline: Option<PathBuf>,
@@ -382,6 +397,8 @@ impl Default for AnalyzerConfiguration {
             plugins: vec![],
             excludes: vec![],
             ignore: vec![],
+            only: vec![],
+            only_in: vec![],
             baseline: None,
             baseline_variant: BaselineVariant::default(),
             find_unused_expressions: defaults.find_unused_expressions,

--- a/src/config/linter.rs
+++ b/src/config/linter.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use mago_reporting::OnlyEntry;
+use mago_reporting::OnlyInEntry;
 use mago_reporting::baseline::BaselineVariant;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -17,6 +19,21 @@ use mago_php_version::PHPVersion;
 pub struct LinterConfiguration {
     /// A list of patterns to exclude from linting.
     pub excludes: Vec<String>,
+
+    /// Run only specific rule codes, optionally scoped to paths.
+    ///
+    /// Same formats as analyzer/linter `ignore`: plain string (e.g. `"strict-types"`),
+    /// or `{ code = "strict-types", in = "src/" }` / `in = ["src/", "tests/"]`.
+    /// When non-empty, only these rules run and only matching issues are reported.
+    #[serde(default)]
+    pub only: Vec<OnlyEntry>,
+
+    /// In the given paths, run only the specified rule; other paths are not restricted.
+    ///
+    /// Each entry is `{ code = "...", in = "path/" }` or `in = ["a/", "b/"]`. Files outside any entry's paths
+    /// are unaffected.
+    #[serde(default, rename = "only-in")]
+    pub only_in: Vec<OnlyInEntry>,
 
     /// Integrations to enable during linting.
     pub integrations: Vec<Integration>,
@@ -51,6 +68,8 @@ impl LinterConfiguration {
 
         serde_json::json!({
             "excludes": self.excludes,
+            "only": self.only,
+            "only-in": self.only_in,
             "integrations": self.integrations,
             "rules": filtered_rules,
             "baseline": self.baseline,


### PR DESCRIPTION
## 📌 What Does This PR Do?

- Add the `only` option (global allowlist)
- Add the `only-in` option (scoped filtering)

## 🔍 Context & Motivation

We only use `strict-types` for the linter, would be nice if we wouldn't have to pass it to the CLI all the time.

## 📂 Affected Areas

- [X] Analyzer
- [X] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [X] Documentation
