### PR TITLE
fix(linter): narrow annotation spans to highlight minimal code regions

### DIFF
--- a/crates/linter/src/rule/maintainability/cyclomatic_complexity.rs
+++ b/crates/linter/src/rule/maintainability/cyclomatic_complexity.rs
@@ -19,6 +19,7 @@ use crate::context::LintContext;
 use crate::requirements::RuleRequirements;
 use crate::rule::Config;
 use crate::rule::LintRule;
+use crate::rule::utils::misc::get_class_like_header_span;
 use crate::rule::utils::misc::is_method_setter_or_getter;
 use crate::rule_meta::RuleMeta;
 use crate::settings::RuleSettings;
@@ -185,14 +186,16 @@ impl LintRule for CyclomaticComplexityRule {
     }
 
     fn check<'arena>(&self, ctx: &mut LintContext<'_, 'arena>, node: Node<'_, 'arena>) {
+        let span = get_class_like_header_span(node);
+
         match node {
-            Node::Class(n) => self.check_class_like("Class", n.members.as_slice(), n.span(), ctx),
-            Node::Trait(n) => self.check_class_like("Trait", n.members.as_slice(), n.span(), ctx),
-            Node::AnonymousClass(n) => self.check_class_like("Class", n.members.as_slice(), n.span(), ctx),
-            Node::Enum(n) => self.check_class_like("Enum", n.members.as_slice(), n.span(), ctx),
-            Node::Interface(n) => self.check_class_like("Interface", n.members.as_slice(), n.span(), ctx),
-            Node::Function(n) => self.check_function_like("Function", &n.body, n.span(), ctx),
-            Node::Closure(n) => self.check_function_like("Closure", &n.body, n.span(), ctx),
+            Node::Class(n) => self.check_class_like("Class", n.members.as_slice(), span, ctx),
+            Node::Trait(n) => self.check_class_like("Trait", n.members.as_slice(), span, ctx),
+            Node::AnonymousClass(n) => self.check_class_like("Class", n.members.as_slice(), span, ctx),
+            Node::Enum(n) => self.check_class_like("Enum", n.members.as_slice(), span, ctx),
+            Node::Interface(n) => self.check_class_like("Interface", n.members.as_slice(), span, ctx),
+            Node::Function(n) => self.check_function_like("Function", &n.body, span, ctx),
+            Node::Closure(n) => self.check_function_like("Closure", &n.body, span, ctx),
             _ => (),
         }
     }

--- a/crates/linter/src/rule/maintainability/kan_defect.rs
+++ b/crates/linter/src/rule/maintainability/kan_defect.rs
@@ -5,7 +5,6 @@ use serde::Serialize;
 use mago_reporting::Annotation;
 use mago_reporting::Issue;
 use mago_reporting::Level;
-use mago_span::HasSpan;
 use mago_syntax::ast::Node;
 use mago_syntax::ast::NodeKind;
 
@@ -14,6 +13,7 @@ use crate::context::LintContext;
 use crate::requirements::RuleRequirements;
 use crate::rule::Config;
 use crate::rule::LintRule;
+use crate::rule::utils::misc::get_class_like_header_span;
 use crate::rule_meta::RuleMeta;
 use crate::settings::RuleSettings;
 
@@ -202,7 +202,7 @@ impl LintRule for KanDefectRule {
             ctx.collector.report(
                 Issue::new(self.cfg.level, format!("{kind} has a high kan defect score ({kan_defect})."))
                     .with_code(self.meta.code)
-                    .with_annotation(Annotation::primary(node.span()).with_message(format!(
+                    .with_annotation(Annotation::primary(get_class_like_header_span(node)).with_message(format!(
                         "{kind} has a kan defect score of {kan_defect}, which exceeds the threshold of {threshold}.",
                     )))
                     .with_note("Kan defect is a heuristic used by phpmetrics to estimate defect-proneness based on control-flow statements.")


### PR DESCRIPTION
## 📌 What Does This PR Do?

Reduces the primary span for cyclomatic-complexity and kan-defect diagnostics so editors don't highlight the whole class body.

## 🔍 Context & Motivation

Highlight noise in the editor makes things unrecognizable.

## 🛠️ Summary of Changes


- **Bug Fix:** Reduced the span size for cyclomatic-complexity and kan-defect to be less noisy in editors

## 📂 Affected Areas

- [x] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

More of the same as for #745

## 📝 Notes for Reviewers

:rainbow: 
