### PR TITLE
fix(formatter): stabilize chain-breaking heuristic for method chains with complex arguments

### DIFF
--- a/crates/formatter/src/internal/format/call_arguments.rs
+++ b/crates/formatter/src/internal/format/call_arguments.rs
@@ -2,14 +2,11 @@ use bumpalo::collections::Vec;
 use bumpalo::vec;
 
 use mago_span::HasSpan;
-use mago_syntax::ast::Access;
 use mago_syntax::ast::Argument;
 use mago_syntax::ast::ArgumentList;
-use mago_syntax::ast::ArrayElement;
 use mago_syntax::ast::Call;
 use mago_syntax::ast::Expression;
 use mago_syntax::ast::PartialArgumentList;
-use mago_syntax::ast::UnaryPrefixOperator;
 
 use crate::document::BreakMode;
 use crate::document::Document;
@@ -27,9 +24,9 @@ use crate::internal::format::format_token;
 use crate::internal::format::misc;
 use crate::internal::format::misc::is_breaking_expression;
 use crate::internal::format::misc::is_expandable_expression;
+use crate::internal::format::misc::is_simple_call_argument;
 use crate::internal::format::misc::is_simple_expression;
 use crate::internal::format::misc::is_simple_single_line_expression;
-use crate::internal::format::misc::is_string_word_type;
 use crate::internal::format::misc::should_hug_expression;
 use crate::internal::utils::could_expand_value;
 use crate::internal::utils::foreach_binary_operand;
@@ -707,101 +704,5 @@ fn is_hopefully_short_call_argument(mut node: &Expression) -> bool {
             is_simple_call_argument(operation.lhs, 1) && is_simple_call_argument(operation.rhs, 1)
         }
         _ => is_simple_call_argument(node, 2),
-    }
-}
-
-fn is_simple_call_argument<'arena>(node: &'arena Expression<'arena>, depth: usize) -> bool {
-    let is_child_simple = |node: &'arena Expression<'arena>| {
-        if depth <= 1 {
-            return false;
-        }
-
-        is_simple_call_argument(node, depth - 1)
-    };
-
-    let is_simple_element = |node: &'arena ArrayElement<'arena>| match node {
-        ArrayElement::KeyValue(element) => is_child_simple(element.key) && is_child_simple(element.value),
-        ArrayElement::Value(element) => is_child_simple(element.value),
-        ArrayElement::Variadic(element) => is_child_simple(element.value),
-        ArrayElement::Missing(_) => true,
-    };
-
-    if node.is_literal() || is_string_word_type(node) {
-        return true;
-    }
-
-    match node {
-        Expression::Parenthesized(parenthesized) => is_simple_call_argument(parenthesized.expression, depth),
-        Expression::UnaryPrefix(operation) => {
-            if let UnaryPrefixOperator::PreIncrement(_) | UnaryPrefixOperator::PreDecrement(_) = operation.operator {
-                return false;
-            }
-
-            if operation.operator.is_cast() {
-                return false;
-            }
-
-            is_simple_call_argument(operation.operand, depth)
-        }
-        Expression::Array(array) => array.elements.iter().all(is_simple_element),
-        Expression::LegacyArray(array) => array.elements.iter().all(is_simple_element),
-        Expression::Call(call) => {
-            let argument_list = match call {
-                Call::Function(function_call) => {
-                    if !is_simple_call_argument(function_call.function, depth) {
-                        return false;
-                    }
-
-                    &function_call.argument_list
-                }
-                Call::Method(method_call) => {
-                    if !is_simple_call_argument(method_call.object, depth) {
-                        return false;
-                    }
-
-                    &method_call.argument_list
-                }
-                Call::NullSafeMethod(null_safe_method_call) => {
-                    if !is_simple_call_argument(null_safe_method_call.object, depth) {
-                        return false;
-                    }
-
-                    &null_safe_method_call.argument_list
-                }
-                Call::StaticMethod(static_method_call) => {
-                    if !is_simple_call_argument(static_method_call.class, depth) {
-                        return false;
-                    }
-
-                    &static_method_call.argument_list
-                }
-            };
-
-            argument_list.arguments.len() <= depth
-                && argument_list.arguments.iter().map(Argument::value).all(is_child_simple)
-        }
-        Expression::Access(access) => {
-            let object_or_class = match access {
-                Access::Property(property_access) => &property_access.object,
-                Access::NullSafeProperty(null_safe_property_access) => &null_safe_property_access.object,
-                Access::StaticProperty(static_property_access) => &static_property_access.class,
-                Access::ClassConstant(class_constant_access) => &class_constant_access.class,
-            };
-
-            is_simple_call_argument(object_or_class, depth)
-        }
-        Expression::ArrayAccess(array_access) => {
-            is_simple_call_argument(array_access.array, depth) && is_simple_call_argument(array_access.index, depth)
-        }
-        Expression::Instantiation(instantiation) if is_simple_call_argument(instantiation.class, depth) => {
-            match &instantiation.argument_list {
-                Some(argument_list) => {
-                    argument_list.arguments.len() <= depth
-                        && argument_list.arguments.iter().map(Argument::value).all(is_child_simple)
-                }
-                None => true,
-            }
-        }
-        _ => false,
     }
 }

--- a/crates/formatter/src/internal/format/member_access.rs
+++ b/crates/formatter/src/internal/format/member_access.rs
@@ -30,6 +30,7 @@ use crate::internal::format::Format;
 use crate::internal::format::call_arguments::print_argument_list;
 use crate::internal::format::misc;
 use crate::internal::format::misc::is_breaking_expression;
+use crate::internal::format::misc::is_simple_call_argument;
 use crate::internal::format::misc::is_simple_expression;
 use crate::internal::format::misc::is_string_word_type;
 use crate::internal::utils::string_width;
@@ -369,38 +370,19 @@ impl<'arena> MemberAccessChain<'arena> {
     }
 
     /// Checks if any method call in the chain has arguments that will force the chain to break.
-    /// This considers:
-    /// - Closures and anonymous classes (always break)
-    /// - Arrays/matches that are already formatted with line breaks
     #[inline]
-    fn has_breaking_arguments(&self, f: &FormatterState<'_, 'arena>) -> bool {
+    fn has_breaking_arguments(&self) -> bool {
+        let call_count = self.accesses.iter().filter(|a| a.get_arguments_list().is_some()).count();
+        if call_count <= 2 {
+            return false;
+        }
+
         self.accesses.iter().any(|access| {
             let Some(argument_list) = access.get_arguments_list() else {
                 return false;
             };
 
-            argument_list.arguments.iter().any(|arg| {
-                let value = arg.value();
-                match value {
-                    Expression::Closure(_) | Expression::AnonymousClass(_) => true,
-                    Expression::Array(arr) => misc::has_new_line_in_range(
-                        f.source_text,
-                        arr.left_bracket.start_offset(),
-                        arr.right_bracket.end_offset(),
-                    ),
-                    Expression::LegacyArray(arr) => misc::has_new_line_in_range(
-                        f.source_text,
-                        arr.array.span.start_offset(),
-                        arr.right_parenthesis.end_offset(),
-                    ),
-                    Expression::Match(m) => misc::has_new_line_in_range(
-                        f.source_text,
-                        m.r#match.span.start_offset(),
-                        m.right_brace.end_offset(),
-                    ),
-                    _ => false,
-                }
-            })
+            argument_list.arguments.iter().any(|arg| !is_simple_call_argument(arg.value(), 2))
         })
     }
 
@@ -674,7 +656,7 @@ pub(super) fn print_member_access_chain<'arena>(
         }
     }
 
-    let should_break = must_break || member_access_chain.has_breaking_arguments(f);
+    let should_break = must_break || member_access_chain.has_breaking_arguments();
     if should_break && !matches!(f.parent_node(), Node::Binary(_)) {
         parts.push(Document::BreakParent);
     }

--- a/crates/formatter/src/internal/format/misc.rs
+++ b/crates/formatter/src/internal/format/misc.rs
@@ -6,6 +6,7 @@ use mago_span::Span;
 use mago_syntax::ast::Access;
 use mago_syntax::ast::Argument;
 use mago_syntax::ast::ArrayAccess;
+use mago_syntax::ast::ArrayElement;
 use mago_syntax::ast::AttributeList;
 use mago_syntax::ast::Call;
 use mago_syntax::ast::ConstantAccess;
@@ -19,6 +20,7 @@ use mago_syntax::ast::Node;
 use mago_syntax::ast::Sequence;
 use mago_syntax::ast::Statement;
 use mago_syntax::ast::Terminator;
+use mago_syntax::ast::UnaryPrefixOperator;
 use mago_syntax::ast::Variable;
 use mago_syntax::ast::Yield;
 
@@ -424,6 +426,102 @@ pub(super) const fn is_string_word_type(node: &Expression) -> bool {
             | Expression::ConstantAccess(ConstantAccess { name: Identifier::Local(_) })
             | Expression::Variable(Variable::Direct(_))
     )
+}
+
+pub(super) fn is_simple_call_argument<'arena>(node: &'arena Expression<'arena>, depth: usize) -> bool {
+    let is_child_simple = |node: &'arena Expression<'arena>| {
+        if depth <= 1 {
+            return false;
+        }
+
+        is_simple_call_argument(node, depth - 1)
+    };
+
+    let is_simple_element = |node: &'arena ArrayElement<'arena>| match node {
+        ArrayElement::KeyValue(element) => is_child_simple(element.key) && is_child_simple(element.value),
+        ArrayElement::Value(element) => is_child_simple(element.value),
+        ArrayElement::Variadic(element) => is_child_simple(element.value),
+        ArrayElement::Missing(_) => true,
+    };
+
+    if node.is_literal() || is_string_word_type(node) {
+        return true;
+    }
+
+    match node {
+        Expression::Parenthesized(parenthesized) => is_simple_call_argument(parenthesized.expression, depth),
+        Expression::UnaryPrefix(operation) => {
+            if let UnaryPrefixOperator::PreIncrement(_) | UnaryPrefixOperator::PreDecrement(_) = operation.operator {
+                return false;
+            }
+
+            if operation.operator.is_cast() {
+                return false;
+            }
+
+            is_simple_call_argument(operation.operand, depth)
+        }
+        Expression::Array(array) => array.elements.iter().all(is_simple_element),
+        Expression::LegacyArray(array) => array.elements.iter().all(is_simple_element),
+        Expression::Call(call) => {
+            let argument_list = match call {
+                Call::Function(function_call) => {
+                    if !is_simple_call_argument(function_call.function, depth) {
+                        return false;
+                    }
+
+                    &function_call.argument_list
+                }
+                Call::Method(method_call) => {
+                    if !is_simple_call_argument(method_call.object, depth) {
+                        return false;
+                    }
+
+                    &method_call.argument_list
+                }
+                Call::NullSafeMethod(null_safe_method_call) => {
+                    if !is_simple_call_argument(null_safe_method_call.object, depth) {
+                        return false;
+                    }
+
+                    &null_safe_method_call.argument_list
+                }
+                Call::StaticMethod(static_method_call) => {
+                    if !is_simple_call_argument(static_method_call.class, depth) {
+                        return false;
+                    }
+
+                    &static_method_call.argument_list
+                }
+            };
+
+            argument_list.arguments.len() <= depth
+                && argument_list.arguments.iter().map(Argument::value).all(is_child_simple)
+        }
+        Expression::Access(access) => {
+            let object_or_class = match access {
+                Access::Property(property_access) => &property_access.object,
+                Access::NullSafeProperty(null_safe_property_access) => &null_safe_property_access.object,
+                Access::StaticProperty(static_property_access) => &static_property_access.class,
+                Access::ClassConstant(class_constant_access) => &class_constant_access.class,
+            };
+
+            is_simple_call_argument(object_or_class, depth)
+        }
+        Expression::ArrayAccess(array_access) => {
+            is_simple_call_argument(array_access.array, depth) && is_simple_call_argument(array_access.index, depth)
+        }
+        Expression::Instantiation(instantiation) if is_simple_call_argument(instantiation.class, depth) => {
+            match &instantiation.argument_list {
+                Some(argument_list) => {
+                    argument_list.arguments.len() <= depth
+                        && argument_list.arguments.iter().map(Argument::value).all(is_child_simple)
+                }
+                None => true,
+            }
+        }
+        _ => false,
+    }
 }
 
 pub(super) fn print_colon_delimited_body<'arena>(

--- a/crates/formatter/tests/cases/idempotent_chain_with_complex_arguments/after.php
+++ b/crates/formatter/tests/cases/idempotent_chain_with_complex_arguments/after.php
@@ -1,0 +1,54 @@
+<?php
+
+$mock->expects($this->once())->method('serialize')->with([], 'json', ['headers' => [], 'delivery_mode' => 2]);
+
+$result = $service
+    ->configure($options)
+    ->process($data)
+    ->transform(match ($type) {
+        'json' => new JsonTransformer(),
+        'xml' => new XmlTransformer(),
+    });
+
+$result = $factory->create()->configure('json', true)->execute('default');
+
+$table->addColumn('total', Types::STRING, ['length' => 3, 'precision' => 10])->setNotnull(false);
+
+$query
+    ->select('*')
+    ->from('users')
+    ->where(function ($q) {
+        $q->where('active', true);
+    });
+
+$builder
+    ->setHeader('Content-Type', 'application/json')
+    ->setBody(json_encode(['key' => 'value', 'nested' => ['a' => 1]]))
+    ->send();
+
+TestCase::create()
+    ->expects($this->once())
+    ->method('handle')
+    ->willReturn(['status' => 'ok', 'code' => 200]);
+
+$repository->findBy(function ($item) {
+    return $item->isActive();
+})->sortBy('name');
+
+class IdempotencyTest
+{
+    public function testChainWithExpandedArray()
+    {
+        $builder->select('*')->from('users')->whereFullText('body', '+Hello -World', [
+            'mode' => 'boolean',
+            'expanded' => true,
+        ]);
+
+        static::createClient()->request('GET', '/books/1', options: ['headers' => ['accept' => 'application/ld+json']]);
+
+        $this->artisan('test:select')->expectsChoice('What is your name?', 'jane', [
+            'john' => 'John',
+            'jane' => 'Jane',
+        ])->expectsOutput('Your name is jane.');
+    }
+}

--- a/crates/formatter/tests/cases/idempotent_chain_with_complex_arguments/before.php
+++ b/crates/formatter/tests/cases/idempotent_chain_with_complex_arguments/before.php
@@ -1,0 +1,52 @@
+<?php
+
+$mock->expects($this->once())->method('serialize')->with([], 'json', ['headers' => [], 'delivery_mode' => 2]);
+
+$result = $service
+    ->configure($options)
+    ->process($data)
+    ->transform(match ($type) {
+        'json' => new JsonTransformer(),
+        'xml' => new XmlTransformer(),
+    });
+
+$result = $factory->create()->configure('json', true)->execute('default');
+
+$table->addColumn('total', Types::STRING, ['length' => 3, 'precision' => 10])->setNotnull(false);
+
+$query
+    ->select('*')
+    ->from('users')
+    ->where(function ($q) {
+        $q->where('active', true);
+    });
+
+$builder
+    ->setHeader('Content-Type', 'application/json')
+    ->setBody(json_encode(['key' => 'value', 'nested' => ['a' => 1]]))
+    ->send();
+
+TestCase::create()
+    ->expects($this->once())
+    ->method('handle')
+    ->willReturn(['status' => 'ok', 'code' => 200]);
+
+$repository->findBy(function ($item) { return $item->isActive(); })->sortBy('name');
+
+class IdempotencyTest
+{
+    public function testChainWithExpandedArray()
+    {
+        $builder->select('*')->from('users')->whereFullText('body', '+Hello -World', [
+            'mode' => 'boolean',
+            'expanded' => true,
+        ]);
+
+        static::createClient()->request('GET', '/books/1', options: ['headers' => ['accept' => 'application/ld+json']]);
+
+        $this->artisan('test:select')->expectsChoice('What is your name?', 'jane', [
+            'john' => 'John',
+            'jane' => 'Jane',
+        ])->expectsOutput('Your name is jane.');
+    }
+}

--- a/crates/formatter/tests/cases/idempotent_chain_with_complex_arguments/settings.inc
+++ b/crates/formatter/tests/cases/idempotent_chain_with_complex_arguments/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings::default()

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -246,6 +246,7 @@ test_case!(align_run_breaking);
 test_case!(align_modifier_breaking);
 test_case!(inline_block_comments_in_arguments);
 test_case!(idempotent_chain_with_array);
+test_case!(idempotent_chain_with_complex_arguments);
 test_case!(match_idempotency);
 test_case!(heredoc_indentation);
 test_case!(heredoc_indentation_disabled);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes a formatter idempotency failure where `has_breaking_arguments` used `has_new_line_in_range` on source text, causing its result to flip after array expansion rewrites the layout.

## 🛠️ Summary of Changes

- Replaced source-text-based `has_new_line_in_range` checks in `has_breaking_arguments` with AST-based `is_simple_call_argument` (Prettier's `isSimpleCallArgument`, already present in the codebase)
- Added `call_count > 2` threshold - matches Prettier's [`member-chain.js`](https://github.com/prettier/prettier/blob/main/src/language-js/print/member-chain.js) and Biome's [`member_chain/mod.rs`](https://github.com/biomejs/biome/blob/main/crates/biome_js_formatter/src/utils/member_chain/mod.rs)
- Moved `is_simple_call_argument` from `call_arguments.rs` to `misc.rs`

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Related to #793

## 📝 Notes for Reviewers

The new implementation inspects only AST structure, not source text, consistent with Prettier and Biome.

For 2-call chains, `has_breaking_arguments` now always returns `false`. This has no observable effect — short chains are already handled by the eligibility score, `must_break`, and print-width overflow.

### Idempotency improvement

Measured by formatting each file twice (`mago fmt` × 2) and counting files where output differs between passes.

**Method**: L1 fuzzing across 30 PHP repositories (~69k files), `threads = 1`, default preset, release build. Repos include Mago's official corpus (symfony, laravel, doctrine, phpunit, etc.) plus additional high-profile projects (WordPress, drupal, mediawiki, nextcloud, etc.) for broader coverage.

| | v1.14.0 | This PR | Delta |
|:--|--:|--:|--:|
| Total failures | 181 | 106 | -75 |

No regressions observed in any of the tested repositories.

<details>
<summary>Per-repo breakdown (sorted by delta)</summary>

Mago corpus repos:

| Repo | v1.14.0 | This PR | Delta |
|:--|--:|--:|--:|
| symfony/symfony | 21 | 8 | -13 |
| laravel/framework | 7 | 1 | -6 |
| yiisoft/yii2 | 3 | 0 | -3 |
| phpstan/phpstan-src | 11 | 11 | 0 |
| sebastianbergmann/phpunit | 2 | 2 | 0 |
| briannesbitt/Carbon | 1 | 1 | 0 |
| doctrine/orm | 1 | 1 | 0 |
| azjezz/psl | 0 | 0 | 0 |
| doctrine/dbal | 0 | 0 | 0 |
| nikic/PHP-Parser | 0 | 0 | 0 |
| twigphp/Twig | 0 | 0 | 0 |

Additional repos:

| Repo | v1.14.0 | This PR | Delta |
|:--|--:|--:|--:|
| api-platform/core | 37 | 5 | -32 |
| wikimedia/mediawiki | 36 | 28 | -8 |
| drupal/drupal | 9 | 3 | -6 |
| cakephp/cakephp | 4 | 2 | -2 |
| nextcloud/server | 7 | 5 | -2 |
| Seldaek/monolog | 1 | 0 | -1 |
| predis/predis | 1 | 0 | -1 |
| livewire/livewire | 1 | 0 | -1 |
| WordPress/WordPress | 26 | 26 | 0 |
| filamentphp/filament | 7 | 7 | 0 |
| composer/composer | 1 | 1 | 0 |
| thephpleague/flysystem | 1 | 1 | 0 |
| spatie/laravel-data | 1 | 1 | 0 |
| squizlabs/PHP_CodeSniffer | 1 | 1 | 0 |
| pestphp/pest | 2 | 2 | 0 |
| FakerPHP/Faker | 0 | 0 | 0 |
| Intervention/image | 0 | 0 | 0 |
| slimphp/Slim | 0 | 0 | 0 |

</details>
