### PR TITLE
fix(composer): don't spinlock waiting for proc to close

### DIFF
--- a/composer/internal.php
+++ b/composer/internal.php
@@ -492,7 +492,7 @@ function execute(string $executablePath, array $args): never
     }
 
     do {
-        usleep(STATUS_CHECK_INTERVAL);
+        \usleep(STATUS_CHECK_INTERVAL);
         $status = proc_get_status($process);
     } while ($status['running']);
 


### PR DESCRIPTION

## 📌 What Does This PR Do?

<!-- Briefly describe what this PR introduces or fixes. -->

When running `analyze --watch` with a composer installation of mago, the PHP wrapper process will run at 100% on a single core seemingly polling until the process is done. This adds a 500ms delay that will stop the php wrapper from looping so hard.

This also fixes a bug where currently when the mago process gets killed by a signal, it exits with the signal code (so like 2 for SIGINT), instead of the exit code 130 (128 + 2). The $status variable has a boolean termsig which is true when the process was killed by a signal, and a termsig field which is the termsig is. Updating this causes the PHP wrapper to exit with the same exit code that mago did.

## 🔍 Context & Motivation

I noticed that when `mago analyze --watch` was running from a composer installation, a PHP process was using up 100% of a CPU core even when the watcher said it was waiting for changes to be made.

This second fix is less important, but I noticed that when I killed the mago process (the rust binary, not the PHP script), the exit code returned from proc_get_status was -1 instead of the exit code of the mago process. The $status return value has a field to use when the process was sigterm'd, which propagates the right exit code when the php wrapper exits.

This image shows the exit codes being set correctly
<img width="1384" height="656" alt="Screenshot 2026-03-19 at 6 54 43 PM" src="https://github.com/user-attachments/assets/138fda1b-a854-48e0-bd88-0d782ab97b71" />

This image shows the cpu at 100% while it's waiting for changes
<img width="1373" height="260" alt="Screenshot 2026-03-19 at 6 59 20 PM" src="https://github.com/user-attachments/assets/5e414a8c-376a-4c07-b2ed-7be846c98494" />


<!-- Why is this change needed? Is it fixing a bug, adding a feature, or refactoring? -->

## 🛠️ Summary of Changes

- **Bug Fix:** Stopped spinlocking when running watch mode from a composer install. Also fixed signal-based error code.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Composer wrapper

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
