### PR TITLE
fix(formatter): revert #1407 due to excessive parenthesis removal

### DIFF
--- a/crates/formatter/src/internal/parens.rs
+++ b/crates/formatter/src/internal/parens.rs
@@ -291,9 +291,7 @@ impl<'arena> FormatterState<'_, 'arena> {
                 }
 
                 if (operator.is_arithmetic() && !e.operator.is_arithmetic())
-                    || (operator.is_multiplicative()
-                        && e.operator.is_multiplicative()
-                        && !e.operator.is_same_as(operator))
+                    || (operator.is_multiplicative() || e.operator.is_multiplicative())
                     || (operator.is_bit_shift() && !e.operator.is_bit_shift())
                     || (operator.is_bitwise() && e.operator.is_bitwise() && !e.operator.is_same_as(operator))
                 {

--- a/crates/formatter/tests/cases/drupal_preset/after.php
+++ b/crates/formatter/tests/cases/drupal_preset/after.php
@@ -1296,7 +1296,7 @@ $form['frontend'] = [
   ->fields(['uid', 'last_sent', 'reminders'], [
     $user->id(),
     \Drupal::time()->getCurrentTime()
-      - ($i + 1) * (int) \Drupal::config('example_auth.settings')->get('email_verification_timeout'),
+      - (($i + 1) * (int) \Drupal::config('example_auth.settings')->get('email_verification_timeout')),
     $i,
   ])
   ->execute();

--- a/crates/formatter/tests/precedence.rs
+++ b/crates/formatter/tests/precedence.rs
@@ -68,8 +68,8 @@ mod precedence {
     test_expression_format!(keep_parens_for_shift_vs_concat, "$a . ($b << $c)", "$a . ($b << $c)");
     test_expression_format!(keep_parens_for_shift_vs_addition, "$a << ($b + $c)", "$a << ($b + $c)");
     test_expression_format!(keep_parens_in_ternary_condition, "$a > ($b && $c) ? $d : $e", "$a > ($b && $c) ? $d : $e");
-    test_expression_format!(remove_redundant_simple_arithmetic, "($a * $b) + $c", "$a * $b + $c");
-    test_expression_format!(remove_redundant_nested_arithmetic, "$a + (($b - $c) * $d)", "$a + ($b - $c) * $d");
+    test_expression_format!(keep_redundant_simple_arithmetic, "($a * $b) + $c", "($a * $b) + $c");
+    test_expression_format!(keep_redundant_nested_arithmetic, "$a + (($b - $c) * $d)", "$a + (($b - $c) * $d)");
     test_expression_format!(remove_logical, "($a && $b) || $c", "$a && $b || $c");
     test_expression_format!(remove_comparison, "($a > $b) && ($c < $d)", "$a > $b && $c < $d");
     test_expression_format!(remove_left_associative, "($a - $b) - $c", "$a - $b - $c");
@@ -91,7 +91,7 @@ mod precedence {
     test_expression_format!(
         complex_1_messy,
         "(($a = (((((++$b * ((((-$c)))))))) + ($d / ($e ** $f))) && ($g || $h)))",
-        "$a = (++$b * -$c + $d / $e ** $f) && ($g || $h)"
+        "$a = ((++$b * -$c) + ($d / ($e ** $f))) && ($g || $h)"
     );
     test_expression_format!(
         complex_2_messy,
@@ -101,23 +101,23 @@ mod precedence {
     test_expression_format!(
         complex_3_messy,
         "$a = ($b << ($c + ($d * $e))) >> ($f - $g)",
-        "$a = ($b << ($c + $d * $e)) >> ($f - $g)"
+        "$a = ($b << ($c + ($d * $e))) >> ($f - $g)"
     );
-    test_expression_format!(complex_4_messy, "$a = ((!$b) + ((~$c * --$d) / @$e))", "$a = !$b + (~$c * --$d) / @$e");
+    test_expression_format!(complex_4_messy, "$a = ((!$b) + ((~$c * --$d) / @$e))", "$a = !$b + ((~$c * --$d) / @$e)");
     test_expression_format!(
         complex_5_messy,
         "($a = (($b + ($c * $d)) <=> (($e / $f) - $g)))",
-        "$a = ($b + $c * $d) <=> ($e / $f - $g)"
+        "$a = ($b + ($c * $d)) <=> (($e / $f) - $g)"
     );
     test_expression_format!(
         complex_6_messy,
         "(($a = (((((($b))) + ($c * $d)) > $e) && ((((($f))) & $g) | ($h ^ $i)))) or (($j = (((($k ?? $l)))))))",
-        "($a = ($b + $c * $d) > $e && ($f & $g) | ($h ^ $i)) or ($j = $k ?? $l)"
+        "($a = ($b + ($c * $d)) > $e && ($f & $g) | ($h ^ $i)) or ($j = $k ?? $l)"
     );
     test_expression_format!(
         complex_7_messy,
         "$a = ($b + ($c - (($d * $e) / ($f % ($g ** $h)))))",
-        "$a = $b + ($c - ($d * $e) / ($f % $g ** $h))"
+        "$a = $b + ($c - (($d * $e) / ($f % ($g ** $h))))"
     );
     test_expression_format!(complex_8_messy, "$a = ((($b ?? ($c ?? $d))) ? $e : $f)", "$a = $b ?? $c ?? $d ? $e : $f");
     test_expression_format!(


### PR DESCRIPTION
## 📌 What Does This PR Do?

Reverts #1407.

## 🔍 Context & Motivation

#1407 is broken. Parenthesis removal is too excessive, see https://github.com/carthage-software/mago/pull/1430.

## 🛠️ Summary of Changes

- **Bug Fix:** Reverts excessive parenthesis removal.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

#1407, #1430

## 📝 Notes for Reviewers
