### PR TITLE
fix(analyzer): treat array-to-object cast as stdClass instance

### DIFF
--- a/crates/analyzer/src/expression/unary.rs
+++ b/crates/analyzer/src/expression/unary.rs
@@ -18,6 +18,7 @@ use mago_codex::ttype::atomic::array::list::TList;
 use mago_codex::ttype::atomic::callable::TCallableSignature;
 use mago_codex::ttype::atomic::mixed::TMixed;
 use mago_codex::ttype::atomic::object::TObject;
+use mago_codex::ttype::atomic::object::named::TNamedObject;
 use mago_codex::ttype::atomic::scalar::TScalar;
 use mago_codex::ttype::atomic::scalar::float::TFloat;
 use mago_codex::ttype::atomic::scalar::int::TInteger;
@@ -1433,10 +1434,16 @@ fn cast_type_to_object<'arena>(
                         known_properties.insert(property_name, item.clone());
                     }
 
-                    possibilities.push(TAtomic::Object(TObject::new_with_properties(
+                    // Casting an array to an object produces a `stdClass` instance in PHP,
+                    // so intersect the shape with `stdClass` to preserve both the shape
+                    // information and the nominal `stdClass` type.
+                    let mut named = TNamedObject::new(atom("stdClass"));
+                    named.intersection_types = Some(vec![TAtomic::Object(TObject::new_with_properties(
                         keyed_array.parameters.is_none(),
                         known_properties,
-                    )));
+                    ))]);
+
+                    possibilities.push(TAtomic::Object(TObject::Named(named)));
                 }
             }
             _ => {}

--- a/crates/analyzer/tests/cases/object_shape.php
+++ b/crates/analyzer/tests/cases/object_shape.php
@@ -70,3 +70,9 @@ function y(): object {
 }
 
 take_one(y()->{'1'});
+
+function take_stdclass(stdClass $o): void {}
+
+// The result of casting an array to an object is a `stdClass`, so it must be
+// assignable to a `stdClass` parameter.
+take_stdclass((object) ['a' => 1]);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes an analyzer bug involving array-to-object casts, where the object resulting from the cast was not considered `stdClass`, despite the fact that it produces an `stdClass` instance at runtime.

## 🔍 Context & Motivation

This fixes a bug that could cause false positives.

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed handling of array-to-object casts so that they always intersect with `stdClass`

## 📂 Affected Areas

- [x] Analyzer
- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

None

## 📝 Notes for Reviewers

Claude Code was used to help find the source of the bug and author the fix.
