### PR TITLE
fix(atom): use uppercase range [A-Z] in SIMD case folding

### DIFF
--- a/crates/atom/src/lib.rs
+++ b/crates/atom/src/lib.rs
@@ -220,6 +220,8 @@ pub fn ascii_lowercase_atom(s: &str) -> Atom {
 /// assert!(starts_with_ignore_case("HelloWorld", "hello"));
 /// assert!(starts_with_ignore_case("FOOBAR", "FooBar"));
 /// assert!(starts_with_ignore_case("test", "TEST"));
+/// assert!(starts_with_ignore_case("abcdefghijklmnop", "ABCDEFGHIJKLMNOP"));
+/// assert!(starts_with_ignore_case("abcdefghijklmnopqrstuvwxyzabcdef", "ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEF"));
 /// assert!(!starts_with_ignore_case("hello", "world"));
 /// assert!(!starts_with_ignore_case("hi", "hello"));
 /// ```
@@ -233,8 +235,8 @@ pub fn starts_with_ignore_case(haystack: &str, prefix: &str) -> bool {
             let haystack_bytes = haystack.as_bytes();
             let prefix_bytes = prefix.as_bytes();
 
-            let lower_a = _mm256_set1_epi8(b'a' as i8);
-            let lower_z = _mm256_set1_epi8(b'z' as i8);
+            let upper_a = _mm256_set1_epi8(b'A' as i8);
+            let upper_z = _mm256_set1_epi8(b'Z' as i8);
             let case_bit = _mm256_set1_epi8(0x20);
 
             let mut i = 0;
@@ -243,18 +245,18 @@ pub fn starts_with_ignore_case(haystack: &str, prefix: &str) -> bool {
                 let p = _mm256_loadu_si256(prefix_bytes.as_ptr().add(i) as *const __m256i);
 
                 // Convert haystack chunk to lowercase
-                let h_is_lower = _mm256_and_si256(
-                    _mm256_cmpgt_epi8(h, _mm256_sub_epi8(lower_a, _mm256_set1_epi8(1))),
-                    _mm256_cmpgt_epi8(_mm256_add_epi8(lower_z, _mm256_set1_epi8(1)), h),
+                let h_is_upper = _mm256_and_si256(
+                    _mm256_cmpgt_epi8(h, _mm256_sub_epi8(upper_a, _mm256_set1_epi8(1))),
+                    _mm256_cmpgt_epi8(_mm256_add_epi8(upper_z, _mm256_set1_epi8(1)), h),
                 );
-                let h_lower = _mm256_or_si256(h, _mm256_and_si256(h_is_lower, case_bit));
+                let h_lower = _mm256_or_si256(h, _mm256_and_si256(h_is_upper, case_bit));
 
                 // Convert prefix chunk to lowercase
-                let p_is_lower = _mm256_and_si256(
-                    _mm256_cmpgt_epi8(p, _mm256_sub_epi8(lower_a, _mm256_set1_epi8(1))),
-                    _mm256_cmpgt_epi8(_mm256_add_epi8(lower_z, _mm256_set1_epi8(1)), p),
+                let p_is_upper = _mm256_and_si256(
+                    _mm256_cmpgt_epi8(p, _mm256_sub_epi8(upper_a, _mm256_set1_epi8(1))),
+                    _mm256_cmpgt_epi8(_mm256_add_epi8(upper_z, _mm256_set1_epi8(1)), p),
                 );
-                let p_lower = _mm256_or_si256(p, _mm256_and_si256(p_is_lower, case_bit));
+                let p_lower = _mm256_or_si256(p, _mm256_and_si256(p_is_upper, case_bit));
 
                 let eq = _mm256_cmpeq_epi8(h_lower, p_lower);
                 let mask = _mm256_movemask_epi8(eq);
@@ -277,8 +279,8 @@ pub fn starts_with_ignore_case(haystack: &str, prefix: &str) -> bool {
             let haystack_bytes = haystack.as_bytes();
             let prefix_bytes = prefix.as_bytes();
 
-            let lower_a = vdupq_n_u8(b'a');
-            let lower_z = vdupq_n_u8(b'z');
+            let upper_a = vdupq_n_u8(b'A');
+            let upper_z = vdupq_n_u8(b'Z');
             let case_bit = vdupq_n_u8(0x20);
 
             let mut i = 0;
@@ -287,16 +289,16 @@ pub fn starts_with_ignore_case(haystack: &str, prefix: &str) -> bool {
                 let p = vld1q_u8(prefix_bytes.as_ptr().add(i));
 
                 // Convert haystack chunk to lowercase
-                let h_ge_a = vcgeq_u8(h, lower_a);
-                let h_le_z = vcleq_u8(h, lower_z);
-                let h_is_lower = vandq_u8(h_ge_a, h_le_z);
-                let h_lower = vorrq_u8(h, vandq_u8(h_is_lower, case_bit));
+                let h_ge_a = vcgeq_u8(h, upper_a);
+                let h_le_z = vcleq_u8(h, upper_z);
+                let h_is_upper = vandq_u8(h_ge_a, h_le_z);
+                let h_lower = vorrq_u8(h, vandq_u8(h_is_upper, case_bit));
 
                 // Convert prefix chunk to lowercase
-                let p_ge_a = vcgeq_u8(p, lower_a);
-                let p_le_z = vcleq_u8(p, lower_z);
-                let p_is_lower = vandq_u8(p_ge_a, p_le_z);
-                let p_lower = vorrq_u8(p, vandq_u8(p_is_lower, case_bit));
+                let p_ge_a = vcgeq_u8(p, upper_a);
+                let p_le_z = vcleq_u8(p, upper_z);
+                let p_is_upper = vandq_u8(p_ge_a, p_le_z);
+                let p_lower = vorrq_u8(p, vandq_u8(p_is_upper, case_bit));
 
                 let eq = vceqq_u8(h_lower, p_lower);
                 let min = vminvq_u8(eq);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes broken SIMD case folding in `starts_with_ignore_case` that caused case-insensitive string comparisons to silently fail for strings >= 16 bytes (NEON/aarch64) or >= 32 bytes (AVX2/x86_64).

## 🔍 Context & Motivation

Both the NEON and AVX2 implementations detected bytes in the range `[a-z]` (already lowercase) and OR'd in `0x20`, which is a no-op. They should detect `[A-Z]` (uppercase) instead, since those are the bytes that actually need lowercasing. This means that any mixed-case comparison hitting the SIMD path returned `false` when it should have returned `true`.

In practice, this broke guard perimeter rules with case-mismatched namespace prefixes >= 16 characters (e.g. `App\Domain\services\` vs `App\Domain\Services\`), which is valid since PHP namespaces are case-insensitive.

Fun fact: I went down into the rabbit hole because of a typo I made. Oh well.

## 🛠️ Summary of Changes

- **Bug Fix:** Changed SIMD range constants from `b'a'`/`b'z'` to `b'A'`/`b'Z'` in both the AVX2 and NEON implementations of `starts_with_ignore_case`, so the `| 0x20` mask is applied to uppercase bytes that actually need conversion.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [x] Dependencies
- [ ] Documentation
- [x] Other (please specify): `mago-atom` crate, used by guard, linter, and analyzer

## 🔗 Related Issues or PRs

I'm unaware if this was reported previously.

## 📝 Notes for Reviewers

I couldn't find tests regarding this other than the doctests. I've extended them with 16 and 32-byte checks.

Reproduction:
```
├── src
│   └── App
│       └── Domain
│           ├── Logic
│           │   └── UserHandler.php
│           └── Services
│               └── UserService.php
└── mago.toml
```

```toml
# mago.toml
php-version = "8.5"

[source]
paths = ["src"]

[guard]

[[guard.perimeter.rules]]
namespace = "App\\Domain\\Logic\\"
permit = ["App\\Domain\\services\\"]
```

```php
// UserService.php
<?php

declare(strict_types=1);

namespace App\Domain\Services;

final class UserService
{
    public function findUser(int $id): void
    {
    }
}
```

```php
// UserHandler.php
<?php

declare(strict_types=1);

namespace App\Domain\Logic;

use App\Domain\Services\UserService;
//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ This `use` statement is not allowed by the architectural rules

final class UserHandler
{
    public function __construct(
        private readonly UserService $service,
//                       ^^^^^^^^^^^ This parameter type-hint is not allowed by the architectural rules
    ) {
    }

    public function handle(int $id): void
    {
        $this->service->findUser($id);
    }
}
```