### PR TITLE
fix(analyzer): mark typed properties without defaults as possibly-undefined to prevent false redundant-null-coalesce diagnostics

### DIFF
--- a/crates/analyzer/src/resolver/property.rs
+++ b/crates/analyzer/src/resolver/property.rs
@@ -637,6 +637,15 @@ fn find_property_in_class<'ctx, 'ast, 'arena>(
         );
     }
 
+    if !for_assignment
+        && property_metadata.type_declaration_metadata.is_some()
+        && !property_metadata.flags.has_default()
+        && !property_metadata.flags.is_promoted_property()
+        && !property_metadata.flags.is_virtual_property()
+    {
+        property_type.set_possibly_undefined(true, None);
+    }
+
     let is_visible = if for_assignment {
         check_property_write_visibility(
             context,

--- a/crates/analyzer/tests/cases/issue_1286.php
+++ b/crates/analyzer/tests/cases/issue_1286.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+enum Suit
+{
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+    case Spades;
+}
+
+/**
+ * @mago-expect analysis:missing-constructor
+ */
+class Card
+{
+    public Suit $suit;
+    public string $label;
+}
+
+function apply_defaults(Card $card): void
+{
+    $card->suit ??= Suit::Hearts;
+    $card->label ??= 'Unknown';
+}
+
+function read_with_fallback(Card $card): string
+{
+    $label = $card->label ?? 'Fallback';
+
+    return $label;
+}
+
+// Properties with defaults: ?? IS redundant
+class WithDefaults
+{
+    public string $name = 'default';
+    public int $count = 0;
+}
+
+function test_with_defaults(WithDefaults $obj): void
+{
+    // @mago-expect analysis:redundant-null-coalesce
+    $_ = $obj->name ?? 'fallback';
+    // @mago-expect analysis:redundant-null-coalesce
+    $_ = $obj->count ?? 42;
+}
+
+class Untyped
+{
+    /** @var string */
+    public $name = 'default';
+}
+
+function test_untyped(Untyped $obj): void
+{
+    // @mago-expect analysis:redundant-null-coalesce
+    $_ = $obj->name ?? 'fallback';
+}
+
+class Promoted
+{
+    public function __construct(
+        public string $name,
+        public int $age,
+    ) {}
+}
+
+function test_promoted(Promoted $obj): void
+{
+    // @mago-expect analysis:redundant-null-coalesce
+    $_ = $obj->name ?? 'fallback';
+    // @mago-expect analysis:redundant-null-coalesce
+    $_ = $obj->age ?? 0;
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -701,6 +701,7 @@ test_case!(issue_1265);
 test_case!(issue_1266);
 test_case!(issue_1266_inheritdoc_narrowing);
 test_case!(issue_1267);
+test_case!(issue_1286);
 
 #[test]
 fn test_all_test_cases_are_ran() {


### PR DESCRIPTION
closes #1286
