### PR TITLE
docs(vscode): add Run On Save extension as an alternative formatter s…

### DIFF
--- a/docs/recipes/vscode.md
+++ b/docs/recipes/vscode.md
@@ -60,3 +60,30 @@ Your setup is now complete.
 
 - With `editor.formatOnSave` enabled, your PHP files will be automatically formatted by Mago every time you save.
 - You can also manually format a file at any time by opening the command palette (`Ctrl+Shift+P`) and running the **Format Document** command.
+
+## Alternative: Run On Save extension
+
+If you prefer to run Mago directly on save (instead of through VS Code's formatter API), you can use the [Run On Save](https://marketplace.visualstudio.com/items?itemName=emeraldwalk.RunOnSave) extension.
+
+This approach can be useful when using a project-local Mago binary because the command runs in your workspace context and applies your repository configuration (including exclude rules in `mago.toml`).
+
+### Configure `settings.json`
+
+Add the following configuration to your workspace or user `settings.json`:
+
+```json
+{
+  // ... your other settings
+
+  "emeraldwalk.runonsave": {
+    "commands": [
+      {
+        "match": "\\.php$",
+        "cmd": "${workspaceFolder}/vendor/bin/mago fmt ${relativeFile}"
+      }
+    ]
+  }
+}
+```
+
+After saving a PHP file, VS Code will execute Mago for that file using your workspace's installed binary.


### PR DESCRIPTION
## 📌 What Does This PR Do?

Adds an alternative VSCode extension for running `mago fmt` on file save.

## 🔍 Context & Motivation

The on save command uses the filename so any configured  `excludes` from the projects `mago.toml` will be respected and formatting will be skipped for those files.

## 🛠️ Summary of Changes

- **Docs:** Update VSCode recipe.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [x] Documentation
- [ ] Other (please specify):
