### PR TITLE
fix(formatter): prevent trailing comment drift in try-catch-finally chains

### DIFF
--- a/crates/formatter/src/internal/comment/format.rs
+++ b/crates/formatter/src/internal/comment/format.rs
@@ -45,15 +45,6 @@ impl<'arena> FormatterState<'_, 'arena> {
     ///
     /// # Returns
     ///
-    /// `true` if the next line is a comment line, `false` otherwise.
-    /// Checks if a node is followed by a comment on its own line.
-    ///
-    /// # Arguments
-    ///
-    /// * `span` - The span of the node after which to check for a comment.
-    ///
-    /// # Returns
-    ///
     /// `true` if the next substantive line is a comment line, `false` otherwise.
     pub(crate) fn is_followed_by_comment_on_next_line(&self, span: Span) -> bool {
         let Some(first_char_offset) = self.skip_spaces(Some(span.end_offset()), false) else {

--- a/crates/formatter/src/internal/format/mod.rs
+++ b/crates/formatter/src/internal/format/mod.rs
@@ -1793,17 +1793,25 @@ impl<'arena> Format<'arena> for Try<'arena> {
         wrap!(f, self, Try, {
             let mut parts = vec![in f.arena; self.r#try.format(f), Document::space(), self.block.format(f)];
 
+            let mut prev_block_span = self.block.span();
             for clause in &self.catch_clauses {
-                if f.settings.following_clause_on_newline {
+                if f.settings.following_clause_on_newline
+                    || f.is_followed_by_comment_on_next_line(prev_block_span)
+                    || f.has_same_line_trailing_comment(prev_block_span)
+                {
                     parts.push(Document::Line(Line::hard()));
                 } else {
                     parts.push(Document::space());
                 }
                 parts.push(clause.format(f));
+                prev_block_span = clause.block.span();
             }
 
             if let Some(clause) = &self.finally_clause {
-                if f.settings.following_clause_on_newline {
+                if f.settings.following_clause_on_newline
+                    || f.is_followed_by_comment_on_next_line(prev_block_span)
+                    || f.has_same_line_trailing_comment(prev_block_span)
+                {
                     parts.push(Document::Line(Line::hard()));
                 } else {
                     parts.push(Document::space());

--- a/crates/formatter/tests/cases/try_catch_trailing_comment/after.php
+++ b/crates/formatter/tests/cases/try_catch_trailing_comment/after.php
@@ -1,0 +1,67 @@
+<?php
+
+// try to catch, same-line comment
+try {
+    doSomething();
+} // @todo Handle this properly
+catch (Exception $e) {
+    handleError($e);
+}
+
+// catch to finally, same-line comment
+try {
+    doSomething();
+} catch (Exception $e) {
+    handleError($e);
+} // end catch
+finally {
+    cleanup();
+}
+
+// try to catch to catch chain, same-line comments
+try {
+    doSomething();
+} // first comment
+catch (RuntimeException $e) {
+    handleRuntime($e);
+} // second comment
+catch (Exception $e) {
+    handleGeneral($e);
+}
+
+// try to catch, next-line comment
+try {
+    doSomething();
+}
+// This comment is on the next line
+catch (Exception $e) {
+    handleError($e);
+}
+
+// try to finally, no catch
+try {
+    doSomething();
+} // cleanup needed
+finally {
+    cleanup();
+}
+
+// catch to finally, next-line comment
+try {
+    doSomething();
+} catch (Exception $e) {
+    handleError($e);
+}
+// next-line before finally
+finally {
+    cleanup();
+}
+
+// no comment, regression guard
+try {
+    doSomething();
+} catch (Exception $e) {
+    handleError($e);
+} finally {
+    cleanup();
+}

--- a/crates/formatter/tests/cases/try_catch_trailing_comment/before.php
+++ b/crates/formatter/tests/cases/try_catch_trailing_comment/before.php
@@ -1,0 +1,67 @@
+<?php
+
+// try to catch, same-line comment
+try {
+    doSomething();
+} // @todo Handle this properly
+catch (Exception $e) {
+    handleError($e);
+}
+
+// catch to finally, same-line comment
+try {
+    doSomething();
+} catch (Exception $e) {
+    handleError($e);
+} // end catch
+finally {
+    cleanup();
+}
+
+// try to catch to catch chain, same-line comments
+try {
+    doSomething();
+} // first comment
+catch (RuntimeException $e) {
+    handleRuntime($e);
+} // second comment
+catch (Exception $e) {
+    handleGeneral($e);
+}
+
+// try to catch, next-line comment
+try {
+    doSomething();
+}
+// This comment is on the next line
+catch (Exception $e) {
+    handleError($e);
+}
+
+// try to finally, no catch
+try {
+    doSomething();
+} // cleanup needed
+finally {
+    cleanup();
+}
+
+// catch to finally, next-line comment
+try {
+    doSomething();
+} catch (Exception $e) {
+    handleError($e);
+}
+// next-line before finally
+finally {
+    cleanup();
+}
+
+// no comment, regression guard
+try {
+    doSomething();
+} catch (Exception $e) {
+    handleError($e);
+} finally {
+    cleanup();
+}

--- a/crates/formatter/tests/cases/try_catch_trailing_comment/settings.inc
+++ b/crates/formatter/tests/cases/try_catch_trailing_comment/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings::default()

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -103,6 +103,7 @@ test_case!(trailing_comma_in_array_destructuring);
 test_case!(inline_control_structures);
 test_case!(aligned_inline_control_structures);
 test_case!(following_clause_on_newline);
+test_case!(try_catch_trailing_comment);
 test_case!(html_template);
 test_case!(complex_html_template);
 test_case!(attributes);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes a formatter idempotency bug where trailing comments on try/catch/finally closing braces cause output to change on each format pass. When `following_clause_on_newline` is `false` (default), a comment like `} // todo` between `try` and `catch` causes the formatter to collapse the hard line break into a space, but the comment prevents this from being stable, producing different output on re-format.

## 🛠️ Summary of Changes

- Added `has_same_line_trailing_comment()` and `is_followed_by_comment_on_next_line()` checks to `Try::format()` for all inter-clause gaps (try→catch, catch→catch, catch→finally), matching the existing pattern in `print_body_clause()`
- Track `prev_block_span` through the catch chain so each gap checks the correct preceding block

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

<!-- N/A -->

## 📝 Notes for Reviewers

<!-- N/A -->
