### PR TITLE
fix(database): skip file read after deletion

### DIFF
--- a/crates/database/src/watcher.rs
+++ b/crates/database/src/watcher.rs
@@ -344,6 +344,7 @@ impl<'a> DatabaseWatcher<'a> {
                     if !changed_file.path.exists() {
                         self.database.delete(changed_file.id);
                         tracing::trace!("Deleted file from database: {}", file.name);
+                        continue;
                     }
 
                     match Self::read_stable_contents(&changed_file.path) {


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fix the database watcher to skip reading a file after it has been deleted from disk.

## 🔍 Context & Motivation

When a watched file is deleted, the watcher correctly removes it from the database, but then falls through to `read_stable_contents`, which attempts to read the already deleted file. This produces an I/O error on every file deletion in watch mode.

## 🛠️ Summary of Changes

- **Bug Fix:** Added missing `continue` after file deletion in the watcher loop to skip the unnecessary read attempt.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [x] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

I'm not aware of any.

## 📝 Notes for Reviewers

It might be worth extracting the check logic into a separate function to make it testable.
