### PR TITLE
feat(formatter): allow `--staged` to be used with unstaged changes

### DIFF
--- a/docs/recipes/pre-commit-hooks.md
+++ b/docs/recipes/pre-commit-hooks.md
@@ -56,10 +56,6 @@ The `--staged` flag on all three commands:
 - For `fmt --staged`, automatically re-stages formatted files
 - For `lint --staged` and `analyze --staged`, when combined with `--fix`, automatically re-stages fixed files
 
-:::warning
-The `fmt --staged` flag will fail if a staged file also has unstaged changes. This prevents accidentally including unintended changes in your commit. Either stage all changes or stash the unstaged ones before committing.
-:::
-
 ### Option 2: Auto-fix and auto-format staged files
 
 This approach automatically fixes linting issues in staged files, then formats them. Fixed and formatted files are re-staged automatically.
@@ -190,9 +186,9 @@ Or if you prefer the check-only approach:
 
 ## Comparison: `--staged` vs `--check`
 
-| Aspect               | `--staged`                                         | `--check`                                     |
-| -------------------- | -------------------------------------------------- | --------------------------------------------- |
-| **Behavior**         | Auto-formats staged files and re-stages them       | Checks if files are formatted, fails if not   |
-| **Developer action** | None required                                      | Must run `mago fmt` manually if check fails   |
-| **Best for**         | Teams that want seamless formatting                | Teams that want explicit control over changes |
-| **Partial staging**  | Fails if file has both staged and unstaged changes | Works regardless of staging state             |
+| Aspect               | `--staged`                                        | `--check`                                     |
+| -------------------- | ------------------------------------------------- | --------------------------------------------- |
+| **Behavior**         | Auto-formats staged files and re-stages them      | Checks if files are formatted, fails if not   |
+| **Developer action** | None required                                     | Must run `mago fmt` manually if check fails   |
+| **Best for**         | Teams that want seamless formatting               | Teams that want explicit control over changes |
+| **Partial staging**  | Formats the staged files, skips the working tree  | Works regardless of staging state             |

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -58,6 +58,8 @@ use crate::error::Error;
 use crate::utils;
 use crate::utils::create_orchestrator;
 use crate::utils::git;
+use crate::utils::git::get_staged_file;
+use crate::utils::git::update_staged_file;
 
 /// Command for formatting PHP source files according to style rules.
 ///
@@ -110,12 +112,11 @@ pub struct FormatCommand {
     ///
     /// This flag is designed for git pre-commit hooks. It will:
     /// 1. Find all PHP files currently staged for commit
-    /// 2. Format those files
-    /// 3. Re-stage them so the formatted version is committed
+    /// 2. Format those staged files in memory
+    /// 3. Update the staged files so the formatted version is committed
     ///
     /// Fails if:
     /// - Not in a git repository
-    /// - A staged file has unstaged changes (would cause data loss)
     #[arg(long, short = 's', conflicts_with_all = ["dry_run", "check", "stdin_input", "path"])]
     pub staged: bool,
 }
@@ -245,9 +246,8 @@ impl FormatCommand {
     ///
     /// 1. Verifies we're in a git repository
     /// 2. Gets the list of staged PHP files
-    /// 3. Checks that no staged files have unstaged changes
-    /// 4. Formats the staged files
-    /// 5. Re-stages the formatted files
+    /// 3. Formats the staged files in memory
+    /// 4. Updates the staged file with its formatted version
     ///
     /// # Arguments
     ///
@@ -258,42 +258,46 @@ impl FormatCommand {
     ///
     /// - `Ok(ExitCode::SUCCESS)` if formatting succeeded
     /// - `Err(Error::NotAGitRepository)` if not in a git repository
-    /// - `Err(Error::StagedFileHasUnstagedChanges)` if a file has partial staging
     fn execute_staged(self, configuration: Configuration, color_choice: ColorChoice) -> Result<ExitCode, Error> {
         let workspace = &configuration.source.workspace;
 
         let mut orchestrator = create_orchestrator(&configuration, color_choice, false, true, false);
         orchestrator.add_exclude_patterns(configuration.formatter.excludes.iter());
 
-        let mut database = orchestrator.load_database(workspace, false, None, None)?;
+        let database = orchestrator.load_database(workspace, false, None, None)?;
 
-        // Get staged files that are clean (no unstaged changes), resolved to file IDs
-        let staged_file_ids = git::get_staged_clean_files(workspace, &database)?;
-        if staged_file_ids.is_empty() {
+        // Get staged files resolved to file IDs
+        let staged_file_paths = git::get_staged_file_paths(workspace)?;
+        if staged_file_paths.is_empty() {
             tracing::info!("No staged files to format.");
             return Ok(ExitCode::SUCCESS);
         }
 
-        let service = orchestrator.get_format_service(database.read_only());
-        let result = service.run_on_files(staged_file_ids)?;
+        let mut changed_files_count = 0;
+        for path in staged_file_paths {
+            let absolute_path = workspace.join(&path);
+            let canonical_path = absolute_path.canonicalize().unwrap_or(absolute_path);
 
-        for (file_id, parse_error) in result.parse_errors() {
-            let file = database.get_ref(file_id)?;
-            tracing::error!("Failed to parse file '{}': {parse_error}", file.name);
+            if database.get_by_path(&canonical_path).is_err() {
+                continue;
+            }
+            let staged_file = get_staged_file(workspace, &path)?;
+            match orchestrator.format_file(&staged_file)? {
+                FileFormatStatus::Unchanged => continue,
+                FileFormatStatus::Changed(new_content) => {
+                    update_staged_file(workspace, &path, new_content)?;
+                    changed_files_count += 1;
+                }
+                FileFormatStatus::FailedToParse(parse_error) => {
+                    tracing::error!("Failed to parse staged file '{}': {}", path.display(), parse_error);
+                }
+            };
         }
-
-        let changed_files_count = result.changed_files_count();
 
         if changed_files_count == 0 {
             tracing::info!("All staged files are already formatted.");
             return Ok(ExitCode::SUCCESS);
         }
-
-        let change_log = to_change_log(&database, &result, false, color_choice)?;
-        let changed_file_ids = change_log.changed_file_ids()?;
-        database.commit(change_log, true)?;
-
-        git::stage_files(workspace, &database, changed_file_ids)?;
 
         tracing::info!("Formatted and re-staged {changed_files_count} file(s).");
 

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -4,14 +4,19 @@
 //! specifically for the `--staged` formatting feature that allows formatting
 //! staged files in pre-commit hooks.
 
+use std::borrow::Cow;
 use std::collections::HashSet;
+use std::ffi::OsString;
+use std::io::Write as _;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
+use std::process::Stdio;
 
 use mago_database::Database;
 use mago_database::DatabaseReader;
 use mago_database::error::DatabaseError;
+use mago_database::file::File;
 use mago_database::file::FileId;
 
 use crate::error::Error;
@@ -37,61 +42,56 @@ pub fn get_staged_file_paths(workspace: &Path) -> Result<Vec<PathBuf>, Error> {
     get_staged_files(workspace)
 }
 
-/// Get staged files that are clean (no unstaged changes) as file IDs.
-///
-/// This function combines multiple git operations and database lookups into
-/// a single convenient function for the `--staged` formatting feature:
-///
-/// 1. Checks if we're in a git repository
-/// 2. Gets all staged files
-/// 3. Gets files with unstaged changes
-/// 4. For each staged file, checks it doesn't have unstaged changes
-/// 5. Resolves each staged file path to a database FileId
+/// Creates an ephemeral file with the contents of a staged file
 ///
 /// # Arguments
 ///
 /// * `workspace` - The git repository root directory
-/// * `database` - The loaded database to look up file IDs
+/// * `path` - The path for which to get the file
 ///
 /// # Returns
 ///
-/// A vector of FileIds for staged files that have no unstaged changes,
-/// or an error if:
-/// - Not in a git repository
-/// - A staged file has unstaged changes (partial staging)
+/// An ephemeral file with the contents of the staged file
+pub fn get_staged_file(workspace: &Path, path: &Path) -> Result<File, Error> {
+    let mut index_path = OsString::from(":");
+    index_path.push(path);
+
+    let output = Command::new("git")
+        .args(["cat-file", "-p"])
+        .arg(index_path)
+        .current_dir(workspace)
+        .output()
+        .map_err(|e| Error::Database(DatabaseError::IOError(e)))?;
+
+    Ok(File::ephemeral(Cow::Borrowed("<stdin>"), Cow::Owned(String::from_utf8_lossy(&output.stdout).into_owned())))
+}
+
+/// Updates the contents of the staged file
 ///
-/// # Errors
+/// # Arguments
 ///
-/// Returns `Error::NotAGitRepository` if not in a git repository.
-/// Returns `Error::StagedFileHasUnstagedChanges` if any staged file
-/// has unstaged modifications (which would cause data loss).
-pub fn get_staged_clean_files(workspace: &Path, database: &Database) -> Result<Vec<FileId>, Error> {
-    if !is_git_repository(workspace) {
-        return Err(Error::NotAGitRepository);
-    }
+/// * `workspace` - The git repository root directory
+/// * `path` - The path for which to get the file
+/// * `new_content` - The new content for the staged file
+pub fn update_staged_file(workspace: &Path, path: &Path, new_content: String) -> Result<(), Error> {
+    let blob_id = create_blob(workspace, path, new_content)?;
+    let mode = get_mode(workspace, path)?;
 
-    let staged_files = get_staged_files(workspace)?;
-    if staged_files.is_empty() {
-        return Ok(Vec::new());
-    }
+    let mut cacheinfo = OsString::new();
+    cacheinfo.push(&mode);
+    cacheinfo.push(",");
+    cacheinfo.push(&blob_id);
+    cacheinfo.push(",");
+    cacheinfo.push(path.as_os_str());
 
-    let files_with_unstaged = get_files_with_unstaged_changes(workspace)?;
+    Command::new("git")
+        .args(["update-index", "--cacheinfo"])
+        .arg(cacheinfo)
+        .current_dir(workspace)
+        .status()
+        .map_err(|e| Error::Database(DatabaseError::IOError(e)))?;
 
-    let mut file_ids = Vec::with_capacity(staged_files.len());
-    for staged_file in staged_files {
-        if files_with_unstaged.contains(&staged_file) {
-            return Err(Error::StagedFileHasUnstagedChanges(staged_file.display().to_string()));
-        }
-
-        let absolute_path = workspace.join(&staged_file);
-        let canonical_path = absolute_path.canonicalize().unwrap_or(absolute_path);
-
-        if let Ok(file) = database.get_by_path(&canonical_path) {
-            file_ids.push(file.id);
-        }
-    }
-
-    Ok(file_ids)
+    Ok(())
 }
 
 /// Verify that none of the given staged files have unstaged changes.
@@ -231,4 +231,56 @@ fn get_files_with_unstaged_changes(workspace: &Path) -> Result<HashSet<PathBuf>,
         .map_err(|e| Error::Database(DatabaseError::IOError(e)))?;
 
     Ok(String::from_utf8_lossy(&output.stdout).lines().filter(|l| !l.is_empty()).map(PathBuf::from).collect())
+}
+
+/// Creates a new blob in the git object store for the given contents
+///
+/// # Arguments
+///
+/// * `workspace` - The git repository root directory
+/// * `path` - The path of the file for which the contents are meant, used to apply git filters
+/// * `content` - The contents for the blob object
+///
+/// # Returns
+///
+/// A string containing the id of the newly created blob
+fn create_blob(workspace: &Path, path: &Path, content: String) -> Result<String, Error> {
+    let mut child = Command::new("git")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .args(["hash-object", "-w", "--stdin", "--path"])
+        .arg(path)
+        .current_dir(workspace)
+        .spawn()
+        .map_err(|e| Error::Database(DatabaseError::IOError(e)))?;
+
+    let mut stdin = child.stdin.take().expect("failed to get stdin");
+    std::thread::spawn(move || {
+        stdin.write_all(content.as_bytes()).expect("failed to write to stdin");
+    });
+
+    let output = child.wait_with_output().map_err(|e| Error::Database(DatabaseError::IOError(e)))?;
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_owned())
+}
+
+/// Gets the object mode for the given path in the git index
+///
+/// # Arguments
+///
+/// * `workspace` - The git repository root directory
+/// * `path` - The path for which the object mode is requested
+///
+/// # Returns
+///
+/// A string containing the object mode for the path
+fn get_mode(workspace: &Path, path: &Path) -> Result<String, Error> {
+    let output = Command::new("git")
+        .args(["ls-files", "--format=%(objectmode)"])
+        .arg(path)
+        .current_dir(workspace)
+        .output()
+        .map_err(|e| Error::Database(DatabaseError::IOError(e)))?;
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_owned())
 }


### PR DESCRIPTION
## 📌 What Does This PR Do?

Currently, `mago fmt --staged` aborts when there are unstaged changes to any file with staged changes, because the formatting is performed in the working tree. We can improve on that by creating ephemeral files from the staged contents, which we can then format in the same way that --stdin does. Finally we can then use git plumbing to update the staged file in place without touching the working tree at all.

## 🔍 Context & Motivation

Not being able to have unstaged changes around makes the --staged mode unusable it a lot of workflows.

## 🛠️ Summary of Changes

- **Feature:** Added support for runnning `mago fmt --staged` with unstaged changes in the working tree.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

nah

## 📝 Notes for Reviewers

:gift: 
