### PR TITLE
fix(formatter): Don't populate the source database when formatting stdin

### DIFF
--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -163,12 +163,9 @@ impl FormatCommand {
             orchestrator.set_source_paths(self.path.iter().map(|p| p.to_string_lossy().to_string()));
         }
 
-        let mut database = orchestrator.load_database(&configuration.source.workspace, false, None)?;
-        let service = orchestrator.get_format_service(database.read_only());
-
         if self.stdin_input {
             let file = Self::create_file_from_stdin()?;
-            let status = service.format_file(&file)?;
+            let status = orchestrator.format_file(&file)?;
 
             let exit_code = match status {
                 FileFormatStatus::Unchanged => {
@@ -190,6 +187,9 @@ impl FormatCommand {
 
             return Ok(exit_code);
         }
+
+        let mut database = orchestrator.load_database(&configuration.source.workspace, false, None)?;
+        let service = orchestrator.get_format_service(database.read_only());
 
         let result = service.run()?;
 


### PR DESCRIPTION
## 📌 What Does This PR Do?

Uses the specialized format_file method on the orchestrator that uses an empty database, skipping the database population which can be quite slow.

## 🔍 Context & Motivation

Reports on tempest where it takes almost a second to populate the database. For absolutely no reason when formatting stdin. Formatting individual files is already slow because in that case the database is only populated with that fie.

## 🛠️ Summary of Changes

- **Bug Fix:** Improved speed of stdin formatting in huge projects.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Discord perf issue report by @innocenzi 

## 📝 Notes for Reviewers

choo choo
