### PR TITLE
fix(codex): preserve is_this flag when expanding static/self types in non-final classes

### DIFF
--- a/crates/analyzer/tests/cases/issue_1410.php
+++ b/crates/analyzer/tests/cases/issue_1410.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+class X1410 {
+    /** @return $this */
+    public function chained(): self
+    {
+        /** @mago-expect analysis:less-specific-return-statement */
+        return new self();
+    }
+}
+
+final class FinalX1410 {
+    /** @return $this */
+    public function chained(): self
+    {
+        return new self();
+    }
+}

--- a/crates/analyzer/tests/cases/issue_1411.php
+++ b/crates/analyzer/tests/cases/issue_1411.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+class Y1411 {
+    public static function new(): static
+    {
+        /** @mago-expect analysis:less-specific-return-statement */
+        return new self;
+    }
+}
+
+final class FinalY1411 {
+    public static function new(): static
+    {
+        return new self;
+    }
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -718,6 +718,8 @@ test_case!(issue_1368);
 test_case!(issue_1372);
 test_case!(issue_1374);
 test_case!(issue_1375);
+test_case!(issue_1410);
+test_case!(issue_1411);
 test_case!(issue_1412);
 test_case!(issue_1416);
 test_case!(parent_static_call_template_resolution);

--- a/crates/codex/src/ttype/expander.rs
+++ b/crates/codex/src/ttype/expander.rs
@@ -526,17 +526,31 @@ fn resolve_static_type(
             }
 
             named.name = static_obj.name;
-            // For final classes, static === self, so is_this should be false
-            named.is_this = !codebase.get_class_like(&static_obj.name).is_some_and(|meta| meta.flags.is_final());
+            named.is_this = !is_effectively_final(&static_obj.name, codebase, options);
         }
         StaticClassType::Name(static_class)
             if (!check_compatibility || codebase.is_instance_of(static_class, &named.name)) =>
         {
             named.name = *static_class;
-            named.is_this = false;
+            named.is_this = !is_effectively_final(static_class, codebase, options);
         }
         _ => {}
     }
+}
+
+/// Checks whether a class is effectively final for the purpose of `$this`/`static` resolution.
+///
+/// A class is effectively final when it cannot be extended, meaning `static` === `self`:
+///
+/// - The class is declared `final`
+/// - The class is anonymous
+/// - The method is declared `final`
+fn is_effectively_final(class_name: &Atom, codebase: &CodebaseMetadata, options: &TypeExpansionOptions) -> bool {
+    if options.function_is_final {
+        return true;
+    }
+
+    codebase.get_class_like(class_name).is_some_and(|meta| meta.name_span.is_none() || meta.flags.is_final())
 }
 
 /// Checks if the static object type is compatible with a type that has is_this=true.


### PR DESCRIPTION
closes #1410
closes #1411