### PR TITLE
feat(linter): Add a fixer for redundant parentheses

### DIFF
--- a/crates/linter/src/rule/redundancy/no_redundant_parentheses.rs
+++ b/crates/linter/src/rule/redundancy/no_redundant_parentheses.rs
@@ -1,4 +1,5 @@
 use indoc::indoc;
+use mago_text_edit::TextEdit;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
@@ -203,6 +204,9 @@ impl LintRule for NoRedundantParenthesesRule {
             )
             .with_help("Remove the redundant inner parentheses.");
 
-        ctx.collector.report(issue);
+        ctx.collector.propose(issue, |edits| {
+            edits.push(TextEdit::delete(parenthesized.left_parenthesis));
+            edits.push(TextEdit::delete(parenthesized.right_parenthesis));
+        });
     }
 }


### PR DESCRIPTION
## 📌 What Does This PR Do?

Add a fixer to remove redundant parentheses, for those of us without the luxurious option to use the mago formatter.

## 🔍 Context & Motivation

Can't use the formatter yet, but still want to use the no-redundant-parentheses rules, and am too lazy to remove them manually.

## 🛠️ Summary of Changes

- **Feature:** Add a fixer for linter rule no-redundant-parentheses.
- **Bug Fix:** Fixed incorrect handling of `readonly` properties in PHP 8.2.
- **Refactor:** Improved `mago_ast` structure.
- **Docs:** Updated installation guide.

## 📂 Affected Areas

- [x] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

none

## 📝 Notes for Reviewers

(((((((((((((((((((((((((did it)))))))))))))))))))))))))))
