### PR TITLE
fix(docs): Remove limitations from docker recipe docs page

### DIFF
--- a/docs/recipes/docker.md
+++ b/docs/recipes/docker.md
@@ -147,12 +147,3 @@ mago lint
 mago fmt --check
 mago analyze
 ```
-
-## Limitations
-
-The container image is built from `scratch` and contains only the Mago binary. This means:
-
-- **No shell**: You cannot exec into the container or run shell commands inside it.
-- **No git**: The `--staged` flag for `lint` and `fmt` commands will not work, as there is no `git` binary available inside the container.
-
-For workflows that require `--staged` support, use a [native installation](/guide/installation).


### PR DESCRIPTION
## 📌 What Does This PR Do?

Update the documentations for the docker image. Remove the limitations paragraph since it has been resolved by both #1339 #1369 (Alpine provides a shell and git is now installed) :+1:

## 🔍 Context & Motivation

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [x] Documentation
- [ ] Other (please specify):