### PR TITLE
fix(formatter): correct fits() handling of LineSuffix

### DIFF
--- a/crates/formatter/src/internal/printer/mod.rs
+++ b/crates/formatter/src/internal/printer/mod.rs
@@ -461,6 +461,7 @@ impl<'arena> Printer<'arena> {
 
     fn fits(&self, next: &Command<'arena>, width: isize) -> bool {
         let mut remaining_width = width;
+        let mut has_line_suffix = false;
         // Use a Vec as a stack. Pre-allocating avoids reallocation churn.
         let mut stack: Vec<(Mode, &Document<'arena>)> = Vec::with_capacity_in(128, self.arena);
         let mut cmds = self.commands.iter().rev();
@@ -533,13 +534,12 @@ impl<'arena> Printer<'arena> {
                     }
                 }
                 Document::LineSuffix(_) => {
-                    break;
+                    has_line_suffix = true;
                 }
                 Document::LineSuffixBoundary => {
-                    if !self.line_suffix.is_empty() {
+                    if has_line_suffix || !self.line_suffix.is_empty() {
                         return false;
                     }
-                    break;
                 }
                 Document::BreakParent | Document::Trim(_) | Document::DoNotTrim => {}
             }
@@ -549,6 +549,7 @@ impl<'arena> Printer<'arena> {
             }
 
             if stack.is_empty()
+                && !has_line_suffix
                 && let Some(cmd) = cmds.next()
             {
                 stack.push((cmd.mode, &cmd.document));

--- a/crates/formatter/tests/cases/fits_line_suffix/after.php
+++ b/crates/formatter/tests/cases/fits_line_suffix/after.php
@@ -1,0 +1,43 @@
+<?php
+
+// Chain with trailing comment on intermediate call
+$form
+    ->setMethod('get')
+    ->setTitle($this->getPageTitle()) // Remove subpage
+    ->setFormIdentifier('blocklist')
+    ->setWrapperLegendMsg('legend')
+    ->setSubmitTextMsg('submit')
+    ->prepareForm()
+    ->displayForm(false);
+
+// Chain with trailing comment on last call
+$form
+    ->setMethod('get')
+    ->setTitle($this->getPageTitle())
+    ->setFormIdentifier('blocklist')
+    ->setWrapperLegendMsg('legend')
+    ->setSubmitTextMsg('submit')
+    ->prepareForm()
+    ->displayForm(false); // Remove subpage
+
+// Short chain with trailing comment (should stay on one line)
+$result = $builder->method($a)->other(); // trailing
+
+// Argument list with intermediate trailing comment
+foo(
+    $first, // after first
+    $second,
+    $third,
+);
+
+// Binary chain with trailing comment in if condition
+if (
+    $condition_a
+    && $condition_b // check b
+    && $condition_c
+    && $condition_d
+) {
+    return true;
+}
+?>
+<div><?php echo $value; /* inline block comment */ ?>text</div>

--- a/crates/formatter/tests/cases/fits_line_suffix/before.php
+++ b/crates/formatter/tests/cases/fits_line_suffix/before.php
@@ -1,0 +1,43 @@
+<?php
+
+// Chain with trailing comment on intermediate call
+$form
+    ->setMethod('get')
+    ->setTitle($this->getPageTitle()) // Remove subpage
+    ->setFormIdentifier('blocklist')
+    ->setWrapperLegendMsg('legend')
+    ->setSubmitTextMsg('submit')
+    ->prepareForm()
+    ->displayForm(false);
+
+// Chain with trailing comment on last call
+$form
+    ->setMethod('get')
+    ->setTitle($this->getPageTitle())
+    ->setFormIdentifier('blocklist')
+    ->setWrapperLegendMsg('legend')
+    ->setSubmitTextMsg('submit')
+    ->prepareForm()
+    ->displayForm(false); // Remove subpage
+
+// Short chain with trailing comment (should stay on one line)
+$result = $builder->method($a)->other(); // trailing
+
+// Argument list with intermediate trailing comment
+foo(
+    $first, // after first
+    $second,
+    $third,
+);
+
+// Binary chain with trailing comment in if condition
+if (
+    $condition_a
+    && $condition_b // check b
+    && $condition_c
+    && $condition_d
+) {
+    return true;
+}
+?>
+<div><?php echo $value; /* inline block comment */ ?>text</div>

--- a/crates/formatter/tests/cases/fits_line_suffix/settings.inc
+++ b/crates/formatter/tests/cases/fits_line_suffix/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings::default()

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -257,6 +257,7 @@ test_case!(null_type_hint_null_pipe_last);
 test_case!(comment_placement_binary);
 test_case!(comment_placement_conditional);
 test_case!(comment_placement_conditional_preserve);
+test_case!(fits_line_suffix);
 
 // A special test case for regressions in the Psl codebase
 test_case!(psl_regressions);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes `fits()` to continue width calculation past `LineSuffix` documents instead of aborting, improving formatter idempotency.

## 🔍 Context & Motivation

When `fits()` encountered a `LineSuffix` (trailing comments), it used `break` to exit the measurement loop entirely. Prettier's `fits()` instead sets a flag and continues measuring the remaining content on the line. The early exit made lines with trailing comments appear shorter than they are, causing incorrect flat-mode decisions that produced different output on a second formatting pass.

## 🛠️ Summary of Changes

- `LineSuffix`: changed from `break` (loop exit) to `has_line_suffix = true` (flag and continue).
- `LineSuffixBoundary`: now also checks `has_line_suffix`, and no longer breaks.
- When `has_line_suffix` is set, skip pulling the next printer command (`cmds.next()`). See "Difference from Prettier" below.
- Added `fits_line_suffix` test case covering method chains, argument lists, binary conditions, and inline PHP with `?>` boundary.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Follows #1456, #1465

## 📝 Notes for Reviewers

### Idempotency improvement

Files where a second `mago fmt` changes output. Real-world PHP repos, `threads = 1`, default preset.

| | v1.16.0 | This PR | Delta |
|:--|--:|--:|--:|
| Total failures | 91 | 69 | **-22** |

<details>
<summary>Per-repo breakdown</summary>

| Repo | Files | v1.16.0 | This PR | Delta |
|:--|--:|--:|--:|--:|
| api-platform/core | 2513 | 2 | 2 | 0 |
| briannesbitt/Carbon | 2000 | 1 | 1 | 0 |
| cakephp/cakephp | 1608 | 0 | 0 | 0 |
| composer/composer | 580 | 0 | 0 | 0 |
| doctrine/dbal | 682 | 0 | 0 | 0 |
| doctrine/orm | 1473 | 1 | 1 | 0 |
| drupal/drupal | 10300 | 0 | 0 | 0 |
| FakerPHP/Faker | 666 | 0 | 0 | 0 |
| filamentphp/filament | 5029 | 7 | 6 | **-1** |
| Intervention/image | 534 | 0 | 0 | 0 |
| laravel/framework | 2863 | 0 | 0 | 0 |
| livewire/livewire | 771 | 0 | 0 | 0 |
| moodle/moodle | 49869 | 27 | 22 | **-5** |
| nextcloud/server | 5374 | 2 | 2 | 0 |
| nikic/PHP-Parser | 341 | 0 | 0 | 0 |
| pestphp/pest | 464 | 2 | 0 | **-2** |
| php-standard-library/php-standard-library | 2844 | 0 | 0 | 0 |
| phpstan/phpstan-src | 7034 | 8 | 5 | **-3** |
| predis/predis | 1218 | 0 | 0 | 0 |
| sebastianbergmann/phpunit | 2489 | 2 | 0 | **-2** |
| Seldaek/monolog | 217 | 0 | 0 | 0 |
| slimphp/Slim | 125 | 0 | 0 | 0 |
| spatie/laravel-data | 508 | 1 | 0 | **-1** |
| squizlabs/PHP_CodeSniffer | 613 | 1 | 1 | 0 |
| symfony/symfony | 10365 | 2 | 2 | 0 |
| thephpleague/flysystem | 182 | 1 | 1 | 0 |
| twigphp/Twig | 420 | 0 | 0 | 0 |
| wikimedia/mediawiki | 5497 | 19 | 12 | **-7** |
| WordPress/WordPress | 1884 | 15 | 15 | 0 |
| yiisoft/yii2 | 1046 | 0 | 0 | 0 |

</details>

### Difference from Prettier in cmds handling

Prettier's `fits()` unconditionally pulls from the outer command queue after the stack empties. This PR skips that pull when `has_line_suffix` is set, to handle a PHP-specific case that Prettier does not encounter.

In PHP templates, inline PHP blocks like `<?php echo $x; /* c */ ?>text` have no hard line break before the closing tag. Without the skip, `fits()` measures the HTML content after `?>` as part of the PHP expression's width, causing unnecessary expansion that leads to non-idempotent output. Between normal PHP statements, hard line breaks always intervene, so the skip has no effect there.
