### PR TITLE
fix(codex): correctly mark empty array literals as non_empty=false in type inference

### DIFF
--- a/crates/analyzer/tests/cases/issue_1422.php
+++ b/crates/analyzer/tests/cases/issue_1422.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @template T of array
+ */
+class Box
+{
+    /**
+     * @param T $value
+     */
+    public function __construct(
+        /** @mago-expect analysis:unused-property */
+        private array $value = [],
+    ) {}
+}
+
+/** @param Box<array<string, mixed>> $box */
+function accept(Box $box): void {}
+
+accept(new Box([]));
+accept(new Box());
+
+/** @var Box<array<string, mixed>> */
+$box = new Box();
+accept($box);

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -724,6 +724,7 @@ test_case!(issue_1411);
 test_case!(issue_1412);
 test_case!(issue_1415);
 test_case!(issue_1416);
+test_case!(issue_1422);
 test_case!(psl_async_integration);
 test_case!(parent_static_call_template_resolution);
 test_case!(bitwise_shift_bounds);

--- a/crates/codex/src/scanner/inference/mod.rs
+++ b/crates/codex/src/scanner/inference/mod.rs
@@ -512,7 +512,7 @@ pub(super) fn infer_with_constants<'arena>(
                 known_count: Some(entries.len()),
                 known_elements: Some(entries),
                 element_type: Arc::new(get_never()),
-                non_empty: true,
+                non_empty: !elements.is_empty(),
             }))))
         }
         Expression::Array(Array { elements, .. }) | Expression::LegacyArray(LegacyArray { elements, .. })


### PR DESCRIPTION

closes #1422
