### PR TITLE
fix(codex): include literal floats in type combination simplicity check

### DIFF
--- a/crates/analyzer/tests/cases/issue_1262.php
+++ b/crates/analyzer/tests/cases/issue_1262.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Example;
+
+/**
+ * @template T of int|float
+ *
+ * @param T $start
+ * @param T $end
+ * @param T|null $step
+ *
+ * @return non-empty-list<T>
+ */
+function range(int|float $start, int|float $end, int|float|null $step = null): array
+{
+    return range($start, $end, $step);
+}
+
+range(start: 0.0, end: 1.0, step: 0.5);

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -693,6 +693,7 @@ test_case!(issue_1230_simple, {
     s
 });
 test_case!(issue_1226);
+test_case!(issue_1262);
 test_case!(issue_1265);
 test_case!(issue_1264);
 test_case!(issue_1267);

--- a/crates/codex/src/ttype/combination.rs
+++ b/crates/codex/src/ttype/combination.rs
@@ -201,6 +201,7 @@ impl TypeCombination {
             return self.object_type_params.is_empty()
                 && self.enum_names.is_empty()
                 && self.literal_strings.is_empty()
+                && self.literal_floats.is_empty()
                 && self.class_string_types.is_empty()
                 && self.integers.is_empty()
                 && self.derived_types.is_empty();


### PR DESCRIPTION
closes #1262
