### PR TITLE
fix(codex): don't skip closure or arrow function likes in incremental build

### DIFF
--- a/crates/codex/src/populator/mod.rs
+++ b/crates/codex/src/populator/mod.rs
@@ -121,13 +121,6 @@ fn populate_codebase_inner(
     if let Some(dirty) = &dirty_symbols {
         for dirty_key in dirty {
             if let Some(function_like_metadata) = codebase.function_likes.get_mut(dirty_key) {
-                let is_closure_or_arrow = function_like_metadata.get_kind().is_closure()
-                    || function_like_metadata.get_kind().is_arrow_function();
-
-                if is_closure_or_arrow {
-                    continue;
-                }
-
                 let force_repopulation = function_like_metadata.flags.is_user_defined();
                 if function_like_metadata.flags.is_populated() && !force_repopulation {
                     continue;

--- a/crates/orchestrator/src/service/incremental_analysis.rs
+++ b/crates/orchestrator/src/service/incremental_analysis.rs
@@ -3801,4 +3801,41 @@ mod tests {
         service.analyze_incremental(None).expect("Incremental failed.");
         assert_matches_full(&service, &db, "both changed to be compatible");
     }
+
+    /// Body-only change in a file with a closure whose parameter references another class.
+    /// Reproduces a bug where closure/arrow function type references were never populated
+    /// in the targeted incremental path, leaving TReference::Symbol entries unresolved.
+    #[test]
+    fn test_watch_body_change_closure_with_typed_param() {
+        let exception_class = "<?php\nclass MyException extends \\Exception {\n    public function getDetails(): string { return 'details'; }\n}\n";
+        let service_v1 = concat!(
+            "<?php\nclass Service {\n",
+            "    public function run(): void {\n",
+            "        $handler = function(MyException $e): string {\n",
+            "            return $e->getDetails();\n",
+            "        };\n",
+            "    }\n",
+            "}\n",
+        );
+
+        let mut db = make_database(vec![("src/MyException.php", exception_class), ("src/Service.php", service_v1)]);
+        let mut service = make_watch_service(&db);
+        service.analyze().expect("Initial analysis failed.");
+        assert_matches_full(&service, &db, "initial");
+
+        // Body-only change: modify the closure body but keep the signature identical.
+        let service_v2 = concat!(
+            "<?php\nclass Service {\n",
+            "    public function run(): void {\n",
+            "        $handler = function(MyException $e): string {\n",
+            "            return $e->getDetails() . ' extra';\n",
+            "        };\n",
+            "    }\n",
+            "}\n",
+        );
+        db.update(FileId::new("src/Service.php"), Cow::Owned(service_v2.to_string()));
+        service.update_database(db.read_only());
+        service.analyze_incremental(None).expect("Incremental failed.");
+        assert_matches_full(&service, &db, "body change in closure with typed param");
+    }
 }


### PR DESCRIPTION
## 📌 What Does This PR Do?

<!-- Briefly describe what this PR introduces or fixes. -->

When running an incremental build with analyze --watch, it appears that types used within anonymous functions end up with an unknown_ref type on incremental builds (after the initial build). This fixes the issue by not skipping population of closure or arrow function likes on an incremental build.

## 🔍 Context & Motivation

<!-- Why is this change needed? Is it fixing a bug, adding a feature, or refactoring? -->

This is fixing a bug when using `mago analyze --watch`

## 🛠️ Summary of Changes

- **Bug Fix:** don't skip closure or arrow function likes in incremental build

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): incremental build

## 🔗 Related Issues or PRs

Fixes #1359 

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
