### PR TITLE
chore(syntax): remove option from LiteralString::kind

### DIFF
--- a/crates/analyzer/src/common/synthetic.rs
+++ b/crates/analyzer/src/common/synthetic.rs
@@ -23,7 +23,7 @@ use mago_syntax::ast::sequence::TokenSeparatedSequence;
 pub fn new_synthetic_call<'arena>(arena: &'arena Bump, f: &str, expression: Expression<'arena>) -> Expression<'arena> {
     Expression::Call(Call::Function(FunctionCall {
         function: arena.alloc(Expression::Literal(Literal::String(LiteralString {
-            kind: Some(LiteralStringKind::SingleQuoted),
+            kind: LiteralStringKind::SingleQuoted,
             span: Span::zero(),
             raw: arena.alloc_str(&format!("'{f}'")),
             value: Some(arena.alloc_str(f)),

--- a/crates/formatter/src/internal/format/string.rs
+++ b/crates/formatter/src/internal/format/string.rs
@@ -39,7 +39,7 @@ pub(super) fn print_uppercase_keyword<'arena>(f: &FormatterState<'_, 'arena>, ke
 
 pub(super) fn print_string<'arena>(
     f: &FormatterState<'_, 'arena>,
-    kind: Option<LiteralStringKind>,
+    kind: LiteralStringKind,
     text: &'arena str,
 ) -> &'arena str {
     // Strip binary string prefix (b/B) if present
@@ -51,9 +51,8 @@ pub(super) fn print_string<'arena>(
     let enclosing_quote = get_preferred_quote(raw_text, quote, f.settings.single_quote);
 
     match kind {
-        None => text,
-        Some(LiteralStringKind::SingleQuoted) if enclosing_quote == '\'' => text,
-        Some(LiteralStringKind::DoubleQuoted) if enclosing_quote == '"' => text,
+        LiteralStringKind::SingleQuoted if enclosing_quote == '\'' => text,
+        LiteralStringKind::DoubleQuoted if enclosing_quote == '"' => text,
         _ if prefix.is_empty() => make_string_in(f.arena, raw_text, enclosing_quote),
         _ => {
             let inner = make_string_in(f.arena, raw_text, enclosing_quote);

--- a/crates/linter/src/rule/consistency/string_style.rs
+++ b/crates/linter/src/rule/consistency/string_style.rs
@@ -152,9 +152,9 @@ impl StringStyleRule {
             )
             .with_help("Use a double-quoted string with `{$variable}` syntax instead of concatenation.");
 
-        let all_fixable = parts
-            .iter()
-            .all(|p| matches!(p, ConcatPart::Literal { safe_to_double_quote: true, .. } | ConcatPart::Interpolable { .. }));
+        let all_fixable = parts.iter().all(|p| {
+            matches!(p, ConcatPart::Literal { safe_to_double_quote: true, .. } | ConcatPart::Interpolable { .. })
+        });
 
         if !all_fixable {
             ctx.collector.report(issue);
@@ -167,7 +167,9 @@ impl StringStyleRule {
             // double-quoted string.
             match parts.first() {
                 Some(ConcatPart::Interpolable { span }) => edits.push(TextEdit::insert(span.start_offset(), "\"{")),
-                Some(ConcatPart::Literal { span, .. }) => edits.push(TextEdit::replace(span.start_offset()..span.start_offset()+1, "\"")),
+                Some(ConcatPart::Literal { span, .. }) => {
+                    edits.push(TextEdit::replace(span.start_offset()..span.start_offset() + 1, "\""))
+                }
                 _ => {}
             };
 
@@ -175,7 +177,9 @@ impl StringStyleRule {
             // is an expression, it needs a closing `}"`.
             match parts.last() {
                 Some(ConcatPart::Interpolable { span }) => edits.push(TextEdit::insert(span.end_offset(), "}\"")),
-                Some(ConcatPart::Literal { span, .. }) => edits.push(TextEdit::replace(span.end_offset()-1..span.end_offset(), "\"")),
+                Some(ConcatPart::Literal { span, .. }) => {
+                    edits.push(TextEdit::replace(span.end_offset() - 1..span.end_offset(), "\""))
+                }
                 _ => {}
             };
 
@@ -291,7 +295,8 @@ fn collect_concat_side<'arena>(expr: &Expression<'arena>, parts: &mut Vec<Concat
             collect_concat_side(binary.rhs, parts);
         }
         Expression::Literal(Literal::String(literal)) => {
-            let safe_to_double_quote = matches!(literal.kind, Some(LiteralStringKind::DoubleQuoted)) || !literal.raw.contains(['\\', '$', '"']);
+            let safe_to_double_quote =
+                matches!(literal.kind, LiteralStringKind::DoubleQuoted) || !literal.raw.contains(['\\', '$', '"']);
             parts.push(ConcatPart::Literal { span: literal.span, safe_to_double_quote });
         }
         expr if is_interpolable(expr) => {

--- a/crates/syntax/src/ast/ast/literal.rs
+++ b/crates/syntax/src/ast/ast/literal.rs
@@ -27,7 +27,7 @@ pub enum LiteralStringKind {
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
 pub struct LiteralString<'arena> {
-    pub kind: Option<LiteralStringKind>,
+    pub kind: LiteralStringKind,
     pub span: Span,
     pub raw: &'arena str,
     pub value: Option<&'arena str>,

--- a/crates/syntax/src/parser/internal/literal.rs
+++ b/crates/syntax/src/parser/internal/literal.rs
@@ -36,14 +36,14 @@ impl<'input, 'arena> Parser<'input, 'arena> {
             T!["false"] => Literal::False(Keyword { span: token.span_for(self.stream.file_id()), value: token.value }),
             T!["null"] => Literal::Null(Keyword { span: token.span_for(self.stream.file_id()), value: token.value }),
             T![LiteralString] => Literal::String(LiteralString {
-                kind: Some(
-                    if token.value.starts_with('"') || token.value.starts_with("b\"") || token.value.starts_with("B\"")
-                    {
-                        LiteralStringKind::DoubleQuoted
-                    } else {
-                        LiteralStringKind::SingleQuoted
-                    },
-                ),
+                kind: if token.value.starts_with('"')
+                    || token.value.starts_with("b\"")
+                    || token.value.starts_with("B\"")
+                {
+                    LiteralStringKind::DoubleQuoted
+                } else {
+                    LiteralStringKind::SingleQuoted
+                },
                 span: token.span_for(self.stream.file_id()),
                 raw: token.value,
                 value: parse_literal_string_in(self.arena, token.value, None, true),


### PR DESCRIPTION
## 📌 What Does This PR Do?

Tidy up

## 🔍 Context & Motivation

Noticed it, wanted it gone.

## 🛠️ Summary of Changes

- **Refactor:** Removed an unnecessary Option wrapper on LiteralString::kind

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): syntax

## 🔗 Related Issues or PRs

Nah

## 📝 Notes for Reviewers

Some(cleanup)
