### PR TITLE
fix(formatter): avoid inlining nested single-element arrays

### DIFF
--- a/crates/formatter/src/internal/format/array.rs
+++ b/crates/formatter/src/internal/format/array.rs
@@ -29,6 +29,7 @@ use crate::internal::format::misc::get_document_width;
 use crate::internal::format::misc::is_expandable_expression;
 use crate::internal::format::misc::is_string_word_type;
 use crate::internal::utils::get_expression_width;
+use crate::internal::utils::string_width;
 
 #[derive(Debug, Clone, Copy)]
 pub enum ArrayLike<'arena> {
@@ -273,7 +274,22 @@ fn inline_single_element<'arena>(
             if (element.key.is_literal() || is_string_word_type(element.key))
                 && is_expandable_expression(element.value, true)
             {
-                Some(element.format(f))
+                let line_start =
+                    f.file.get_line_start_offset(f.file.line_number(array_like.span().start.offset)).unwrap_or(0)
+                        as usize;
+                let current_column = string_width(&f.source_text[line_start..array_like.span().start.offset as usize]);
+
+                if has_nested_array_like_value(element.value) {
+                    return None;
+                }
+
+                let element = element.format(f);
+
+                if current_column + get_document_width(&element) > f.settings.print_width {
+                    return None;
+                }
+
+                Some(element)
             } else {
                 None
             }
@@ -293,6 +309,28 @@ fn inline_single_element<'arena>(
             }
         }
         ArrayElement::Missing(_) => None,
+    }
+}
+
+#[inline]
+fn has_nested_array_like_value<'arena>(expression: &'arena Expression<'arena>) -> bool {
+    fn element_contains_array_like<'arena>(element: &ArrayElement<'arena>) -> bool {
+        let value = match element {
+            ArrayElement::KeyValue(key_value) => key_value.value,
+            ArrayElement::Value(value) => value.value,
+            ArrayElement::Variadic(value) => value.value,
+            ArrayElement::Missing(_) => return false,
+        };
+
+        matches!(value, Expression::Array(_) | Expression::LegacyArray(_) | Expression::List(_))
+            || has_nested_array_like_value(value)
+    }
+
+    match expression {
+        Expression::Array(array) => array.elements.iter().any(element_contains_array_like),
+        Expression::LegacyArray(array) => array.elements.iter().any(element_contains_array_like),
+        Expression::List(list) => list.elements.iter().any(element_contains_array_like),
+        _ => false,
     }
 }
 
@@ -346,16 +384,16 @@ fn extract_array_elements<'arena>(
 
     for doc in contents {
         match doc {
-            delimiter @ Document::Array(arr) => {
+            Document::Array(arr) => {
                 // Check if this array contains the left delimiter
                 for item in arr {
                     if let Document::String(s) = item {
                         if *s == "[" || *s == "(" {
-                            opening_delimiter = Some(clone_in_arena(f.arena, delimiter));
+                            opening_delimiter = Some(clone_in_arena(f.arena, doc));
                             in_elements = true;
                             break;
                         } else if !in_elements && *s == "]" || *s == ")" {
-                            closing_delimiter = Some(clone_in_arena(f.arena, delimiter));
+                            closing_delimiter = Some(clone_in_arena(f.arena, doc));
                             break;
                         }
                     }

--- a/crates/formatter/tests/cases/drupal_preset/after.php
+++ b/crates/formatter/tests/cases/drupal_preset/after.php
@@ -300,8 +300,9 @@ $derivatives["entity:$entity_type_id"] =
       'entity' => ContextDefinition::create("entity:$entity_type_id")
         ->setLabel($entity_type->getLabel())
         ->setRequired(TRUE)
-        ->setDescription(t('The @entity_type for which to create a path alias.', ['@entity_type' =>
-          $entity_type->getLowercaseLabel()])),
+        ->setDescription(t('The @entity_type for which to create a path alias.', [
+          '@entity_type' => $entity_type->getLowercaseLabel(),
+        ])),
       'alias' => ContextDefinition::create('string')
         ->setLabel(t('Path alias'))
         ->setRequired(TRUE)
@@ -321,8 +322,9 @@ $derivatives["entity:$entity_type_id"] =
       'entity' => ContextDefinition::create("entity:$entity_type_id")
         ->setLabel($entity_type->getLabel())
         ->setRequired(TRUE)
-        ->setDescription(t('The @entity_type for which to create a path alias.', ['@entity_type' =>
-          $entity_type->getLowercaseLabel()])),
+        ->setDescription(t('The @entity_type for which to create a path alias.', [
+          '@entity_type' => $entity_type->getLowercaseLabel(),
+        ])),
       'alias' => ContextDefinition::create('string')
         ->setLabel(t('Path alias'))
         ->setRequired(TRUE)

--- a/crates/formatter/tests/cases/issue_1672/after.php
+++ b/crates/formatter/tests/cases/issue_1672/after.php
@@ -1,0 +1,12 @@
+<?php
+
+class TestCase
+{
+    public function test()
+    {
+        $fixtureFiles = [];
+        $this->logger->info('Loading a total of {count} fixture files', [
+            'count' => count($fixtureFiles),
+        ]);
+    }
+}

--- a/crates/formatter/tests/cases/issue_1672/before.php
+++ b/crates/formatter/tests/cases/issue_1672/before.php
@@ -1,0 +1,10 @@
+<?php
+
+class TestCase
+{
+    public function test()
+    {
+        $fixtureFiles = [];
+        $this->logger->info('Loading a total of {count} fixture files', ['count' => count($fixtureFiles)]);
+    }
+}

--- a/crates/formatter/tests/cases/issue_1672/settings.inc
+++ b/crates/formatter/tests/cases/issue_1672/settings.inc
@@ -1,0 +1,4 @@
+FormatSettings {
+    print_width: 100,
+    ..FormatSettings::default()
+}

--- a/crates/formatter/tests/cases/preserve_breaking_array_like_expand_last/after.php
+++ b/crates/formatter/tests/cases/preserve_breaking_array_like_expand_last/after.php
@@ -81,10 +81,14 @@ self::assertSame(
 
 // Same expression, single-line array
 self::assertSame(
-    trim(Neon::encode(['parameters' => ['ignoreErrors' => [[
-        'message' => "#^Escape Regex with file \\# ~ ' \\(\\)$#",
-        'count' => 1,
-        'path' => 'Testfile',
-    ]]]], Neon::BLOCK)),
+    trim(Neon::encode([
+        'parameters' => [
+            'ignoreErrors' => [[
+                'message' => "#^Escape Regex with file \\# ~ ' \\(\\)$#",
+                'count' => 1,
+                'path' => 'Testfile',
+            ]],
+        ],
+    ], Neon::BLOCK)),
     trim($this->getOutputContent()),
 );

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -403,6 +403,7 @@ test_case!(issue_1460);
 test_case!(issue_1513);
 test_case!(issue_1623);
 test_case!(issue_1623_within_width);
+test_case!(issue_1672);
 test_case!(member_access_chain_keeps_breaks_with_comments);
 test_case!(issue_1562);
 test_case!(bare_cr_line_endings);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fix #1672, make sure we correctly expand arrays on multiple lines.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

I've tried to make sure it wouldn't change any of the existing test cases, but I've had to change the `drupal_preset` and the `preserve_breaking_array_like_expand_last` test cases because they were impacted by this issue exactly. I don't know if it's fine for the second one to change because from what I understand it should maybe "preserve" the existing format? But from what I see the formatting settings of the test cases are the default so no `preserve_*` option so idk really
