### PR TITLE
fix(prelude): document array shape for `DateTime::getLastErrors()`

### DIFF
--- a/crates/prelude/assets/extensions/date.php
+++ b/crates/prelude/assets/extensions/date.php
@@ -361,7 +361,12 @@ class DateTime implements DateTimeInterface
     public static function createFromTimestamp(int|float $timestamp): static {}
 
     /**
-     * @return array<string, int|array>|false
+     * @return array{
+     *     warning_count: non-negative-int,
+     *     warnings: array<non-negative-int, non-empty-string>,
+     *     error_count: non-negative-int,
+     *     errors: array<non-negative-int, non-empty-string>,
+     * }|false
      */
     public static function getLastErrors(): array|false {}
 
@@ -422,7 +427,12 @@ class DateTimeImmutable implements DateTimeInterface
     public static function createFromTimestamp(int|float $timestamp): static {}
 
     /**
-     * @return array<string, int|array>|false
+     * @return array{
+     *     warning_count: non-negative-int,
+     *     warnings: array<non-negative-int, non-empty-string>,
+     *     error_count: non-negative-int,
+     *     errors: array<non-negative-int, non-empty-string>,
+     * }|false
      */
     public static function getLastErrors(): array|false {}
 


### PR DESCRIPTION
## 📌 What Does This PR Do?

Adds the array shape for `DateTime::getLastErrors()` and `DateTimeImmutable::getLastErrors()`

## 🔍 Context & Motivation

Updating the stub silences analysis errors in user code bases

## 🛠️ Summary of Changes

Adds the array shape for `DateTime::getLastErrors()` and `DateTimeImmutable::getLastErrors()`

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): analyser

## 🔗 Related Issues or PRs

None

## 📝 Notes for Reviewers

This is my first time here! Please advise whether help is wanted fixing up stubs 👍