### PR TITLE
Speed up line_starts using SIMD-accelerated memchr

### DIFF
--- a/crates/database/src/file.rs
+++ b/crates/database/src/file.rs
@@ -248,8 +248,10 @@ impl std::fmt::Display for FileId {
 /// Returns a vec over the starting byte offsets of each line in `source`.
 #[inline]
 pub(crate) fn line_starts(source: &str) -> Vec<u32> {
-    // Heuristic: Average line of code is ~40 bytes.
-    const LINE_WIDTH_HEURISTIC: usize = 40;
+    // Heuristic: On the test corpus, the mean length is about 30 bytes, the median is 23.
+    // Since the whole vec will be small, we prefer slight over-allocation to avoid re-allocations
+    // in the common case
+    const LINE_WIDTH_HEURISTIC: usize = 20;
 
     let bytes = source.as_bytes();
 


### PR DESCRIPTION
## 📌 What Does This PR Do?

The byte-by-byte scan loop accounts for ~12% of CPU time when loading a large project. The memchr crate (already a dependency) provides AVX2-accelerated searches that cover the same ground in far fewer instructions.

A file uses one line-ending convention throughout, so the style is detected once from the first \r: Unix files (no \r) and Windows files (\r\n) both reduce to a memchr_iter scan for \n; old Mac files (bare \r) use a memchr_iter scan for \r.

## 🔍 Context & Motivation

line_starts() goes brrrrrrrrrrrrrrr

## 🛠️ Summary of Changes

- **Feature:** Improved performance of the code that pre-calculates the line start offsets.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): all the things

## 🔗 Related Issues or PRs

nah

## 📝 Notes for Reviewers

\r\n
