### PR TITLE
fix(analyzer): report `mixed-operand` for unary operators

### DIFF
--- a/crates/analyzer/src/expression/unary.rs
+++ b/crates/analyzer/src/expression/unary.rs
@@ -215,11 +215,20 @@ impl<'ast, 'arena> Analyzable<'ast, 'arena> for UnaryPrefix<'arena> {
                             invalid_operand_messages.push(("Cannot negate `resource`".to_string(), operand_span));
                         }
                         TAtomic::Mixed(_) => {
-                            // Could be anything - possibly invalid
-                            invalid_operand_messages.push((
-                                "Cannot reliably negate `mixed`; it may contain non-numeric types".to_string(),
-                                operand_span,
-                            ));
+                            context.collector.report_with_code(
+                                IssueCode::MixedOperand,
+                                Issue::error("Cannot reliably negate a `mixed` operand.")
+                                    .with_annotation(
+                                        Annotation::primary(operand_span)
+                                            .with_message("Operand is `mixed`."),
+                                    )
+                                    .with_note(
+                                        "Negating `mixed` is unsafe as the actual runtime type is unknown.",
+                                    )
+                                    .with_help(
+                                        "Ensure the operand has a known type (e.g., `int`, `float`) using type hints, assertions, or checks.",
+                                    ),
+                            );
                             resulting_types.push(TAtomic::Scalar(TScalar::int()));
                             resulting_types.push(TAtomic::Scalar(TScalar::float()));
                         }
@@ -608,6 +617,23 @@ fn increment_operand<'ctx, 'arena>(
             TAtomic::Never => {
                 // never type is unreachable, don't produce mixed, just skip.
             }
+            TAtomic::Mixed(_) => {
+                context.collector.report_with_code(
+                    IssueCode::MixedOperand,
+                    Issue::error("Cannot reliably increment a `mixed` operand.")
+                        .with_annotation(
+                            Annotation::primary(operand.span()).with_message("Operand is `mixed`."),
+                        )
+                        .with_note(
+                            "Incrementing `mixed` is unsafe as the actual runtime type is unknown.",
+                        )
+                        .with_help(
+                            "Ensure the operand has a known type (e.g., `int`, `float`, `string`) using type hints, assertions, or checks.",
+                        ),
+                );
+
+                possibilities.push(TAtomic::Mixed(TMixed::new()));
+            }
             _ => {
                 let type_name = operand_atomic_type.get_id();
                 context.collector.report_with_code(
@@ -841,6 +867,23 @@ fn decrement_operand<'ctx, 'arena>(
             }
             TAtomic::Never => {
                 // never type is unreachable, don't produce mixed, just skip.
+            }
+            TAtomic::Mixed(_) => {
+                context.collector.report_with_code(
+                    IssueCode::MixedOperand,
+                    Issue::error("Cannot reliably decrement a `mixed` operand.")
+                        .with_annotation(
+                            Annotation::primary(operand.span()).with_message("Operand is `mixed`."),
+                        )
+                        .with_note(
+                            "Decrementing `mixed` is unsafe as the actual runtime type is unknown.",
+                        )
+                        .with_help(
+                            "Ensure the operand has a known type (e.g., `int`, `float`, `string`) using type hints, assertions, or checks.",
+                        ),
+                );
+
+                possibilities.push(TAtomic::Mixed(TMixed::new()));
             }
             _ => {
                 let type_name = operand_atomic_type.get_id();

--- a/crates/analyzer/tests/cases/mixed_operand_increment.php
+++ b/crates/analyzer/tests/cases/mixed_operand_increment.php
@@ -1,0 +1,21 @@
+<?php
+
+function test_mixed_increment(mixed $n): void {
+    // @mago-expect analysis:mixed-operand
+    // @mago-expect analysis:mixed-assignment
+    $n++;
+
+    // @mago-expect analysis:mixed-operand
+    // @mago-expect analysis:mixed-assignment
+    ++$n;
+}
+
+function test_mixed_decrement(mixed $n): void {
+    // @mago-expect analysis:mixed-operand
+    // @mago-expect analysis:mixed-assignment
+    $n--;
+
+    // @mago-expect analysis:mixed-operand
+    // @mago-expect analysis:mixed-assignment
+    --$n;
+}

--- a/crates/analyzer/tests/cases/negation_operand.php
+++ b/crates/analyzer/tests/cases/negation_operand.php
@@ -33,7 +33,7 @@ function test_general_string(string $s): int|float {
     return -$s; // possibly invalid - could be numeric at runtime
 }
 
-// @mago-expect analysis:possibly-invalid-operand
+// @mago-expect analysis:mixed-operand
 function test_mixed(mixed $m): int|float {
-    return -$m; // possibly invalid - mixed could be anything
+    return -$m; // mixed - type is unknown at compile time
 }

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -172,6 +172,7 @@ test_case!(properties_of_visibility);
 test_case!(assert_or_type);
 test_case!(impossible_assertion);
 test_case!(negation_operand);
+test_case!(mixed_operand_increment);
 test_case!(infere_closure_parameter_type);
 test_case!(negated_union_type);
 test_case!(reference_constraint_violation);


### PR DESCRIPTION
## 📌 What Does This PR Do?

This fixes issues reported for unary operators `++`, `--`, and `-` so that they're consistently `mixed-operand` rather than `invalid-operand` or `possibly-invalid-operand`.

## 🔍 Context & Motivation

closes #1635 

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed issue type reported for unary operators on mixed operands to `mixed-operand`.

## 📂 Affected Areas

- [x] Analyzer
- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

#1635 

## 📝 Notes for Reviewers

Claude Code was used to help author this change, but I've reviewed it and have a thorough understanding of how it works.