### PR TITLE
fix(formatter): preserve parentheses around unbounded constructs in member access chains

### DIFF
--- a/crates/formatter/src/internal/format/member_access.rs
+++ b/crates/formatter/src/internal/format/member_access.rs
@@ -723,18 +723,7 @@ fn base_needs_parens<'arena>(f: &FormatterState<'_, 'arena>, base: &'arena Expre
 
     match base {
         Expression::Instantiation(instantiation) => f.instantiation_needs_parens(instantiation),
-        Expression::Binary(_)
-        | Expression::UnaryPrefix(_)
-        | Expression::UnaryPostfix(_)
-        | Expression::Assignment(_)
-        | Expression::Conditional(_)
-        | Expression::AnonymousClass(_)
-        | Expression::Closure(_)
-        | Expression::ArrowFunction(_)
-        | Expression::Match(_)
-        | Expression::Yield(_)
-        | Expression::Clone(_) => true,
-        _ => false,
+        _ => f.callee_expression_need_parenthesis(base, false),
     }
 }
 

--- a/crates/formatter/src/internal/parens.rs
+++ b/crates/formatter/src/internal/parens.rs
@@ -464,7 +464,7 @@ impl<'arena> FormatterState<'_, 'arena> {
         false
     }
 
-    const fn callee_expression_need_parenthesis(
+    pub(crate) const fn callee_expression_need_parenthesis(
         &self,
         expression: &'arena Expression<'arena>,
         instantiation: bool,

--- a/crates/formatter/tests/cases/parens_around_constructs/after.php
+++ b/crates/formatter/tests/cases/parens_around_constructs/after.php
@@ -7,3 +7,11 @@
 (include_once __DIR__ . '/../bootstrap/app.php')->handleRequest(Request::capture());
 
 (include __DIR__ . '/../bootstrap/app.php')->handleRequest(Request::capture());
+
+// Long chain, eligible for chaining
+(require 'rector-shared.php')
+    ->withPaths([__DIR__ . '/apps', __DIR__ . '/lib', __DIR__ . '/core'])
+    ->withSkip([SimplifyUselessVariableRector::class])
+    ->withRules([SimplifyUselessVariableRector::class])
+    ->withSets([SetList::CODE_QUALITY, SetList::DEAD_CODE])
+    ->withTypeCoverageLevel(2);

--- a/crates/formatter/tests/cases/parens_around_constructs/before.php
+++ b/crates/formatter/tests/cases/parens_around_constructs/before.php
@@ -9,3 +9,11 @@
     "/../bootstrap/app.php")->handleRequest(Request::capture());
 
 (include __DIR__ . "/../bootstrap/app.php")->handleRequest(Request::capture());
+
+// Long chain, eligible for chaining
+(require "rector-shared.php")
+    ->withPaths([__DIR__ . "/apps", __DIR__ . "/lib", __DIR__ . "/core"])
+    ->withSkip([SimplifyUselessVariableRector::class])
+    ->withRules([SimplifyUselessVariableRector::class])
+    ->withSets([SetList::CODE_QUALITY, SetList::DEAD_CODE])
+    ->withTypeCoverageLevel(2);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Prevents the formatter from removing required parentheses around `require`, `include`, `include_once`, `require_once`, and `print` when used as the base of a member access chain.

## 🔍 Context & Motivation

```php
// Input
(require 'rector-shared.php')
    ->withPaths([...])->withSkip([...])->withRules([...])->withSets([...])->withTypeCoverageLevel(2);

// After formatting (bug): parentheses removed
require 'rector-shared.php'
    ->withPaths([...])
    ...
```

Without parentheses, PHP parses this as `require ('rector-shared.php'->withPaths(...))`, changing the program's meaning.

## 🛠️ Summary of Changes

- Delegated `base_needs_parens()` to `callee_expression_need_parenthesis()`, eliminating duplicated logic that was missing the `Construct` case.
- Extended `parens_around_constructs` test with a long chain case that triggers `is_eligible_for_chaining()`.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

<!-- N/A — discovered via idempotency fuzzing on nextcloud/server -->

## 📝 Notes for Reviewers

<!-- N/A -->
