### PR TITLE
fix(cli): handle spaces in binary path

### DIFF
--- a/composer/internal.php
+++ b/composer/internal.php
@@ -17,7 +17,6 @@ use function curl_getinfo;
 use function curl_init;
 use function curl_setopt;
 use function escapeshellarg;
-use function escapeshellcmd;
 use function extension_loaded;
 use function fclose;
 use function file_exists;
@@ -471,7 +470,7 @@ function ensure_binary(
  */
 function execute(string $executablePath, array $args): never
 {
-    $command = escapeshellcmd($executablePath);
+    $command = escapeshellarg($executablePath);
     if ($args !== []) {
         $command .= ' ' . implode(' ', array_map(escapeshellarg(...), $args));
     }


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes running Mago in a path with spaces.

## 🔍 Context & Motivation

Running Mago in a directory with a space fails because `escapeshellcmd` only prevents multiple commands from running (essentially only escaping `;`), but spaces, quotes, etc are passed through as-is. `escapeshellarg` should be used even for the binary path. ([`escapeshellcmd` is only for ensuring a complete command with arguments is only a single command](https://stackoverflow.com/a/22739494/626682), so is inappropriate for this use case.)

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed incorrect escaping of the binary path.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [x] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):
