### PR TITLE
fix(analyzer): skip unreachable code diagnostics and dead-code filtering for declarations

### DIFF
--- a/crates/analyzer/src/statement/mod.rs
+++ b/crates/analyzer/src/statement/mod.rs
@@ -224,6 +224,8 @@ pub fn analyze_statements<'ctx, 'arena>(
     artifacts: &mut AnalysisArtifacts,
 ) -> Result<(), AnalysisError> {
     for statement in statements {
+        let is_declaration = statement.is_declaration();
+
         if block.flags.has_returned() {
             if context.settings.find_unused_expressions {
                 let is_harmless = match &statement {
@@ -243,7 +245,7 @@ pub fn analyze_statements<'ctx, 'arena>(
                             .with_note("This statement is unreachable because the block has already returned.")
                             .with_help("Consider removing this statement as it does not do anything in this context."),
                     );
-                } else {
+                } else if !is_declaration {
                     context.collector.report_with_code(
                         IssueCode::UnevaluatedCode,
                         Issue::help("Unreachable code detected.")
@@ -254,7 +256,7 @@ pub fn analyze_statements<'ctx, 'arena>(
                 }
             }
 
-            if !context.settings.analyze_dead_code {
+            if !is_declaration && !context.settings.analyze_dead_code {
                 continue;
             }
         }

--- a/crates/analyzer/tests/cases/issue_1259.php
+++ b/crates/analyzer/tests/cases/issue_1259.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+main(function (): int {
+    echo foo();
+
+    return 0;
+});
+
+/**
+ * @param (Closure(): int) $cb
+ */
+function main(Closure $cb): never
+{
+    $code = $cb();
+
+    exit($code);
+}
+
+function foo(): string
+{
+    return 1; // @mago-expect analysis:invalid-return-statement
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -693,9 +693,10 @@ test_case!(issue_1230_simple, {
     s
 });
 test_case!(issue_1226);
+test_case!(issue_1259);
 test_case!(issue_1262);
-test_case!(issue_1265);
 test_case!(issue_1264);
+test_case!(issue_1265);
 test_case!(issue_1266);
 test_case!(issue_1266_inheritdoc_narrowing);
 test_case!(issue_1267);


### PR DESCRIPTION
closes #1259
