### PR TITLE
fix(formatter): preserve parentheses around unbounded constructs in binary expressions

### DIFF
--- a/crates/formatter/src/internal/parens.rs
+++ b/crates/formatter/src/internal/parens.rs
@@ -89,6 +89,7 @@ impl<'arena> FormatterState<'_, 'arena> {
             || self.pipe_node_needs_parens(node)
             || self.class_constant_access_needs_parens(node)
             || self.arrow_function_needs_parens(node)
+            || self.construct_needs_parens(node)
     }
 
     pub(crate) fn should_indent(&self, node: Node<'arena, 'arena>) -> bool {
@@ -210,6 +211,23 @@ impl<'arena> FormatterState<'_, 'arena> {
         };
 
         matches!(self.nth_parent_kind(2), Some(Node::Pipe(_)))
+    }
+
+    /// Unbounded constructs greedily consume everything to their right, so parentheses
+    /// are required when they appear as operands in binary, ternary, or pipe expressions.
+    ///
+    /// Example:
+    /// - `(include 'f.php') + $x` without parens becomes `include ('f.php' + $x)`
+    fn construct_needs_parens(&self, node: Node<'arena, 'arena>) -> bool {
+        let Node::Construct(construct) = node else {
+            return false;
+        };
+
+        if construct.has_bounds() {
+            return false;
+        }
+
+        matches!(self.nth_parent_kind(2), Some(Node::Binary(_) | Node::Conditional(_) | Node::Pipe(_)))
     }
 
     /// Check if a class constant access needs parentheses based on its parent context.

--- a/crates/formatter/tests/cases/parens_around_constructs/after.php
+++ b/crates/formatter/tests/cases/parens_around_constructs/after.php
@@ -15,3 +15,12 @@
     ->withRules([SimplifyUselessVariableRector::class])
     ->withSets([SetList::CODE_QUALITY, SetList::DEAD_CODE])
     ->withTypeCoverageLevel(2);
+
+$a = (include 'file.php') + $x;
+$b = (require_once 'file.php') . $x;
+$c = (print 'hello') && $x;
+$d = (include 'file.php') ? 'yes' : 'no';
+$e = $x + (include 'file.php');
+$f = isset($x) && $y;
+$g = include 'file.php';
+$h = (include 'file.php') |> strtoupper(...);

--- a/crates/formatter/tests/cases/parens_around_constructs/before.php
+++ b/crates/formatter/tests/cases/parens_around_constructs/before.php
@@ -17,3 +17,12 @@
     ->withRules([SimplifyUselessVariableRector::class])
     ->withSets([SetList::CODE_QUALITY, SetList::DEAD_CODE])
     ->withTypeCoverageLevel(2);
+
+$a = (include 'file.php') + $x;
+$b = (require_once 'file.php') . $x;
+$c = (print 'hello') && $x;
+$d = (include 'file.php') ? 'yes' : 'no';
+$e = $x + (include 'file.php');
+$f = (isset($x)) && $y;
+$g = (include 'file.php');
+$h = (include 'file.php') |> strtoupper(...);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Prevents the formatter from changing the semantics of expressions like `(include 'file.php') + $x`, where parentheses around unbounded constructs are required.

## 🔍 Context & Motivation

```php
// input
$modules = (include 'resources.php') + $modules;

// formatted (wrong — changes semantics)
$modules = include 'resources.php' + $modules;
```

Without parentheses, `include` greedily consumes `'resources.php' + $modules` as its argument. The same class of bug was fixed for member access chains in #1322; this addresses the binary/ternary/pipe context.

## 🛠️ Summary of Changes

- Added `construct_needs_parens()` to `parens.rs` that preserves parentheses when an unbounded construct appears inside a `Binary`, `Conditional`, or `Pipe` node.
- Extended `parens_around_constructs` test with binary, ternary, pipe, bounded-construct, and standalone cases.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

<!-- N/A -->

## 📝 Notes for Reviewers

<!-- N/A -->
