### PR TITLE
fix(formatter): keep interpolated string chains inline

### DIFF
--- a/crates/formatter/src/internal/format/misc.rs
+++ b/crates/formatter/src/internal/format/misc.rs
@@ -9,6 +9,7 @@ use mago_syntax::ast::ArrayAccess;
 use mago_syntax::ast::ArrayElement;
 use mago_syntax::ast::AttributeList;
 use mago_syntax::ast::Call;
+use mago_syntax::ast::CompositeString;
 use mago_syntax::ast::ConstantAccess;
 use mago_syntax::ast::Expression;
 use mago_syntax::ast::Identifier;
@@ -19,6 +20,7 @@ use mago_syntax::ast::Modifier;
 use mago_syntax::ast::Node;
 use mago_syntax::ast::Sequence;
 use mago_syntax::ast::Statement;
+use mago_syntax::ast::StringPart;
 use mago_syntax::ast::Terminator;
 use mago_syntax::ast::UnaryPrefixOperator;
 use mago_syntax::ast::Variable;
@@ -478,6 +480,7 @@ pub(super) fn is_simple_call_argument<'arena>(node: &'arena Expression<'arena>, 
         }
         Expression::Array(array) => array.elements.iter().all(is_simple_element),
         Expression::LegacyArray(array) => array.elements.iter().all(is_simple_element),
+        Expression::CompositeString(composite_string) => is_simple_composite_string_argument(composite_string, depth),
         Expression::Call(call) => {
             let argument_list = match call {
                 Call::Function(function_call) => {
@@ -537,6 +540,18 @@ pub(super) fn is_simple_call_argument<'arena>(node: &'arena Expression<'arena>, 
         }
         _ => false,
     }
+}
+
+fn is_simple_composite_string_argument(composite_string: &CompositeString<'_>, depth: usize) -> bool {
+    if matches!(composite_string, CompositeString::Document(_)) {
+        return false;
+    }
+
+    composite_string.parts().iter().all(|part| match part {
+        StringPart::Literal(literal) => !literal.value.contains(['\n', '\r']),
+        StringPart::Expression(expression) => is_simple_call_argument(expression, depth),
+        StringPart::BracedExpression(braced) => is_simple_call_argument(braced.expression, depth),
+    })
 }
 
 pub(super) fn print_colon_delimited_body<'arena>(

--- a/crates/formatter/src/internal/utils.rs
+++ b/crates/formatter/src/internal/utils.rs
@@ -5,6 +5,7 @@ use mago_syntax::ast::ArgumentList;
 use mago_syntax::ast::ClassConstantAccess;
 use mago_syntax::ast::ClassLikeConstantSelector;
 use mago_syntax::ast::ClassLikeMemberSelector;
+use mago_syntax::ast::CompositeString;
 use mago_syntax::ast::ConstantAccess;
 use mago_syntax::ast::FunctionCall;
 use mago_syntax::ast::Identifier;
@@ -349,6 +350,7 @@ pub fn get_expression_width(element: &Expression<'_>) -> Option<usize> {
             Literal::False(_) => 5,
             Literal::Null(_) => 4,
         },
+        Expression::CompositeString(composite_string) => get_composite_string_width(composite_string)?,
         Expression::MagicConstant(magic_constant) => string_width(magic_constant.value().value),
         Expression::ConstantAccess(ConstantAccess { name: Identifier::Local(local) })
         | Expression::Identifier(Identifier::Local(local)) => string_width(local.value),
@@ -382,6 +384,32 @@ pub fn get_expression_width(element: &Expression<'_>) -> Option<usize> {
             return None;
         }
     })
+}
+
+fn get_composite_string_width(composite_string: &CompositeString<'_>) -> Option<usize> {
+    let mut width = match composite_string {
+        CompositeString::Interpolated(interpolated) => {
+            interpolated.prefix.map_or(0, |prefix| string_width(prefix.value)) + 2
+        }
+        CompositeString::ShellExecute(_) => 2,
+        CompositeString::Document(_) => return None,
+    };
+
+    for part in composite_string.parts() {
+        width += match part {
+            StringPart::Literal(literal) => {
+                if literal.value.contains(['\n', '\r']) {
+                    return None;
+                }
+
+                string_width(literal.value)
+            }
+            StringPart::Expression(expression) => get_expression_width(expression)?,
+            StringPart::BracedExpression(braced) => get_expression_width(braced.expression)? + 2,
+        };
+    }
+
+    Some(width)
 }
 
 #[inline]

--- a/crates/formatter/tests/cases/idempotent_chain_with_complex_arguments/after.php
+++ b/crates/formatter/tests/cases/idempotent_chain_with_complex_arguments/after.php
@@ -32,6 +32,11 @@ $repository->findBy(function ($item) {
     return $item->isActive();
 })->sortBy('name');
 
+$cache->expects($this->once())->method('get')->willReturn("e:$token");
+$cache->expects($this->once())->method('get')->willReturn('e:$token');
+$cache->expects($this->once())->method('get')->willReturn("prefix:{$token}");
+$cache->expects($this->once())->method('get')->willReturn('prefix:{$token}');
+
 class IdempotencyTest
 {
     public function testChainWithExpandedArray()

--- a/crates/formatter/tests/cases/idempotent_chain_with_complex_arguments/before.php
+++ b/crates/formatter/tests/cases/idempotent_chain_with_complex_arguments/before.php
@@ -33,6 +33,11 @@ TestCase::create()
 
 $repository->findBy(function ($item) { return $item->isActive(); })->sortBy('name');
 
+$cache->expects($this->once())->method('get')->willReturn("e:$token");
+$cache->expects($this->once())->method('get')->willReturn('e:$token');
+$cache->expects($this->once())->method('get')->willReturn("prefix:{$token}");
+$cache->expects($this->once())->method('get')->willReturn('prefix:{$token}');
+
 class IdempotencyTest
 {
     public function testChainWithExpandedArray()

--- a/crates/formatter/tests/cases/preserve_breaking_member_access_chain_same_line_first_break/after.php
+++ b/crates/formatter/tests/cases/preserve_breaking_member_access_chain_same_line_first_break/after.php
@@ -63,3 +63,23 @@ return parent::configureAssets()
     ->addJsFile('build/tinymce/tinymce.min.js')
     ->addWebpackEncoreEntry(Asset::new('admin'))
 ;
+
+$cache
+    ->expects($this->once())
+    ->method('get')
+    ->willReturn("cache-entry:$token")
+    ->withTag('notifications')
+    ->withTtl(3600)
+    ->withLock('cache-lock-key-for-current-user')
+    ->send()
+;
+
+$cache
+    ->expects($this->once())
+    ->method('get')
+    ->willReturn('cache-entry:$token')
+    ->withTag('notifications')
+    ->withTtl(3600)
+    ->withLock('cache-lock-key-for-current-user')
+    ->send()
+;

--- a/crates/formatter/tests/cases/preserve_breaking_member_access_chain_same_line_first_break/before.php
+++ b/crates/formatter/tests/cases/preserve_breaking_member_access_chain_same_line_first_break/before.php
@@ -47,3 +47,7 @@ return parent::configureAssets()
     ->addJsFile('build/tinymce/tinymce.min.js')
     ->addWebpackEncoreEntry(Asset::new('admin'))
 ;
+
+$cache->expects($this->once())->method('get')->willReturn("cache-entry:$token")->withTag('notifications')->withTtl(3600)->withLock('cache-lock-key-for-current-user')->send();
+
+$cache->expects($this->once())->method('get')->willReturn('cache-entry:$token')->withTag('notifications')->withTtl(3600)->withLock('cache-lock-key-for-current-user')->send();

--- a/crates/formatter/tests/cases/preserve_breaking_member_access_chain_same_line_first_break_opt_in/after.php
+++ b/crates/formatter/tests/cases/preserve_breaking_member_access_chain_same_line_first_break_opt_in/after.php
@@ -53,3 +53,21 @@ return parent::configureAssets()
     ->addJsFile('build/tinymce/tinymce.min.js')
     ->addWebpackEncoreEntry(Asset::new('admin'))
 ;
+
+$cache->expects($this->once())
+    ->method('get')
+    ->willReturn("cache-entry:$token")
+    ->withTag('notifications')
+    ->withTtl(3600)
+    ->withLock('cache-lock-key-for-current-user')
+    ->send()
+;
+
+$cache->expects($this->once())
+    ->method('get')
+    ->willReturn('cache-entry:$token')
+    ->withTag('notifications')
+    ->withTtl(3600)
+    ->withLock('cache-lock-key-for-current-user')
+    ->send()
+;

--- a/crates/formatter/tests/cases/preserve_breaking_member_access_chain_same_line_first_break_opt_in/before.php
+++ b/crates/formatter/tests/cases/preserve_breaking_member_access_chain_same_line_first_break_opt_in/before.php
@@ -41,3 +41,7 @@ return parent::configureAssets()
     ->addJsFile('build/tinymce/tinymce.min.js')
     ->addWebpackEncoreEntry(Asset::new('admin'))
 ;
+
+$cache->expects($this->once())->method('get')->willReturn("cache-entry:$token")->withTag('notifications')->withTtl(3600)->withLock('cache-lock-key-for-current-user')->send();
+
+$cache->expects($this->once())->method('get')->willReturn('cache-entry:$token')->withTag('notifications')->withTtl(3600)->withLock('cache-lock-key-for-current-user')->send();


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes a formatter regression where an interpolated string inside a method-chain argument could force the whole chain to break, even though the equivalent single-quoted string stayed inline.

Input:

```php
$cache->expects($this->once())->method('get')->willReturn("e:$token");
```

Before this PR, Mago formatted it as:

```php
$cache
    ->expects($this->once())
    ->method('get')
    ->willReturn("e:$token");
```

After this PR, the chain stays inline because the interpolated string is simple and single-line:

```php
$cache->expects($this->once())->method('get')->willReturn("e:$token");
```

The equivalent single-quoted case continues to format the same way:

```php
$cache->expects($this->once())->method('get')->willReturn('e:$token');
```

## 🔍 Context & Motivation

`#1613` reports that interpolation alone changes member-chain breaking behavior. The formatter was treating `Expression::CompositeString` as a complex call argument, while literal strings already counted as simple arguments.

While adding coverage for already-broken chains, the same quote-form mismatch showed up in width-sensitive first-method placement. Composite strings could not be measured by the structural width helper, so forced multiline chains could choose different first-link placement for `"...$value"` than for the matching `'...'` string.

No formatter settings, defaults, or presets change in this PR.

## 🛠️ Summary of Changes

- Treat single-line non-document composite strings as simple call arguments when their embedded expressions are simple.
- Add structural width measurement for single-line interpolated and shell composite strings.
- Keep document strings out of these simple/width paths.
- Extend the existing complex-chain and preserve-breaking chain fixtures with matching single-quoted and double-quoted/interpolated cases.

## 📂 Affected Areas

- [x] Formatter
- [ ] Linter
- [ ] Analyzer
- [ ] CLI/configuration
- [ ] Documentation

## 🔗 Related Issues or PRs

Closes #1613.

Also addresses the same interpolated-string symptom noted in the discussion on #951, without changing that broader method-chain threshold feature request.

## 📝 Notes for Reviewers

Verification run:

```bash
cargo test -p mago-formatter idempotent_chain_with_complex_arguments -- --nocapture
cargo test -p mago-formatter preserve_breaking_member_access_chain -- --nocapture
cargo test -p mago-formatter --test mod -- --nocapture
cargo test -p mago-formatter
cargo fmt --all --check
just test
just check
git diff --check
```

Also validated against a larger local formatter corpus for side effects.