### PR TITLE
fix(analyzer): correctly track variable definedness when catch block has multiple leaving paths

### DIFF
--- a/crates/analyzer/src/statement/try.rs
+++ b/crates/analyzer/src/statement/try.rs
@@ -234,17 +234,7 @@ impl<'ast, 'arena> Analyzable<'ast, 'arena> for Try<'arena> {
 
             inherit_branch_context_properties(context, block_context, &catch_block_context);
 
-            let catch_doesnt_leave_parent_scope = {
-                let catch_actions = &catch_actions[i];
-
-                if catch_actions.len() == 1 {
-                    !catch_actions.contains(ControlAction::End)
-                        && !catch_actions.contains(ControlAction::Continue)
-                        && !catch_actions.contains(ControlAction::Break)
-                } else {
-                    true
-                }
-            };
+            let catch_doesnt_leave_parent_scope = catch_actions[i].contains(ControlAction::None);
 
             if catch_doesnt_leave_parent_scope {
                 definitely_newly_assigned_var_ids = new_catch_assigned_variables_ids

--- a/crates/analyzer/tests/cases/issue_1352.php
+++ b/crates/analyzer/tests/cases/issue_1352.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+function shouldThrow1352(): bool
+{
+    return true;
+}
+
+function test1352(): void
+{
+    foreach ([1, 2, 3] as $someDatum) {
+        try {
+            $data = random_bytes(5);
+        } catch (\Throwable $exception) {
+            if (shouldThrow1352()) {
+                throw $exception; // @mago-expect analysis:unhandled-thrown-type
+            }
+
+            continue;
+        }
+
+        print $data;
+    }
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -710,6 +710,7 @@ test_case!(issue_1286);
 test_case!(issue_1341);
 test_case!(issue_1342);
 test_case!(issue_1346);
+test_case!(issue_1352);
 test_case!(issue_1355);
 test_case!(issue_1365);
 test_case!(issue_1372);


### PR DESCRIPTION
closes #1352
