### PR TITLE
fix(analyzer): preserve sign for negative numeric string inc/dec

### DIFF
--- a/crates/analyzer/src/expression/unary.rs
+++ b/crates/analyzer/src/expression/unary.rs
@@ -521,17 +521,11 @@ fn increment_operand<'ctx, 'arena>(
                             if value.is_empty() {
                                 possibilities.push(TAtomic::Scalar(TScalar::literal_int(1)));
                             } else if let Ok(value) = value.parse::<i64>() {
-                                possibilities.push(TAtomic::Scalar(TScalar::literal_int(if negative {
-                                    value.wrapping_sub(1)
-                                } else {
-                                    value.wrapping_add(1)
-                                })));
+                                let signed_value = if negative { -value } else { value };
+                                possibilities.push(TAtomic::Scalar(TScalar::literal_int(signed_value.wrapping_add(1))));
                             } else if let Ok(value) = value.parse::<f64>() {
-                                possibilities.push(TAtomic::Scalar(TScalar::literal_float(if negative {
-                                    value - 1.0
-                                } else {
-                                    value + 1.0
-                                })));
+                                let signed_value = if negative { -value } else { value };
+                                possibilities.push(TAtomic::Scalar(TScalar::literal_float(signed_value + 1.0)));
                             } else {
                                 possibilities.push(TAtomic::Scalar(TScalar::int()));
                                 possibilities.push(TAtomic::Scalar(TScalar::float()));
@@ -763,17 +757,12 @@ fn decrement_operand<'ctx, 'arena>(
                                 if value.is_empty() {
                                     possibilities.push(TAtomic::Scalar(TScalar::literal_int(-1)));
                                 } else if let Ok(value) = value.parse::<i64>() {
-                                    possibilities.push(TAtomic::Scalar(TScalar::literal_int(if negative {
-                                        value.wrapping_add(1)
-                                    } else {
-                                        value.wrapping_sub(1)
-                                    })));
+                                    let signed_value = if negative { -value } else { value };
+                                    possibilities
+                                        .push(TAtomic::Scalar(TScalar::literal_int(signed_value.wrapping_sub(1))));
                                 } else if let Ok(value) = value.parse::<f64>() {
-                                    possibilities.push(TAtomic::Scalar(TScalar::literal_float(if negative {
-                                        value + 1.0
-                                    } else {
-                                        value - 1.0
-                                    })));
+                                    let signed_value = if negative { -value } else { value };
+                                    possibilities.push(TAtomic::Scalar(TScalar::literal_float(signed_value - 1.0)));
                                 } else {
                                     possibilities.push(TAtomic::Scalar(TScalar::int()));
                                     possibilities.push(TAtomic::Scalar(TScalar::float()));
@@ -1904,6 +1893,25 @@ mod tests {
             {
                 return (array) $obj;
             }
+        "}
+    }
+
+    test_analysis! {
+        name = negative_numeric_string_increment_decrement,
+        code = indoc! {r"
+            <?php
+
+            /**
+             * @param -4 $a
+             * @param -6 $b
+             */
+            function check(int $a, int $b): void {}
+
+            $a = '-5';
+            $a++;
+            $b = '-5';
+            $b--;
+            check($a, $b);
         "}
     }
 }


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes incorrect type inference when incrementing or decrementing negative numeric strings.

## 🔍 Context & Motivation

When incrementing/decrementing a negative numeric string like `"-5"`, the sign was stripped during parsing but never re-applied to the result. This caused `"-5"++` to infer `int(4)` instead of `int(-4)`, and `"-5"--` to infer `int(6)` instead of `int(-6)`.

## 🛠️ Summary of Changes

- **Bug Fix:** Reconstruct the signed value before applying increment/decrement arithmetic, for both `i64` and `f64` paths.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): `analyzer`

## 🔗 Related Issues or PRs

None.

## 📝 Notes for Reviewers

Reproduction: https://mago.carthage.software/playground#019cf90f-860d-f73b-42e8-2e71ddebad32
