### PR TITLE
fix(linter): replace Box::leak with owned storage in registry

### DIFF
--- a/crates/linter/src/registry.rs
+++ b/crates/linter/src/registry.rs
@@ -11,7 +11,7 @@ pub struct RuleRegistry {
     integrations: IntegrationSet,
     rules: Vec<AnyRule>,
     rule_excludes: Vec<Vec<String>>,
-    by_kind: Vec<&'static [usize]>,
+    by_kind: Vec<Box<[usize]>>,
 }
 
 impl RuleRegistry {
@@ -41,8 +41,7 @@ impl RuleRegistry {
             }
         }
 
-        let by_kind: Vec<&'static [usize]> =
-            temp.into_iter().map(|v| Box::<[usize]>::leak(v.into_boxed_slice()) as &'static [usize]).collect();
+        let by_kind: Vec<Box<[usize]>> = temp.into_iter().map(|v| v.into_boxed_slice()).collect();
 
         Self { only, integrations, rules, rule_excludes, by_kind }
     }
@@ -87,8 +86,8 @@ impl RuleRegistry {
 
     #[inline]
     #[must_use]
-    pub fn for_kind(&self, kind: NodeKind) -> &'static [usize] {
-        self.by_kind[kind as usize]
+    pub fn for_kind(&self, kind: NodeKind) -> &[usize] {
+        &self.by_kind[kind as usize]
     }
 
     #[inline]


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes a memory leak in `RuleRegistry::build` where `Box::leak` was used to create `&'static [usize]` slices that were never freed.

## 🔍 Context & Motivation

Each call to `RuleRegistry::build` leaked up to 256 boxed slices. Mostly affected the WASM playground and test suite, where the memory grows indefinitely since the registry is rebuilt on every interaction or test case.

## 🛠️ Summary of Changes

- **Bug Fix:** Replaced `Box::leak` with owned `Box<[usize]>` storage in `RuleRegistry`, so memory is freed when the registry is dropped.

## 📂 Affected Areas

- [x] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

None.

## 📝 Notes for Reviewers

Non-breaking public API change, callers only borrow the slice while the registry is alive.