### PR TITLE
feat(linter): Add disallowed-type-instantiation rule

### DIFF
--- a/crates/linter/src/rule/mod.rs
+++ b/crates/linter/src/rule/mod.rs
@@ -193,6 +193,7 @@ define_rules! {
     ConstantName(constant_name @ ConstantNameRule),
     CyclomaticComplexity(cyclomatic_complexity @ CyclomaticComplexityRule),
     DisallowedFunctions(disallowed_functions @ DisallowedFunctionsRule),
+    DisallowedTypeInstantiation(disallowed_type_instantiation @ DisallowedTypeInstantiationRule),
     EnumName(enum_name @ EnumNameRule),
     ExcessiveNesting(excessive_nesting @ ExcessiveNestingRule),
     ExcessiveParameterList(excessive_parameter_list @ ExcessiveParameterListRule),

--- a/crates/linter/src/rule/security/disallowed_type_instantiation.rs
+++ b/crates/linter/src/rule/security/disallowed_type_instantiation.rs
@@ -1,0 +1,371 @@
+use indoc::indoc;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+
+use mago_reporting::Annotation;
+use mago_reporting::Issue;
+use mago_reporting::Level;
+use mago_span::HasSpan;
+use mago_syntax::ast::Expression;
+use mago_syntax::ast::Node;
+use mago_syntax::ast::NodeKind;
+
+use crate::category::Category;
+use crate::context::LintContext;
+use crate::requirements::RuleRequirements;
+use crate::rule::Config;
+use crate::rule::LintRule;
+use crate::rule_meta::RuleMeta;
+use crate::settings::RuleSettings;
+
+#[derive(Debug, Clone)]
+pub struct DisallowedTypeInstantiationRule {
+    meta: &'static RuleMeta,
+    cfg: DisallowedTypeInstantiationConfig,
+}
+
+/// An entry that can be either a simple string or an object with name and optional help.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum DisallowedTypeEntry {
+    /// Simple string entry (just the name).
+    Simple(String),
+    /// Entry with name and optional help message.
+    WithHelp {
+        name: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        help: Option<String>,
+    },
+}
+
+impl DisallowedTypeEntry {
+    /// Returns the name of the disallowed type.
+    pub fn name(&self) -> &str {
+        match self {
+            DisallowedTypeEntry::Simple(name) => name,
+            DisallowedTypeEntry::WithHelp { name, .. } => name,
+        }
+    }
+
+    /// Returns the custom help message, if any.
+    pub fn help(&self) -> Option<&str> {
+        match self {
+            DisallowedTypeEntry::Simple(_) => None,
+            DisallowedTypeEntry::WithHelp { help, .. } => help.as_deref(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct DisallowedTypeInstantiationConfig {
+    pub level: Level,
+    #[serde(default)]
+    pub types: Vec<DisallowedTypeEntry>,
+}
+
+impl Default for DisallowedTypeInstantiationConfig {
+    fn default() -> Self {
+        Self { level: Level::Warning, types: Vec::new() }
+    }
+}
+
+impl Config for DisallowedTypeInstantiationConfig {
+    fn level(&self) -> Level {
+        self.level
+    }
+
+    fn default_enabled() -> bool {
+        false
+    }
+}
+
+impl LintRule for DisallowedTypeInstantiationRule {
+    type Config = DisallowedTypeInstantiationConfig;
+
+    fn meta() -> &'static RuleMeta {
+        const META: RuleMeta = RuleMeta {
+            name: "Disallowed Type Instantiation",
+            code: "disallowed-type-instantiation",
+            description: indoc! {r"
+                Flags direct instantiation of specific types that are disallowed via rule configuration.
+
+                This rule helps enforce architectural patterns such as factory methods or provider patterns
+                by preventing direct instantiation of specific classes. This is useful for ensuring consistent
+                configuration, centralizing object creation, and maintaining architectural boundaries.
+
+                Each entry can be a simple string or an object with `name` and optional `help`:
+
+                ```toml
+                [linter.rules]
+                disallowed-type-instantiation = {
+                    enabled = true,
+                    types = [
+                        'HttpService\\Client',
+                        { name = 'DatabaseConnection', help = 'Use DatabaseFactory::create() instead' },
+                    ]
+                }
+                ```
+            "},
+            good_example: indoc! {r"
+                <?php
+
+                // Using factory pattern instead of direct instantiation
+                $client = ClientProvider::getClient();
+            "},
+            bad_example: indoc! {r"
+                <?php
+
+                // Direct instantiation of disallowed type
+                $client = new HttpService\Client();
+
+                // Another disallowed instantiation
+                $db = new DatabaseConnection('localhost', 'user', 'pass');
+            "},
+            category: Category::Security,
+            requirements: RuleRequirements::None,
+        };
+
+        &META
+    }
+
+    fn targets() -> &'static [NodeKind] {
+        const TARGETS: &[NodeKind] = &[NodeKind::Instantiation];
+        TARGETS
+    }
+
+    fn build(settings: &RuleSettings<Self::Config>) -> Self {
+        Self { meta: Self::meta(), cfg: settings.config.clone() }
+    }
+
+    fn check<'arena>(&self, ctx: &mut LintContext<'_, 'arena>, node: Node<'_, 'arena>) {
+        let Node::Instantiation(instantiation) = node else {
+            return;
+        };
+
+        let Expression::Identifier(identifier) = instantiation.class else {
+            return;
+        };
+
+        let class_name = ctx.lookup_name(identifier);
+
+        for entry in &self.cfg.types {
+            let disallowed_type = entry.name();
+            if !class_name.eq_ignore_ascii_case(disallowed_type) {
+                continue;
+            }
+
+            let help_text = entry.help().unwrap_or(
+                "Use an alternative factory or provider pattern, or update your configuration if this restriction is no longer needed.",
+            );
+
+            let issue = Issue::new(
+                self.cfg.level,
+                format!("Direct instantiation of type `{disallowed_type}` is disallowed."),
+            )
+            .with_code(self.meta.code)
+            .with_annotation(
+                Annotation::primary(instantiation.span())
+                    .with_message(format!("direct instantiation of disallowed type `{disallowed_type}`")),
+            )
+            .with_note(format!(
+                "The type `{disallowed_type}` is explicitly disallowed from being instantiated directly by your project configuration."
+            ))
+            .with_help(help_text);
+
+            ctx.collector.report(issue);
+
+            return;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+
+    use super::*;
+    use crate::test_lint_failure;
+    use crate::test_lint_success;
+
+    test_lint_success! {
+        name = allowed_types_not_flagged,
+        rule = DisallowedTypeInstantiationRule,
+        code = indoc! {r"
+            <?php
+
+            $dateTime = new DateTime();
+            $stdClass = new stdClass();
+            $exception = new Exception('error');
+        "}
+    }
+
+    test_lint_success! {
+        name = different_class_same_short_name,
+        rule = DisallowedTypeInstantiationRule,
+        settings = |s: &mut crate::settings::Settings| {
+            s.rules.disallowed_type_instantiation.config.types = vec![
+                DisallowedTypeEntry::Simple("HttpService\\Client".to_string()),
+            ];
+        },
+        code = indoc! {r"
+            <?php
+
+            namespace App;
+
+            class Client {}
+
+            // This should NOT be flagged (different class than HttpService\Client)
+            $myClient = new Client();
+        "}
+    }
+
+    test_lint_failure! {
+        name = disallow_type_simple_string,
+        rule = DisallowedTypeInstantiationRule,
+        settings = |s: &mut crate::settings::Settings| {
+            s.rules.disallowed_type_instantiation.config.types = vec![
+                DisallowedTypeEntry::Simple("HttpService\\Client".to_string()),
+            ];
+        },
+        code = indoc! {r"
+            <?php
+
+            use HttpService\Client;
+
+            $client = new Client();
+        "}
+    }
+
+    test_lint_failure! {
+        name = disallow_type_with_help,
+        rule = DisallowedTypeInstantiationRule,
+        settings = |s: &mut crate::settings::Settings| {
+            s.rules.disallowed_type_instantiation.config.types = vec![
+                DisallowedTypeEntry::WithHelp {
+                    name: "HttpService\\Client".to_string(),
+                    help: Some("Use ClientProvider::getClient() instead".to_string()),
+                },
+            ];
+        },
+        code = indoc! {r"
+            <?php
+
+            use HttpService\Client;
+
+            $client = new Client();
+        "}
+    }
+
+    test_lint_failure! {
+        name = disallow_fully_qualified_name,
+        rule = DisallowedTypeInstantiationRule,
+        settings = |s: &mut crate::settings::Settings| {
+            s.rules.disallowed_type_instantiation.config.types = vec![
+                DisallowedTypeEntry::Simple("HttpService\\Client".to_string()),
+            ];
+        },
+        code = indoc! {r"
+            <?php
+
+            $client = new \HttpService\Client();
+        "}
+    }
+
+    test_lint_failure! {
+        name = case_insensitive_matching,
+        rule = DisallowedTypeInstantiationRule,
+        count = 3,
+        settings = |s: &mut crate::settings::Settings| {
+            s.rules.disallowed_type_instantiation.config.types = vec![
+                DisallowedTypeEntry::Simple("HttpService\\Client".to_string()),
+            ];
+        },
+        code = indoc! {r"
+            <?php
+
+            use HttpService\Client;
+
+            $a = new Client();
+            $b = new client();
+            $c = new CLIENT();
+        "}
+    }
+
+    test_lint_failure! {
+        name = multiple_disallowed_types,
+        rule = DisallowedTypeInstantiationRule,
+        count = 2,
+        settings = |s: &mut crate::settings::Settings| {
+            s.rules.disallowed_type_instantiation.config.types = vec![
+                DisallowedTypeEntry::Simple("HttpService\\Client".to_string()),
+                DisallowedTypeEntry::WithHelp {
+                    name: "DatabaseConnection".to_string(),
+                    help: Some("Use DatabaseFactory::create() instead".to_string()),
+                },
+            ];
+        },
+        code = indoc! {r"
+            <?php
+
+            use HttpService\Client;
+
+            $client = new Client();
+            $db = new \DatabaseConnection('localhost', 'user', 'pass');
+        "}
+    }
+
+    test_lint_failure! {
+        name = disallow_in_namespace_context,
+        rule = DisallowedTypeInstantiationRule,
+        settings = |s: &mut crate::settings::Settings| {
+            s.rules.disallowed_type_instantiation.config.types = vec![
+                DisallowedTypeEntry::Simple("HttpService\\Client".to_string()),
+            ];
+        },
+        code = indoc! {r"
+            <?php
+
+            namespace App\Services;
+
+            use HttpService\Client;
+
+            class MyService {
+                public function create() {
+                    return new Client();
+                }
+            }
+        "}
+    }
+
+    test_lint_failure! {
+        name = disallow_with_constructor_arguments,
+        rule = DisallowedTypeInstantiationRule,
+        settings = |s: &mut crate::settings::Settings| {
+            s.rules.disallowed_type_instantiation.config.types = vec![
+                DisallowedTypeEntry::Simple("DatabaseConnection".to_string()),
+            ];
+        },
+        code = indoc! {r"
+            <?php
+
+            $db = new \DatabaseConnection('localhost', 'user', 'password');
+        "}
+    }
+
+    test_lint_failure! {
+        name = disallow_without_parentheses,
+        rule = DisallowedTypeInstantiationRule,
+        settings = |s: &mut crate::settings::Settings| {
+            s.rules.disallowed_type_instantiation.config.types = vec![
+                DisallowedTypeEntry::Simple("stdClass".to_string()),
+            ];
+        },
+        code = indoc! {r"
+            <?php
+
+            $obj = new stdClass;
+        "}
+    }
+}

--- a/crates/linter/src/rule/security/mod.rs
+++ b/crates/linter/src/rule/security/mod.rs
@@ -1,4 +1,5 @@
 pub mod disallowed_functions;
+pub mod disallowed_type_instantiation;
 pub mod no_db_schema_change;
 pub mod no_debug_symbols;
 pub mod no_insecure_comparison;
@@ -11,6 +12,7 @@ pub mod sensitive_parameter;
 pub mod tainted_data_to_sink;
 
 pub use disallowed_functions::*;
+pub use disallowed_type_instantiation::*;
 pub use no_db_schema_change::*;
 pub use no_debug_symbols::*;
 pub use no_insecure_comparison::*;

--- a/crates/linter/src/settings.rs
+++ b/crates/linter/src/settings.rs
@@ -24,6 +24,7 @@ use crate::rule::DeprecatedCastConfig;
 use crate::rule::DeprecatedShellExecuteStringConfig;
 use crate::rule::DeprecatedSwitchSemicolonConfig;
 use crate::rule::DisallowedFunctionsConfig;
+use crate::rule::DisallowedTypeInstantiationConfig;
 use crate::rule::EnumNameConfig;
 use crate::rule::ExcessiveNestingConfig;
 use crate::rule::ExcessiveParameterListConfig;
@@ -213,6 +214,7 @@ pub struct RulesSettings {
     pub constant_name: RuleSettings<ConstantNameConfig>,
     pub cyclomatic_complexity: RuleSettings<CyclomaticComplexityConfig>,
     pub disallowed_functions: RuleSettings<DisallowedFunctionsConfig>,
+    pub disallowed_type_instantiation: RuleSettings<DisallowedTypeInstantiationConfig>,
     pub enum_name: RuleSettings<EnumNameConfig>,
     pub excessive_nesting: RuleSettings<ExcessiveNestingConfig>,
     pub excessive_parameter_list: RuleSettings<ExcessiveParameterListConfig>,

--- a/crates/linter/tests/rule_examples.rs
+++ b/crates/linter/tests/rule_examples.rs
@@ -8,6 +8,8 @@ use mago_linter::integration::IntegrationSet;
 use mago_linter::registry::RuleRegistry;
 use mago_linter::rule::DisallowedEntry;
 use mago_linter::rule::DisallowedFunctionsConfig;
+use mago_linter::rule::DisallowedTypeEntry;
+use mago_linter::rule::DisallowedTypeInstantiationConfig;
 use mago_linter::settings::RuleSettings;
 use mago_linter::settings::RulesSettings;
 use mago_linter::settings::Settings;
@@ -60,6 +62,16 @@ fn test_code_snippet(rule_code: &str, code: &str, should_have_issues: bool) -> R
             disallowed_functions: RuleSettings {
                 config: DisallowedFunctionsConfig {
                     extensions: vec![DisallowedEntry::Simple("curl".to_string())],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            disallowed_type_instantiation: RuleSettings {
+                config: DisallowedTypeInstantiationConfig {
+                    types: vec![
+                        DisallowedTypeEntry::Simple("HttpService\\Client".to_string()),
+                        DisallowedTypeEntry::Simple("DatabaseConnection".to_string()),
+                    ],
                     ..Default::default()
                 },
                 ..Default::default()

--- a/docs/tools/linter/rules/security.md
+++ b/docs/tools/linter/rules/security.md
@@ -10,6 +10,7 @@ This document details the rules available in the `Security` category.
 | Rule | Code |
 | :--- | :---------- |
 | Disallowed Functions | [`disallowed-functions`](#disallowed-functions) |
+| Disallowed Type Instantiation | [`disallowed-type-instantiation`](#disallowed-type-instantiation) |
 | No Database Schema Changes | [`no-db-schema-change`](#no-db-schema-change) |
 | No Debug Symbols | [`no-debug-symbols`](#no-debug-symbols) |
 | No Insecure Comparison | [`no-insecure-comparison`](#no-insecure-comparison) |
@@ -70,6 +71,61 @@ allowed_function(); // Not flagged
 <?php
 
 curl_init(); // Error: part of a disallowed extension
+```
+
+
+## <a id="disallowed-type-instantiation"></a>`disallowed-type-instantiation`
+
+Flags direct instantiation of specific types that are disallowed via rule configuration.
+
+This rule helps enforce architectural patterns such as factory methods or provider patterns
+by preventing direct instantiation of specific classes. This is useful for ensuring consistent
+configuration, centralizing object creation, and maintaining architectural boundaries.
+
+Each entry can be a simple string or an object with `name` and optional `help`:
+
+```toml
+[linter.rules]
+disallowed-type-instantiation = {
+    enabled = true,
+    types = [
+        'HttpService\\Client',
+        { name = 'DatabaseConnection', help = 'Use DatabaseFactory::create() instead' },
+    ]
+}
+```
+
+
+
+### Configuration
+
+| Option | Type | Default |
+| :--- | :--- | :--- |
+| `enabled` | `boolean` | `false` |
+| `level` | `string` | `"warning"` |
+| `types` | `array` | `[]` |
+
+### Examples
+
+#### Correct code
+
+```php
+<?php
+
+// Using factory pattern instead of direct instantiation
+$client = ClientProvider::getClient();
+```
+
+#### Incorrect code
+
+```php
+<?php
+
+// Direct instantiation of disallowed type
+$client = new HttpService\Client();
+
+// Another disallowed instantiation
+$db = new DatabaseConnection('localhost', 'user', 'pass');
 ```
 
 


### PR DESCRIPTION
Create a config to let people lint the usage of class constructors.

## 📌 What Does This PR Do?

Add the ability to lint for the usage of constructors.

## 🔍 Context & Motivation

Our team wants to prevent direct usage of some class constructors as we have specific providers to make the standard version.
Our first one we want to do this way is creating Guzzle clients, we have a provider that sets sane defaults like User Agent and timeouts.

## 🛠️ Summary of Changes

- **Feature:** Added `disallowed-type-instantiation ` lint rule.

## 📂 Affected Areas

- [X] Linter

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
