### PR TITLE
fix(codex): class-string is not contained by known string literals

### DIFF
--- a/crates/analyzer/tests/cases/conditional_return_class_string_not_literal.php
+++ b/crates/analyzer/tests/cases/conditional_return_class_string_not_literal.php
@@ -1,0 +1,32 @@
+<?php
+
+class A {}
+
+/**
+ * @template T
+ * @param T $value
+ * @return (T is 'special' ? int : string)
+ */
+function conditional_literal(mixed $value): int|string
+{
+    return 'default';
+}
+
+/**
+ * When T is the literal 'special', the conditional resolves to int.
+ */
+function test_literal_match(): int
+{
+    return conditional_literal('special');
+}
+
+/**
+ * class-string<A> is not a subtype of 'special', so the result must not
+ * resolve to just int.
+ *
+ * @mago-expect analysis:invalid-return-statement
+ */
+function test_class_string_no_match(): int
+{
+    return conditional_literal(A::class);
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -243,6 +243,7 @@ test_case!(method_signature_param_types);
 test_case!(method_signature_return_types);
 test_case!(return_type_override_native_vs_docblock);
 test_case!(conditional_return_with_default_parameters);
+test_case!(conditional_return_class_string_not_literal);
 test_case!(method_signature_visibility);
 test_case!(method_signature_static);
 test_case!(trait_method_conflicts);

--- a/crates/codex/src/ttype/comparator/scalar_comparator.rs
+++ b/crates/codex/src/ttype/comparator/scalar_comparator.rs
@@ -113,7 +113,7 @@ pub fn is_contained_by(
             return true;
         }
         (TAtomic::Scalar(TScalar::String(c)), TAtomic::Scalar(TScalar::ClassLikeString(_)))
-            if !c.is_unspecified_literal() && !c.is_numeric =>
+            if !c.is_literal_origin() && !c.is_numeric =>
         {
             return true;
         }
@@ -162,4 +162,67 @@ pub fn is_contained_by(
     }
 
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use mago_atom::atom;
+
+    use crate::ttype::atomic::TAtomic;
+    use crate::ttype::atomic::scalar::TScalar;
+    use crate::ttype::atomic::scalar::class_like_string::TClassLikeString;
+    use crate::ttype::atomic::scalar::class_like_string::TClassLikeStringKind;
+    use crate::ttype::atomic::scalar::string::TString;
+    use crate::ttype::comparator::ComparisonResult;
+    use crate::ttype::comparator::tests::create_test_codebase;
+
+    use super::is_contained_by;
+
+    fn class_string_literal(name: &str) -> TAtomic {
+        TAtomic::Scalar(TScalar::ClassLikeString(TClassLikeString::literal(atom(name))))
+    }
+
+    fn string_literal(value: &str) -> TAtomic {
+        TAtomic::Scalar(TScalar::String(TString::known_literal(atom(value))))
+    }
+
+    #[test]
+    fn class_string_is_contained_by_string() {
+        let codebase = create_test_codebase("<?php");
+        let input = class_string_literal("Foo");
+        let container = TAtomic::Scalar(TScalar::String(TString::general()));
+        let mut result = ComparisonResult::new();
+
+        assert!(is_contained_by(&codebase, &input, &container, false, &mut result));
+    }
+
+    #[test]
+    fn class_string_is_contained_by_non_empty_string() {
+        let codebase = create_test_codebase("<?php");
+        let input = class_string_literal("Foo");
+        let container = TAtomic::Scalar(TScalar::String(TString::non_empty()));
+        let mut result = ComparisonResult::new();
+
+        assert!(is_contained_by(&codebase, &input, &container, false, &mut result));
+    }
+
+    #[test]
+    fn class_string_is_not_contained_by_literal_string() {
+        let codebase = create_test_codebase("<?php");
+        let input = class_string_literal("Foo");
+        let container = string_literal("bar");
+        let mut result = ComparisonResult::new();
+
+        assert!(!is_contained_by(&codebase, &input, &container, false, &mut result));
+    }
+
+    #[test]
+    fn class_string_any_is_not_contained_by_literal_string() {
+        let codebase = create_test_codebase("<?php");
+        let input = TAtomic::Scalar(TScalar::ClassLikeString(TClassLikeString::any(TClassLikeStringKind::Class)));
+        let container = string_literal("bar");
+        let mut result = ComparisonResult::new();
+
+        assert!(!is_contained_by(&codebase, &input, &container, false, &mut result));
+    }
 }


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes a bug in the type comparator that caused `class-string` to be contained by known literal string types like `'foo'`.

## 🔍 Context & Motivation

I found this while trying to figure out why this code wasn't working as expected: https://mago.carthage.software/playground#019d8d85-da2f-f6f4-9084-29849466e6e3

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed a type comparator bug causing class strings to be subtypes of known string literals.

## 📂 Affected Areas

- [x] Analyzer
- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

None

## 📝 Notes for Reviewers

Claude Code was used to help author this change. New unit tests in `scalar_comparator` follow the pattern set by `array_comparator`.
