### PR TITLE
chore(linter): fixers for str-contains/str-starts-with are potentially unsafe

### DIFF
--- a/crates/linter/src/rule/clarity/str_contains.rs
+++ b/crates/linter/src/rule/clarity/str_contains.rs
@@ -16,6 +16,7 @@ use mago_syntax::ast::FunctionCall;
 use mago_syntax::ast::Literal;
 use mago_syntax::ast::Node;
 use mago_syntax::ast::NodeKind;
+use mago_text_edit::Safety;
 use mago_text_edit::TextEdit;
 
 use crate::category::Category;
@@ -193,22 +194,40 @@ impl LintRule for StrContainsRule {
                 // Replace entire binary expression with !str_contains(...)
                 if left {
                     // strpos(...) === false
-                    edits.push(TextEdit::replace(function_span, format!("!{STR_CONTAINS}")));
-                    edits.push(TextEdit::delete(binary.operator.span().join(binary.rhs.span())));
+                    edits.push(
+                        TextEdit::replace(function_span, format!("!{STR_CONTAINS}"))
+                            .with_safety(Safety::PotentiallyUnsafe),
+                    );
+                    edits.push(
+                        TextEdit::delete(binary.operator.span().join(binary.rhs.span()))
+                            .with_safety(Safety::PotentiallyUnsafe),
+                    );
                 } else {
                     // false === strpos(...)
-                    edits.push(TextEdit::delete(binary.lhs.span().join(binary.operator.span())));
-                    edits.push(TextEdit::replace(function_span, format!("!{STR_CONTAINS}")));
+                    edits.push(
+                        TextEdit::delete(binary.lhs.span().join(binary.operator.span()))
+                            .with_safety(Safety::PotentiallyUnsafe),
+                    );
+                    edits.push(
+                        TextEdit::replace(function_span, format!("!{STR_CONTAINS}"))
+                            .with_safety(Safety::PotentiallyUnsafe),
+                    );
                 }
             } else {
                 // For !== false, just replace with str_contains
-                edits.push(TextEdit::replace(function_span, STR_CONTAINS));
+                edits.push(TextEdit::replace(function_span, STR_CONTAINS).with_safety(Safety::PotentiallyUnsafe));
 
                 // Remove comparison part
                 if left {
-                    edits.push(TextEdit::delete(binary.operator.span().join(binary.rhs.span())));
+                    edits.push(
+                        TextEdit::delete(binary.operator.span().join(binary.rhs.span()))
+                            .with_safety(Safety::PotentiallyUnsafe),
+                    );
                 } else {
-                    edits.push(TextEdit::delete(binary.lhs.span().join(binary.operator.span())));
+                    edits.push(
+                        TextEdit::delete(binary.lhs.span().join(binary.operator.span()))
+                            .with_safety(Safety::PotentiallyUnsafe),
+                    );
                 }
             }
         });

--- a/crates/linter/src/rule/clarity/str_starts_with.rs
+++ b/crates/linter/src/rule/clarity/str_starts_with.rs
@@ -17,6 +17,7 @@ use mago_syntax::ast::Literal;
 use mago_syntax::ast::LiteralInteger;
 use mago_syntax::ast::Node;
 use mago_syntax::ast::NodeKind;
+use mago_text_edit::Safety;
 use mago_text_edit::TextEdit;
 
 use crate::category::Category;
@@ -146,17 +147,26 @@ impl LintRule for StrStartsWithRule {
             let function_span = call.function.span();
 
             if equal {
-                edits.push(TextEdit::replace(function_span, STR_STARTS_WITH));
+                edits.push(TextEdit::replace(function_span, STR_STARTS_WITH).with_safety(Safety::PotentiallyUnsafe));
             } else {
-                edits.push(TextEdit::replace(function_span, format!("!{STR_STARTS_WITH}")));
+                edits.push(
+                    TextEdit::replace(function_span, format!("!{STR_STARTS_WITH}"))
+                        .with_safety(Safety::PotentiallyUnsafe),
+                );
             }
 
             if left {
                 // delete the `=== 0` part
-                edits.push(TextEdit::delete(binary.operator.span().join(binary.rhs.span())));
+                edits.push(
+                    TextEdit::delete(binary.operator.span().join(binary.rhs.span()))
+                        .with_safety(Safety::PotentiallyUnsafe),
+                );
             } else {
                 // delete the `0 ===` part
-                edits.push(TextEdit::delete(binary.lhs.span().join(binary.operator.span())));
+                edits.push(
+                    TextEdit::delete(binary.lhs.span().join(binary.operator.span()))
+                        .with_safety(Safety::PotentiallyUnsafe),
+                );
             }
         });
     }


### PR DESCRIPTION
## 📌 What Does This PR Do?

This marks fixers for `str-contains`/`str-starts-with` as potentially unsafe.

## 🔍 Context & Motivation

These fixers may behave incorrectly in the unlikely case that there is a locally-defined `str_contains` or `str_starts_with` that behaves differently from the PHP builtins.

## 🛠️ Summary of Changes

- **Bug Fix:** Mark fixers for `str-contains`/`str-starts-with` as potentially unsafe

## 📂 Affected Areas

- [x] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Discussed in PR #1297

## 📝 Notes for Reviewers


