### PR TITLE
chore(docker): install git for command option --staged

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM alpine:3
+RUN apk add git 
 COPY mago /usr/local/bin/mago
 ENTRYPOINT ["/usr/local/bin/mago"]


### PR DESCRIPTION
## 📌 What Does This PR Do?

Install git inside alpine container

## 🔍 Context & Motivation

Its now impossible to run commands in docker images where git is needed to determine which files are staged for commit.
Like:

```bash
mago format --staged
mago lint --staged
```

## 🛠️ Summary of Changes

 **Bug Fix:** Install git in docker image to support --staged commands inside container

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Docker

## 🔗 Related Issues or PRs

Fixes: https://github.com/carthage-software/mago/issues/1362 


