### PR TITLE
fix(prelude): remove `@deprecated` annotation from mb_scrub

### DIFF
--- a/crates/prelude/assets/extensions/mbstring.php
+++ b/crates/prelude/assets/extensions/mbstring.php
@@ -409,7 +409,6 @@ function mb_ord(string $string, ?string $encoding = null): int|false {}
 
 /**
  * @pure
- * @deprecated
  */
 function mb_scrub(string $string, ?string $encoding = null): string {}
 


### PR DESCRIPTION
closes #1476
