### PR TITLE
docs: fix exit code and sort order documentation

### DIFF
--- a/crates/reporting/src/lib.rs
+++ b/crates/reporting/src/lib.rs
@@ -639,7 +639,7 @@ impl IssueCollection {
 
     /// Sorts the issues in the collection.
     ///
-    /// The issues are sorted by severity level in descending order,
+    /// The issues are sorted by severity level in ascending order,
     /// then by code in ascending order, and finally by the primary annotation span.
     #[must_use]
     pub fn sorted(self) -> Self {

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,7 +15,8 @@
 //!    before the application exits
 //! 3. **Displayed**: User-friendly error messages are provided via the [`Display`](std::fmt::Display)
 //!    implementation, with technical details available through [`source()`](std::error::Error::source)
-//! 4. **Mapped to Exit Codes**: All errors result in [`ExitCode::FAILURE`](std::process::ExitCode::FAILURE)
+//! 4. **Mapped to Exit Codes**: Errors result in [`EXIT_CODE_ERROR`](crate::EXIT_CODE_ERROR).
+//!    Analysis/lint failures result in [`ExitCode::FAILURE`](std::process::ExitCode::FAILURE).
 //!
 //! # Error Categories
 //!


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes incorrect doc comments about exit codes and sort order.

## 🔍 Context & Motivation

Doc comments were out of date.

## 🛠️ Summary of Changes

- Docs: Fixed exit code documentation
- Docs: Fixed sort order description

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [x] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

None.

## 📝 Notes for Reviewers
