### PR TITLE
fix(formatter): restore correct brace placement for preserved single-parameter lists

### DIFF
--- a/crates/formatter/src/internal/format/function_like.rs
+++ b/crates/formatter/src/internal/format/function_like.rs
@@ -30,6 +30,7 @@ use crate::internal::format::block::block_is_empty;
 use crate::internal::format::format_token;
 use crate::internal::format::misc::print_modifiers;
 use crate::internal::format::parameters::force_break_parameters;
+use crate::internal::format::parameters::preserve_break_parameters;
 use crate::internal::format::parameters::should_hug_the_only_parameter;
 use crate::settings::BraceStyle;
 use crate::wrap;
@@ -296,7 +297,7 @@ impl<'arena> FunctionLikeParts<'arena> {
 
         let parameter_list_will_break = if self.parameter_list.parameters.is_empty() {
             if f.has_inner_comment(self.parameter_list.span()) { None } else { Some(false) }
-        } else if force_break_parameters(f, self.parameter_list) {
+        } else if force_break_parameters(f, self.parameter_list) || preserve_break_parameters(f, self.parameter_list) {
             Some(true)
         } else if should_hug_the_only_parameter(f, self.parameter_list) {
             Some(false)

--- a/crates/formatter/src/internal/format/parameters.rs
+++ b/crates/formatter/src/internal/format/parameters.rs
@@ -30,12 +30,7 @@ pub(super) fn print_function_like_parameters<'arena>(
     }
 
     let mut force_break = force_break_parameters(f, parameter_list);
-    let preserve_break = f.settings.preserve_breaking_parameter_list
-        && misc::has_new_line_in_range(
-            f.source_text,
-            parameter_list.left_parenthesis.start.offset,
-            parameter_list.parameters.as_slice()[0].span().start.offset,
-        );
+    let preserve_break = preserve_break_parameters(f, parameter_list);
     let should_break = force_break || preserve_break;
 
     let previous_break = f.parameter_state.force_break;
@@ -127,6 +122,19 @@ pub(super) fn force_break_parameters<'arena>(
 ) -> bool {
     f.settings.break_promoted_properties_list
         && parameter_list.parameters.iter().any(FunctionLikeParameter::is_promoted_property)
+}
+
+pub(super) fn preserve_break_parameters<'arena>(
+    f: &FormatterState<'_, 'arena>,
+    parameter_list: &'arena FunctionLikeParameterList<'arena>,
+) -> bool {
+    f.settings.preserve_breaking_parameter_list
+        && !parameter_list.parameters.is_empty()
+        && misc::has_new_line_in_range(
+            f.source_text,
+            parameter_list.left_parenthesis.start.offset,
+            parameter_list.parameters.as_slice()[0].span().start.offset,
+        )
 }
 
 pub(super) fn should_hug_the_only_parameter<'arena>(

--- a/crates/formatter/tests/cases/preserve_breaking_parameter_list/after.php
+++ b/crates/formatter/tests/cases/preserve_breaking_parameter_list/after.php
@@ -1,6 +1,47 @@
 <?php
 
-function foo(
+function empty_body(
     $a,
     $b,
 ) {}
+
+function with_body(
+    $a,
+    $b,
+): void {
+    echo $a . $b;
+}
+
+function single_param(
+    string $bar,
+): void {
+    echo $bar;
+}
+
+function single_param_no_return(
+    string $bar,
+) {
+    echo $bar;
+}
+
+class Foo
+{
+    public function method(
+        string $bar,
+    ): void {
+        echo $bar;
+    }
+
+    public function method2(
+        string $a,
+        string $b,
+    ): void {
+        echo $a . $b;
+    }
+}
+
+$closure = function (
+    string $bar,
+): void {
+    echo $bar;
+};

--- a/crates/formatter/tests/cases/preserve_breaking_parameter_list/before.php
+++ b/crates/formatter/tests/cases/preserve_breaking_parameter_list/before.php
@@ -1,6 +1,47 @@
 <?php
 
-function foo(
+function empty_body(
 $a,
 $b
 ) {}
+
+function with_body(
+$a,
+$b
+): void {
+echo $a . $b;
+}
+
+function single_param(
+string $bar,
+): void {
+echo $bar;
+}
+
+function single_param_no_return(
+string $bar,
+) {
+echo $bar;
+}
+
+class Foo
+{
+    public function method(
+string $bar,
+): void {
+echo $bar;
+}
+
+    public function method2(
+string $a,
+string $b,
+): void {
+echo $a . $b;
+}
+}
+
+$closure = function (
+string $bar,
+): void {
+echo $bar;
+};

--- a/crates/formatter/tests/cases/preserve_breaking_parameter_list_promoted_properties/after.php
+++ b/crates/formatter/tests/cases/preserve_breaking_parameter_list_promoted_properties/after.php
@@ -2,7 +2,16 @@
 
 class A
 {
-    public function foo(
+    public function __construct(
         private array $a,
     ) {}
+}
+
+class B
+{
+    public function __construct(
+        private array $a,
+    ) {
+        echo $a;
+    }
 }

--- a/crates/formatter/tests/cases/preserve_breaking_parameter_list_promoted_properties/before.php
+++ b/crates/formatter/tests/cases/preserve_breaking_parameter_list_promoted_properties/before.php
@@ -1,7 +1,15 @@
 <?php
 
 class A {
-public function foo(
+public function __construct(
 private array $a,
 ) {}
+}
+
+class B {
+public function __construct(
+private array $a,
+) {
+echo $a;
+}
 }


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes the opening brace being placed on a new line for functions/methods with a single parameter and non-empty body when `preserve_breaking_parameter_list` is enabled.

## 🔍 Context & Motivation

PR #1260 narrowed `should_break_parameters` to `force_break_parameters` (promoted properties only), but did not add a corresponding preserve-break check to the `parameter_list_will_break` pre-calculation. This let `should_hug_the_only_parameter` produce a false prediction, forcing a hard line before the brace.

## 🛠️ Summary of Changes

- Added `preserve_break_parameters` function in `parameters.rs` and used it in both `parameter_list_will_break` (`function_like.rs`) and `print_function_like_parameters`, replacing the inline duplicate
- Expanded `preserve_breaking_parameter_list` tests with non-empty body cases (`single_param` and `single_param_no_return` directly reproduce the bug)
- Expanded `preserve_breaking_parameter_list_promoted_properties` tests with a non-empty body case, and renamed methods to `__construct` (promoted properties are only valid in constructors)

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Fixes #1290

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
