### PR TITLE
fix(formatter): add conditional expression comment placement handler

### DIFF
--- a/crates/formatter/src/internal/comment/placement.rs
+++ b/crates/formatter/src/internal/comment/placement.rs
@@ -2,6 +2,7 @@ use foldhash::HashMap;
 
 use mago_span::HasSpan;
 use mago_span::Span;
+use mago_syntax::ast::Conditional;
 use mago_syntax::ast::Expression;
 use mago_syntax::ast::Node;
 use mago_syntax::ast::Trivia;
@@ -243,6 +244,7 @@ fn unwrap_parenthesized_node<'ast, 'arena>(node: Node<'ast, 'arena>) -> Node<'as
 fn place_comment<'ast, 'arena>(comment: DecoratedComment<'ast, 'arena>) -> CommentPlacement<'ast, 'arena> {
     match comment.enclosing {
         Node::Binary(_) => place_binary(comment),
+        Node::Conditional(_) => place_conditional(comment),
         _ => CommentPlacement::Default,
     }
 }
@@ -275,6 +277,69 @@ fn place_binary<'ast, 'arena>(comment: DecoratedComment<'ast, 'arena>) -> Commen
 
     if cs >= rhs_span.end.offset {
         return CommentPlacement::Trailing { node: Node::Expression(rhs), comment_index: index };
+    }
+
+    CommentPlacement::Default
+}
+
+fn place_conditional<'ast, 'arena>(comment: DecoratedComment<'ast, 'arena>) -> CommentPlacement<'ast, 'arena> {
+    let Node::Conditional(Conditional { condition, question_mark, then, colon, r#else }) = comment.enclosing else {
+        return CommentPlacement::Default;
+    };
+
+    let index = comment.comment_index;
+    let cs = comment.trivia_start;
+    let condition = unwrap_parenthesized(condition);
+    let condition_span = condition.span();
+    let r#else = unwrap_parenthesized(r#else);
+    let else_span = r#else.span();
+
+    // Handles comments exposed before condition by DFS parenthesized transparency.
+    if cs < condition_span.start.offset {
+        return CommentPlacement::Leading { node: Node::Expression(condition), comment_index: index };
+    }
+
+    match then {
+        Some(then) => {
+            let then = unwrap_parenthesized(then);
+            let then_span = then.span();
+
+            if cs >= condition_span.end.offset && cs < question_mark.start.offset {
+                return CommentPlacement::Trailing { node: Node::Expression(condition), comment_index: index };
+            }
+
+            if cs >= question_mark.end.offset && cs < then_span.start.offset {
+                return CommentPlacement::Leading { node: Node::Expression(then), comment_index: index };
+            }
+
+            if cs >= then_span.end.offset && cs < colon.start.offset {
+                return CommentPlacement::Trailing { node: Node::Expression(then), comment_index: index };
+            }
+
+            if cs >= colon.end.offset && cs < else_span.start.offset {
+                return CommentPlacement::Leading { node: Node::Expression(r#else), comment_index: index };
+            }
+
+            if cs >= else_span.end.offset {
+                return CommentPlacement::Trailing { node: Node::Expression(r#else), comment_index: index };
+            }
+        }
+        None => {
+            // Elvis (`?:`): condition and else only, no then branch.
+            if cs >= condition_span.end.offset && cs < question_mark.start.offset {
+                return CommentPlacement::Trailing { node: Node::Expression(condition), comment_index: index };
+            }
+
+            // Between `?` and `:` or after `:` but before else: treat as else leading,
+            // matching binary's "after operator" convention.
+            if cs >= question_mark.start.offset && cs < else_span.start.offset {
+                return CommentPlacement::Leading { node: Node::Expression(r#else), comment_index: index };
+            }
+
+            if cs >= else_span.end.offset {
+                return CommentPlacement::Trailing { node: Node::Expression(r#else), comment_index: index };
+            }
+        }
     }
 
     CommentPlacement::Default

--- a/crates/formatter/tests/cases/comment_placement_conditional/after.php
+++ b/crates/formatter/tests/cases/comment_placement_conditional/after.php
@@ -1,0 +1,40 @@
+<?php
+
+// Before condition in parenthesized ternary
+$a = /* before condition */ $condition ? $then : $else;
+
+// Line comment trailing condition
+$b = $condition ? $then : $else; // trailing condition
+
+// Block comment between `?` and then
+$c = $condition ? /* block comment */ value_function('arg') : $else;
+
+// Line comment trailing then
+$d = $condition ? $then : $else; // trailing then
+
+// Own-line line comment between `:` and else
+$e = $condition
+    ? $then
+    : // leading else
+    $else;
+
+// Line comment trailing else
+$f = is_type($value) ? $value : ($flag_a ? CONST_A : 0) | ($flag_b ? CONST_B : 0); // trailing
+
+// Elvis with block comment between condition and `?`
+$g = $condition /* before ?: */ ?: $fallback;
+
+// Elvis with block comment between `?` and `:`
+$h = $condition ?: /* between ?: */ $fallback;
+
+// Elvis with block comment after `:`
+$i = $condition ?: /* block before fallback */ $fallback;
+
+// Elvis with trailing line comment
+$j = $condition ?: $fallback; // elvis trailing
+
+// Multiple comments in same zone
+$k = $condition
+    ? $then // first
+    // second
+    : $else;

--- a/crates/formatter/tests/cases/comment_placement_conditional/before.php
+++ b/crates/formatter/tests/cases/comment_placement_conditional/before.php
@@ -1,0 +1,52 @@
+<?php
+
+// Before condition in parenthesized ternary
+$a = (/* before condition */ $condition ? $then : $else);
+
+// Line comment trailing condition
+$b = $condition // trailing condition
+    ? $then
+    : $else;
+
+// Block comment between `?` and then
+$c = $condition
+    ? /* block comment */
+    value_function('arg')
+    : $else;
+
+// Line comment trailing then
+$d = $condition
+    ? $then // trailing then
+    : $else;
+
+// Own-line line comment between `:` and else
+$e = $condition
+    ? $then
+    :
+    // leading else
+    $else;
+
+// Line comment trailing else
+$f = is_type($value)
+    ? $value
+    : ($flag_a ? CONST_A : 0) | ($flag_b ? CONST_B : 0); // trailing
+
+// Elvis with block comment between condition and `?`
+$g = $condition /* before ?: */ ?: $fallback;
+
+// Elvis with block comment between `?` and `:`
+$h = $condition ?/* between ?: */: $fallback;
+
+// Elvis with block comment after `:`
+$i = $condition ?:
+    /* block before fallback */
+    $fallback;
+
+// Elvis with trailing line comment
+$j = $condition ?: $fallback; // elvis trailing
+
+// Multiple comments in same zone
+$k = $condition
+    ? $then // first
+    // second
+    : $else;

--- a/crates/formatter/tests/cases/comment_placement_conditional/settings.inc
+++ b/crates/formatter/tests/cases/comment_placement_conditional/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings::default()

--- a/crates/formatter/tests/cases/comment_placement_conditional_preserve/after.php
+++ b/crates/formatter/tests/cases/comment_placement_conditional_preserve/after.php
@@ -1,0 +1,48 @@
+<?php
+
+// Before condition in parenthesized ternary
+$a = /* before condition */ $condition ? $then : $else;
+
+// Line comment trailing condition
+$b = $condition // trailing condition
+    ? $then
+    : $else;
+
+// Block comment between `?` and then
+$c = $condition
+    ? /* block comment */ value_function('arg')
+    : $else;
+
+// Line comment trailing then
+$d = $condition
+    ? $then // trailing then
+    : $else;
+
+// Own-line line comment between `:` and else
+$e = $condition
+    ? $then
+    : // leading else
+    $else;
+
+// Line comment trailing else
+$f = is_type($value)
+    ? $value
+    : ($flag_a ? CONST_A : 0) | ($flag_b ? CONST_B : 0); // trailing
+
+// Elvis with block comment between condition and `?`
+$g = $condition /* before ?: */ ?: $fallback;
+
+// Elvis with block comment between `?` and `:`
+$h = $condition ?: /* between ?: */ $fallback;
+
+// Elvis with block comment after `:`
+$i = $condition ?: /* block before fallback */ $fallback;
+
+// Elvis with trailing line comment
+$j = $condition ?: $fallback; // elvis trailing
+
+// Multiple comments in same zone
+$k = $condition
+    ? $then // first
+    // second
+    : $else;

--- a/crates/formatter/tests/cases/comment_placement_conditional_preserve/before.php
+++ b/crates/formatter/tests/cases/comment_placement_conditional_preserve/before.php
@@ -1,0 +1,52 @@
+<?php
+
+// Before condition in parenthesized ternary
+$a = (/* before condition */ $condition ? $then : $else);
+
+// Line comment trailing condition
+$b = $condition // trailing condition
+    ? $then
+    : $else;
+
+// Block comment between `?` and then
+$c = $condition
+    ? /* block comment */
+    value_function('arg')
+    : $else;
+
+// Line comment trailing then
+$d = $condition
+    ? $then // trailing then
+    : $else;
+
+// Own-line line comment between `:` and else
+$e = $condition
+    ? $then
+    :
+    // leading else
+    $else;
+
+// Line comment trailing else
+$f = is_type($value)
+    ? $value
+    : ($flag_a ? CONST_A : 0) | ($flag_b ? CONST_B : 0); // trailing
+
+// Elvis with block comment between condition and `?`
+$g = $condition /* before ?: */ ?: $fallback;
+
+// Elvis with block comment between `?` and `:`
+$h = $condition ?/* between ?: */: $fallback;
+
+// Elvis with block comment after `:`
+$i = $condition ?:
+    /* block before fallback */
+    $fallback;
+
+// Elvis with trailing line comment
+$j = $condition ?: $fallback; // elvis trailing
+
+// Multiple comments in same zone
+$k = $condition
+    ? $then // first
+    // second
+    : $else;

--- a/crates/formatter/tests/cases/comment_placement_conditional_preserve/settings.inc
+++ b/crates/formatter/tests/cases/comment_placement_conditional_preserve/settings.inc
@@ -1,0 +1,4 @@
+FormatSettings {
+  preserve_breaking_conditional_expression: true,
+  ..Default::default()
+}

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -255,6 +255,8 @@ test_case!(drupal_preset);
 test_case!(redundant_grouping_parens);
 test_case!(null_type_hint_null_pipe_last);
 test_case!(comment_placement_binary);
+test_case!(comment_placement_conditional);
+test_case!(comment_placement_conditional_preserve);
 
 // A special test case for regressions in the Psl codebase
 test_case!(psl_regressions);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Adds a comment placement handler for conditional (ternary) expressions, stabilizing comment positions across formatting passes and resolving 5 idempotency failures.

## 🛠️ Summary of Changes

- Added `place_conditional` handler in `placement.rs` that assigns comments around `?` and `:` operators to their nearest AST nodes based on structural position rather than byte offsets.
- Handles full ternary (`$a ? $b : $c`) and elvis (`$a ?: $b`) expressions.
- Added test cases covering all placement zones, including `preserve_breaking` interaction.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Follows #1456

## 📝 Notes for Reviewers

### Idempotency improvement

Files where a second `mago fmt` changes output. Real-world PHP repos, `threads = 1`, default preset. Corpus differs from #1456 (added `moodle/moodle`, replaced `azjezz/psl` with `php-standard-library/php-standard-library`), so v1.15.3 totals do not match.

| | v1.15.3 | This PR | Delta |
|:--|--:|--:|--:|
| Total failures | 99 | 94 | **−5** |

<details>
<summary>Per-repo breakdown</summary>

| Repo | Files | v1.15.3 | This PR | Delta |
|:--|--:|--:|--:|--:|
| api-platform/core | 2498 | 2 | 2 | 0 |
| briannesbitt/Carbon | 2000 | 1 | 1 | 0 |
| cakephp/cakephp | 1608 | 0 | 0 | 0 |
| composer/composer | 580 | 0 | 0 | 0 |
| doctrine/dbal | 681 | 0 | 0 | 0 |
| doctrine/orm | 1473 | 1 | 1 | 0 |
| drupal/drupal | 10307 | 0 | 0 | 0 |
| FakerPHP/Faker | 666 | 0 | 0 | 0 |
| filamentphp/filament | 5023 | 7 | 7 | 0 |
| Intervention/image | 534 | 0 | 0 | 0 |
| laravel/framework | 2854 | 0 | 0 | 0 |
| livewire/livewire | 769 | 0 | 0 | 0 |
| moodle/moodle | 49869 | 27 | 27 | 0 |
| nextcloud/server | 5368 | 2 | 2 | 0 |
| nikic/PHP-Parser | 341 | 0 | 0 | 0 |
| pestphp/pest | 464 | 2 | 2 | 0 |
| php-standard-library/php-standard-library | 2705 | 0 | 0 | 0 |
| phpstan/phpstan-src | 6977 | 8 | 8 | 0 |
| predis/predis | 1218 | 0 | 0 | 0 |
| sebastianbergmann/phpunit | 2489 | 2 | 2 | 0 |
| Seldaek/monolog | 217 | 0 | 0 | 0 |
| slimphp/Slim | 125 | 0 | 0 | 0 |
| spatie/laravel-data | 508 | 1 | 1 | 0 |
| squizlabs/PHP_CodeSniffer | 613 | 1 | 1 | 0 |
| symfony/symfony | 10363 | 3 | 2 | **−1** |
| thephpleague/flysystem | 182 | 1 | 1 | 0 |
| twigphp/Twig | 420 | 0 | 0 | 0 |
| wikimedia/mediawiki | 5489 | 20 | 19 | **−1** |
| WordPress/WordPress | 1983 | 21 | 18 | **−3** |
| yiisoft/yii2 | 1046 | 0 | 0 | 0 |

</details>
