### PR TITLE
fix(analyzer): use effective type for property hook parameter compatibility check

### DIFF
--- a/crates/analyzer/src/statement/class_like/mod.rs
+++ b/crates/analyzer/src/statement/class_like/mod.rs
@@ -2588,11 +2588,10 @@ fn check_class_like_properties<'ctx>(context: &mut Context<'ctx, '_>, class_like
         }
 
         // Validate set hook parameter type is supertype of property type
-        // Use type_declaration_metadata (native type) not get_type_metadata() (merged with docblock)
         if let Some(set_hook) = property_metadata.hooks.get(&atom("set"))
             && let Some(param) = &set_hook.parameter
             && let Some(param_type) = param.type_declaration_metadata.as_ref()
-            && let Some(property_type) = property_metadata.type_declaration_metadata.as_ref()
+            && let Some(property_type) = property_metadata.type_metadata.as_ref()
         {
             // The set hook parameter type must contain the property type (contravariance)
             // i.e., any value assignable to the property type should be accepted by the hook

--- a/crates/analyzer/tests/cases/issue_1342.php
+++ b/crates/analyzer/tests/cases/issue_1342.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+interface Context1342
+{
+    /**
+     * @var array<string, string>
+     */
+    public array $parameters { get; set; }
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -707,6 +707,7 @@ test_case!(issue_1278);
 test_case!(issue_1287);
 test_case!(issue_1286);
 test_case!(issue_1341);
+test_case!(issue_1342);
 
 #[test]
 fn test_all_test_cases_are_ran() {


### PR DESCRIPTION
closes #1342
