### PR TITLE
fix(analyzer): preserve generic class-string identity during match exhaustiveness narrowing

### DIFF
--- a/crates/analyzer/src/context/block.rs
+++ b/crates/analyzer/src/context/block.rs
@@ -723,7 +723,7 @@ mod tests {
     fn block_context_with_locals(vars: &[&str]) -> BlockContext<'static> {
         let mut block_context = BlockContext::new(ScopeContext::new(), false);
         for variable in vars {
-            let variable_atom = atom(*variable);
+            let variable_atom = atom(variable);
             block_context.locals.insert(variable_atom, Rc::new(get_mixed()));
             block_context.variables_possibly_in_scope.insert(variable_atom);
         }

--- a/crates/analyzer/src/reconciler/assertion_reconciler.rs
+++ b/crates/analyzer/src/reconciler/assertion_reconciler.rs
@@ -1053,7 +1053,11 @@ fn handle_literal_equality_with_class_string(
                         trigger_issue_for_impossible(context, old_var_type_atom, key, assertion, true, negated, span);
                     }
 
-                    return TUnion::from_atomic(asserted_atomic);
+                    return if matches!(class_like_string, TClassLikeString::Generic { .. }) {
+                        existing_var_type.clone()
+                    } else {
+                        TUnion::from_atomic(asserted_atomic)
+                    };
                 }
             }
             TAtomic::Scalar(TScalar::String(TString {

--- a/crates/analyzer/tests/cases/issue_1375.php
+++ b/crates/analyzer/tests/cases/issue_1375.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+class Player1375 {}
+class Team1375 {}
+
+/**
+ * @template T of object
+ * @param class-string<T> $className
+ * @return list<T>
+ */
+function executeSearch1375(string $className): array { return []; }
+
+/**
+ * @template T of Player1375|Team1375
+ * @param class-string<T> $className
+ * @return list<T>
+ */
+function advancedSearch1375(string $className): array
+{
+    $_ = match ($className) {
+        Player1375::class => 'players',
+        Team1375::class   => 'teams',
+        default       => throw new \LogicException(),
+    };
+
+    return executeSearch1375($className);
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -710,6 +710,7 @@ test_case!(issue_1286);
 test_case!(issue_1341);
 test_case!(issue_1342);
 test_case!(issue_1346);
+test_case!(issue_1375);
 
 #[test]
 fn test_all_test_cases_are_ran() {


### PR DESCRIPTION
closes #1375 

