### PR TITLE
fix(codex): use second_part in list identity comparison

### DIFF
--- a/crates/codex/src/ttype/comparator/atomic_comparator.rs
+++ b/crates/codex/src/ttype/comparator/atomic_comparator.rs
@@ -588,7 +588,7 @@ pub(crate) fn can_be_identical<'a>(
         || (second_part.is_list() && first_part.is_non_empty_list())
     {
         return if let Some(first_element_type) = first_part.get_list_element_type()
-            && let Some(second_element_type) = first_part.get_list_element_type()
+            && let Some(second_element_type) = second_part.get_list_element_type()
         {
             union_comparator::can_expression_types_be_identical(
                 codebase,


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes a copypaste (🙄) error in `can_be_identical` where `list` vs `non-empty-list` identity comparison used the first operand's element type for both sides.

## 🔍 Context & Motivation

This was supposed to fail, but it didn't:

```php
/**
 * @param list<int> $a
 * @param non-empty-list<string> $b
 */
function compare(array $a, array $b): bool
{
    return $a === $b; // should trigger redundant-comparison
}
```

## 🛠️ Summary of Changes

- **Bug Fix:** Use `second_part.get_list_element_type()` for the second operand in the list vs non-empty-list branch of `can_be_identical`.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): `codex`

## 🔗 Related Issues or PRs

I'm unaware of any.

## 📝 Notes for Reviewers

You can use the code in "Context & Motivation" for reproduction.
