### PR TITLE
fix(playground): stop Vue from clobbering CodeJar's contenteditable=plaintext-only

### DIFF
--- a/docs/.vitepress/theme/components/playground/PlaygroundEditor.vue
+++ b/docs/.vitepress/theme/components/playground/PlaygroundEditor.vue
@@ -122,7 +122,6 @@ watch(
           ref="editorRef"
           class="editor"
           spellcheck="false"
-          :contenteditable="!disabled"
         ></div>
       </div>
     </div>


### PR DESCRIPTION
## 📌 What Does This PR Do?

This fixes issues on Chrome where the playground text editor caret jumps around sometimes while typing.

## 🔍 Context & Motivation

Fixing a usability issue in the playground.

CodeJar [sets plaintext-only at init](https://github.com/antonmedv/codejar/blob/32f7a803cccb191ff10f550dc58403c6b2eb311e/codejar.ts#L60), but Mago's Vue code was clobbering this.

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed incorrect handling of `readonly` properties in PHP 8.2.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [x] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Discord discussion

## 📝 Notes for Reviewers

Heavily assisted by Claude Code, but I've run the playground locally and verified that this fixes the issue.