### PR TITLE
fix(syntax): avoid quadratic allocation in Node::filter_map

### DIFF
--- a/crates/syntax/src/ast/node.rs
+++ b/crates/syntax/src/ast/node.rs
@@ -704,24 +704,23 @@ impl<'ast, 'arena> Node<'ast, 'arena> {
     where
         F: Fn(&Node<'ast, 'arena>) -> Option<T>,
     {
-        self.filter_map_internal(&f)
+        let mut result = vec![];
+        self.filter_map_internal(&f, &mut result);
+        result
     }
 
     #[inline]
-    fn filter_map_internal<F, T: 'ast>(&self, f: &F) -> Vec<T>
+    fn filter_map_internal<F, T: 'ast>(&self, f: &F, result: &mut Vec<T>)
     where
         F: Fn(&Node<'ast, 'arena>) -> Option<T>,
     {
-        let mut result = vec![];
         for child in self.children() {
-            result.extend(child.filter_map_internal(f));
+            child.filter_map_internal(f, result);
         }
 
-        if let Some(child) = f(self) {
-            result.push(child);
+        if let Some(item) = f(self) {
+            result.push(item);
         }
-
-        result
     }
 
     #[inline]


### PR DESCRIPTION
## 📌 What Does This PR Do?

filter_map_internal creates a new vector at every node, returning it and then extending the parent node' vector with it. This means a bunch of unnecessary allocations, and also O(n²) runtime behaviour due to the repeated copies from the child vectors into their parent vectors.

Passing the result vector down as an accumulator avoids both issues.

## 🔍 Context & Motivation

Making this go brrrrrrrr

## 🛠️ Summary of Changes

- **Bug Fix:** Avoid unnecessary allocations and copies.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [x] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

none

## 📝 Notes for Reviewers

```
Summary
  ~/mago-quad --threads 32 lint --retain-code none ran
    1.05 ± 0.04 times faster than ~/mago-base --threads 32 lint --retain-code none
```