### PR TITLE
perf(database): avoid HashMap rehashing when building the database

### DIFF
--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -230,6 +230,12 @@ impl<'a> Database<'a> {
         db
     }
 
+    /// Reserves capacity for at least `additional` more files.
+    pub fn reserve(&mut self, additional: usize) {
+        self.files.reserve(additional);
+        self.id_to_name.reserve(additional);
+    }
+
     pub fn add(&mut self, file: File) -> FileId {
         let name = file.name.clone();
         let id = file.id;

--- a/crates/database/src/loader.rs
+++ b/crates/database/src/loader.rs
@@ -167,6 +167,8 @@ impl<'a> DatabaseLoader<'a> {
             }
         }
 
+        db.reserve(file_decisions.len() + self.memory_sources.len());
+
         for (file_id, (final_type, _)) in file_decisions {
             if let Some(mut file) = all_files.remove(&file_id) {
                 file.file_type = final_type;


### PR DESCRIPTION
## 📌 What Does This PR Do?

The Database HashMaps grow incrementally as files are added, triggering rehashes. At the point where db.add() is called we already know the exact number of files about to be inserted, so we can reserve capacity upfront.

## 🔍 Context & Motivation

performance

## 🛠️ Summary of Changes

- **Feature:** Avoid unnecessary reallocations while building the file database

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [x] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify): 

## 🔗 Related Issues or PRs

none

## 📝 Notes for Reviewers

This actually has greater impact with higher thread counts. Not sure what to make of that.