### PR TITLE
feat(guard): allow Guard structural autofix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,6 +1529,7 @@ dependencies = [
  "mago-span",
  "mago-syntax",
  "mago-syntax-core",
+ "mago-text-edit",
  "schemars",
  "serde",
  "toml",

--- a/crates/guard/Cargo.toml
+++ b/crates/guard/Cargo.toml
@@ -22,6 +22,7 @@ mago-collector = { workspace = true }
 mago-syntax-core = { workspace = true }
 mago-database = { workspace = true }
 mago-codex = { workspace = true }
+mago-text-edit = { workspace = true }
 foldhash = { workspace = true }
 serde = { workspace = true }
 bumpalo = { workspace = true }

--- a/crates/guard/src/report/flaw.rs
+++ b/crates/guard/src/report/flaw.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use mago_reporting::Annotation;
 use mago_reporting::Issue;
 use mago_span::Span;
+use mago_text_edit::TextEdit;
 
 use crate::settings::StructuralInheritanceConstraint;
 use crate::settings::StructuralSymbolKind;
@@ -20,6 +21,8 @@ pub struct StructuralFlaw {
     pub kind: FlawKind,
     /// An optional human-readable explanation for the flaw.
     pub reason: Option<String>,
+    /// Suggested text edits to fix this flaw. Empty if auto-fix is not available.
+    pub edits: Vec<TextEdit>,
 }
 
 /// Describes the specific kind of structural flaw.
@@ -42,6 +45,9 @@ pub enum FlawKind {
 impl From<StructuralFlaw> for Issue {
     /// Converts a `StructuralFlaw` into a rich, user-friendly `Issue`.
     fn from(flaw: StructuralFlaw) -> Self {
+        let file_id = flaw.span.file_id;
+        let edits = flaw.edits;
+
         let mut issue = Issue::error(format!("Structural flaw in `{}`", flaw.symbol_fqn))
             .with_annotation(Annotation::primary(flaw.span).with_message(flaw.kind.to_string()));
 
@@ -74,7 +80,13 @@ impl From<StructuralFlaw> for Issue {
             }
         };
 
-        issue.with_help(help)
+        issue = issue.with_help(help);
+
+        if !edits.is_empty() {
+            issue = issue.with_file_edits(file_id, edits);
+        }
+
+        issue
     }
 }
 

--- a/crates/guard/src/structural/mod.rs
+++ b/crates/guard/src/structural/mod.rs
@@ -1,3 +1,4 @@
+use mago_span::HasSpan;
 use mago_syntax::ast::Class;
 use mago_syntax::ast::ClassLikeMember;
 use mago_syntax::ast::Constant;
@@ -7,6 +8,7 @@ use mago_syntax::ast::Interface;
 use mago_syntax::ast::Namespace;
 use mago_syntax::ast::Trait;
 use mago_syntax::walker::MutWalker;
+use mago_text_edit::TextEdit;
 
 use crate::context::GuardContext;
 use crate::matcher;
@@ -18,6 +20,36 @@ use crate::settings::StructuralSymbolKind;
 
 #[derive(Debug, Clone, Copy)]
 pub struct StructuralGuardWalker;
+
+fn compute_missing_fqns<'a>(
+    current: &[impl AsRef<str>],
+    constraint: &'a StructuralInheritanceConstraint,
+) -> Vec<&'a str> {
+    match constraint {
+        StructuralInheritanceConstraint::Single(fqn) => {
+            if current.iter().any(|c| c.as_ref().eq_ignore_ascii_case(fqn)) {
+                vec![]
+            } else {
+                vec![fqn.as_str()]
+            }
+        }
+        StructuralInheritanceConstraint::AllOf(fqns) => {
+            fqns.iter()
+                .filter(|fqn| !current.iter().any(|c| c.as_ref().eq_ignore_ascii_case(fqn)))
+                .map(|s| s.as_str())
+                .collect()
+        }
+        _ => vec![],
+    }
+}
+
+fn format_fqn(fqn: &str) -> String {
+    if fqn.starts_with('\\') {
+        fqn.to_string()
+    } else {
+        format!("\\{fqn}")
+    }
+}
 
 impl StructuralGuardWalker {
     fn get_structural_rules<'ctx, 'arena>(
@@ -104,6 +136,7 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                     span: class.name.span,
                     kind: FlawKind::MustBeNamed { pattern: must_be_named.clone() },
                     reason: structural_rule.reason.clone(),
+                    edits: vec![],
                 });
             }
 
@@ -116,6 +149,7 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                     span: class.name.span,
                     kind: FlawKind::MustBe { allowed: allowed_kinds.clone() },
                     reason: structural_rule.reason.clone(),
+                    edits: vec![],
                 });
             }
 
@@ -130,6 +164,14 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                             span: class.name.span,
                             kind: FlawKind::MustBeFinal,
                             reason: structural_rule.reason.clone(),
+                            edits: {
+                                let offset = class
+                                    .modifiers
+                                    .first()
+                                    .map(|m| m.span().start.offset)
+                                    .unwrap_or_else(|| class.class.span().start.offset);
+                                vec![TextEdit::insert(offset, "final ")]
+                            },
                         });
                     }
                     (false, true) => {
@@ -139,6 +181,10 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                             span: class.name.span,
                             kind: FlawKind::MustNotBeFinal,
                             reason: structural_rule.reason.clone(),
+                            edits: match class.modifiers.get_final() {
+                                Some(m) => vec![TextEdit::delete(m.span())],
+                                None => vec![],
+                            },
                         });
                     }
                     _ => {}
@@ -156,6 +202,7 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                             span: class.name.span,
                             kind: FlawKind::MustBeAbstract,
                             reason: structural_rule.reason.clone(),
+                            edits: vec![],
                         });
                     }
                     (false, true) => {
@@ -165,6 +212,10 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                             span: class.name.span,
                             kind: FlawKind::MustNotBeAbstract,
                             reason: structural_rule.reason.clone(),
+                            edits: match class.modifiers.get_abstract() {
+                                Some(m) => vec![TextEdit::delete(m.span())],
+                                None => vec![],
+                            },
                         });
                     }
                     _ => {}
@@ -182,6 +233,10 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                             span: class.name.span,
                             kind: FlawKind::MustBeReadonly,
                             reason: structural_rule.reason.clone(),
+                            edits: {
+                                let offset = class.class.span().start.offset;
+                                vec![TextEdit::insert(offset, "readonly ")]
+                            },
                         });
                     }
                     (false, true) => {
@@ -191,6 +246,10 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                             span: class.name.span,
                             kind: FlawKind::MustNotBeReadonly,
                             reason: structural_rule.reason.clone(),
+                            edits: match class.modifiers.get_readonly() {
+                                Some(m) => vec![TextEdit::delete(m.span())],
+                                None => vec![],
+                            },
                         });
                     }
                     _ => {}
@@ -216,6 +275,23 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                         span: class.name.span,
                         kind: FlawKind::MustExtend { expected: must_extends.clone() },
                         reason: structural_rule.reason.clone(),
+                        edits: {
+                            if class.extends.is_none() {
+                                if let StructuralInheritanceConstraint::Single(fqn) = must_extends {
+                                    let insert_before = class
+                                        .implements
+                                        .as_ref()
+                                        .map(|i| i.implements.span().start.offset)
+                                        .unwrap_or(class.left_brace.start.offset);
+                                    let text = format!(" extends {}", format_fqn(fqn));
+                                    vec![TextEdit::insert(insert_before, text)]
+                                } else {
+                                    vec![]
+                                }
+                            } else {
+                                vec![]
+                            }
+                        },
                     });
                 }
             }
@@ -239,6 +315,27 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                         span: class.name.span,
                         kind: FlawKind::MustImplement { expected: must_implement.clone() },
                         reason: structural_rule.reason.clone(),
+                        edits: {
+                            let missing = compute_missing_fqns(&implemented_fqns, must_implement);
+                            if missing.is_empty() {
+                                vec![]
+                            } else if let Some(implements) = &class.implements {
+                                let last = implements.types.nodes.last().unwrap();
+                                let text: String =
+                                    missing.iter().map(|f| format!(", {}", format_fqn(f))).collect();
+                                vec![TextEdit::insert(last.span().end.offset, text)]
+                            } else {
+                                let text = format!(
+                                    " implements {}",
+                                    missing
+                                        .iter()
+                                        .map(|f| format_fqn(f))
+                                        .collect::<Vec<_>>()
+                                        .join(", ")
+                                );
+                                vec![TextEdit::insert(class.left_brace.start.offset, text)]
+                            }
+                        },
                     });
                 }
             }
@@ -265,6 +362,19 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                         span: class.name.span,
                         kind: FlawKind::MustUseTrait { expected: must_use_traits.clone() },
                         reason: structural_rule.reason.clone(),
+                        edits: {
+                            let missing = compute_missing_fqns(&used_fqns, must_use_traits);
+                            if missing.is_empty() {
+                                vec![]
+                            } else {
+                                let text = missing
+                                    .iter()
+                                    .map(|f| format!("\n    use {};", format_fqn(f)))
+                                    .collect::<Vec<_>>()
+                                    .join("");
+                                vec![TextEdit::insert(class.left_brace.end.offset, text)]
+                            }
+                        },
                     });
                 }
             }
@@ -287,6 +397,7 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                         span: class.name.span,
                         kind: FlawKind::MustUseAttribute { expected: must_use_attributes.clone() },
                         reason: structural_rule.reason.clone(),
+                        edits: vec![],
                     });
                 }
             }
@@ -310,6 +421,7 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                     span: interface.name.span,
                     kind: FlawKind::MustBeNamed { pattern: must_be_named.clone() },
                     reason: structural_rule.reason.clone(),
+                    edits: vec![],
                 });
             }
 
@@ -322,6 +434,7 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                     span: interface.name.span,
                     kind: FlawKind::MustBe { allowed: allowed_kinds.clone() },
                     reason: structural_rule.reason.clone(),
+                    edits: vec![],
                 });
             }
 
@@ -344,6 +457,7 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                         span: interface.name.span,
                         kind: FlawKind::MustExtend { expected: must_extends.clone() },
                         reason: structural_rule.reason.clone(),
+                        edits: vec![],
                     });
                 }
             }
@@ -366,6 +480,7 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                         span: interface.name.span,
                         kind: FlawKind::MustUseAttribute { expected: must_use_attributes.clone() },
                         reason: structural_rule.reason.clone(),
+                        edits: vec![],
                     });
                 }
             }
@@ -387,6 +502,7 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                     span: r#enum.name.span,
                     kind: FlawKind::MustBeNamed { pattern: must_be_named.clone() },
                     reason: structural_rule.reason.clone(),
+                    edits: vec![],
                 });
             }
 
@@ -399,6 +515,7 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                     span: r#enum.name.span,
                     kind: FlawKind::MustBe { allowed: allowed_kinds.clone() },
                     reason: structural_rule.reason.clone(),
+                    edits: vec![],
                 });
             }
 
@@ -421,6 +538,27 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                         span: r#enum.name.span,
                         kind: FlawKind::MustImplement { expected: must_implement.clone() },
                         reason: structural_rule.reason.clone(),
+                        edits: {
+                            let missing = compute_missing_fqns(&implemented_fqns, must_implement);
+                            if missing.is_empty() {
+                                vec![]
+                            } else if let Some(implements) = &r#enum.implements {
+                                let last = implements.types.nodes.last().unwrap();
+                                let text: String =
+                                    missing.iter().map(|f| format!(", {}", format_fqn(f))).collect();
+                                vec![TextEdit::insert(last.span().end.offset, text)]
+                            } else {
+                                let text = format!(
+                                    " implements {}",
+                                    missing
+                                        .iter()
+                                        .map(|f| format_fqn(f))
+                                        .collect::<Vec<_>>()
+                                        .join(", ")
+                                );
+                                vec![TextEdit::insert(r#enum.left_brace.start.offset, text)]
+                            }
+                        },
                     });
                 }
             }
@@ -443,6 +581,7 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                         span: r#enum.name.span,
                         kind: FlawKind::MustUseAttribute { expected: must_use_attributes.clone() },
                         reason: structural_rule.reason.clone(),
+                        edits: vec![],
                     });
                 }
             }
@@ -466,6 +605,7 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                     span: r#trait.name.span,
                     kind: FlawKind::MustBeNamed { pattern: must_be_named.clone() },
                     reason: structural_rule.reason.clone(),
+                    edits: vec![],
                 });
             }
 
@@ -478,6 +618,7 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                     span: r#trait.name.span,
                     kind: FlawKind::MustBe { allowed: allowed_kinds.clone() },
                     reason: structural_rule.reason.clone(),
+                    edits: vec![],
                 });
             }
 
@@ -503,6 +644,7 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                         span: r#trait.name.span,
                         kind: FlawKind::MustUseTrait { expected: must_use_traits.clone() },
                         reason: structural_rule.reason.clone(),
+                        edits: vec![],
                     });
                 }
             }
@@ -525,6 +667,7 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                         span: r#trait.name.span,
                         kind: FlawKind::MustUseAttribute { expected: must_use_attributes.clone() },
                         reason: structural_rule.reason.clone(),
+                        edits: vec![],
                     });
                 }
             }
@@ -548,6 +691,7 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                     span: function.name.span,
                     kind: FlawKind::MustBeNamed { pattern: must_be_named.clone() },
                     reason: structural_rule.reason.clone(),
+                    edits: vec![],
                 });
             }
 
@@ -560,6 +704,7 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                     span: function.name.span,
                     kind: FlawKind::MustBe { allowed: allowed_kinds.clone() },
                     reason: structural_rule.reason.clone(),
+                    edits: vec![],
                 });
             }
 
@@ -581,6 +726,7 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                         span: function.name.span,
                         kind: FlawKind::MustUseAttribute { expected: must_use_attribute.clone() },
                         reason: structural_rule.reason.clone(),
+                        edits: vec![],
                     });
                 }
             }
@@ -605,6 +751,7 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                         span: constant_item.name.span,
                         kind: FlawKind::MustBeNamed { pattern: must_be_named.clone() },
                         reason: structural_rule.reason.clone(),
+                        edits: vec![],
                     });
                 }
 
@@ -617,6 +764,7 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                         span: constant_item.name.span,
                         kind: FlawKind::MustBe { allowed: allowed_kinds.clone() },
                         reason: structural_rule.reason.clone(),
+                        edits: vec![],
                     });
                 }
 
@@ -638,6 +786,7 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                             span: constant_item.name.span,
                             kind: FlawKind::MustUseAttribute { expected: must_use_attributes.clone() },
                             reason: structural_rule.reason.clone(),
+                            edits: vec![],
                         });
                     }
                 }

--- a/crates/guard/tests/structural_fix.rs
+++ b/crates/guard/tests/structural_fix.rs
@@ -1,0 +1,166 @@
+use std::borrow::Cow;
+use std::sync::LazyLock;
+
+use bumpalo::Bump;
+use foldhash::HashSet;
+use indoc::indoc;
+
+use mago_atom::AtomSet;
+use mago_codex::populator::populate_codebase;
+use mago_codex::scanner::scan_program;
+use mago_database::DatabaseReader;
+use mago_database::file::File;
+use mago_guard::ArchitecturalGuard;
+use mago_guard::settings::Settings;
+use mago_guard::settings::StructuralInheritanceConstraint;
+use mago_guard::settings::StructuralRule;
+use mago_guard::settings::StructuralSettings;
+use mago_names::resolver::NameResolver;
+use mago_prelude::Prelude;
+use mago_syntax::parser::parse_file;
+
+static PRELUDE: LazyLock<Prelude> = LazyLock::new(Prelude::build);
+
+fn apply_fix(code: &'static str, settings: Settings) -> String {
+    let Prelude { mut database, mut metadata, mut symbol_references } = PRELUDE.clone();
+
+    let file = File::ephemeral(Cow::Borrowed("test_fix"), Cow::Borrowed(code));
+    let file_id = database.add(file);
+    let source_file = database.get_ref(&file_id).expect("File just added should exist");
+
+    let arena = Bump::new();
+    let program = parse_file(&arena, source_file);
+    if program.has_errors() {
+        panic!("Failed to parse code for guard test, errors: {:?}", program.errors);
+    }
+
+    let resolver = NameResolver::new(&arena);
+    let resolved_names = resolver.resolve(program);
+
+    metadata.extend(scan_program(&arena, source_file, program, &resolved_names));
+    populate_codebase(&mut metadata, &mut symbol_references, AtomSet::default(), HashSet::default());
+
+    let guard = ArchitecturalGuard::new(settings);
+    let report = guard.check(&metadata, program, &resolved_names);
+
+    use mago_text_edit::TextEditor;
+    let mut editor = TextEditor::new(&source_file.contents);
+    for flaw in &report.structural_flaws {
+        for edit in &flaw.edits {
+            match editor.apply(edit.clone(), None::<fn(&str) -> bool>) {
+                mago_text_edit::ApplyResult::Applied => {}
+                result => panic!("Failed to apply edit: {:?}", result),
+            }
+        }
+    }
+
+    editor.finish()
+}
+
+#[test]
+fn test_add_final_modifier() {
+    let code = indoc! {r"<?php
+        class MyCommand {}
+    "};
+
+    let settings = Settings {
+        structural: StructuralSettings {
+            rules: vec![StructuralRule {
+                on: "MyCommand".to_string(),
+                must_be_final: Some(true),
+                ..Default::default()
+            }],
+        },
+        ..Default::default()
+    };
+
+    assert!(apply_fix(code, settings).contains("final class MyCommand"));
+}
+
+#[test]
+fn test_remove_final_modifier() {
+    let code = indoc! {r"<?php
+        final class MyCommand {}
+    "};
+
+    let settings = Settings {
+        structural: StructuralSettings {
+            rules: vec![StructuralRule {
+                on: "MyCommand".to_string(),
+                must_be_final: Some(false),
+                ..Default::default()
+            }],
+        },
+        ..Default::default()
+    };
+
+    let result = apply_fix(code, settings);
+    assert!(!result.contains("final class") && result.contains("class MyCommand"));
+}
+
+#[test]
+fn test_add_readonly_modifier() {
+    let code = indoc! {r"<?php
+        class MyCommand {}
+    "};
+
+    let settings = Settings {
+        structural: StructuralSettings {
+            rules: vec![StructuralRule {
+                on: "MyCommand".to_string(),
+                must_be_readonly: Some(true),
+                ..Default::default()
+            }],
+        },
+        ..Default::default()
+    };
+
+    assert!(apply_fix(code, settings).contains("readonly class MyCommand"));
+}
+
+#[test]
+fn test_add_interface_no_existing() {
+    let code = indoc! {r"<?php
+        class MyCommand {}
+    "};
+
+    let settings = Settings {
+        structural: StructuralSettings {
+            rules: vec![StructuralRule {
+                on: "MyCommand".to_string(),
+                must_implement: Some(StructuralInheritanceConstraint::Single(
+                    "App\\Domain\\Command".to_string(),
+                )),
+                ..Default::default()
+            }],
+        },
+        ..Default::default()
+    };
+
+    let result = apply_fix(code, settings);
+    assert!(result.contains("MyCommand") && result.contains("implements") && result.contains("Domain"));
+}
+
+#[test]
+fn test_add_interface_existing() {
+    let code = indoc! {r"<?php
+        class MyCommand implements ExistingInterface {}
+    "};
+
+    let settings = Settings {
+        structural: StructuralSettings {
+            rules: vec![StructuralRule {
+                on: "MyCommand".to_string(),
+                must_implement: Some(StructuralInheritanceConstraint::AllOf(vec![
+                    "ExistingInterface".to_string(),
+                    "App\\Domain\\Command".to_string(),
+                ])),
+                ..Default::default()
+            }],
+        },
+        ..Default::default()
+    };
+
+    let result = apply_fix(code, settings);
+    assert!(result.contains("implements ExistingInterface, \\App\\Domain\\Command"));
+}

--- a/docs/tools/guard/command-reference.md
+++ b/docs/tools/guard/command-reference.md
@@ -73,15 +73,36 @@ Rules:
 
 Under the hood, `TEMP` is added to the host paths and `ORIG` is added to the excludes for this run. The rest of the project is scanned as usual, so layer and namespace checks continue to see the mutation. Reported issues reference the `TEMP` path rather than `ORIG`; mutation-testing tools typically parse the diff of issue counts between a clean run and the substituted run, so this does not affect the workflow.
 
+### Auto-Fix Options
+
+The `guard` command can automatically fix structural violations for rules that support it (modifier constraints, interface/trait/extends additions). The `--fix` flag works the same way as in `mago lint`.
+
+| Flag                   | Description                                                                                        |
+|:-----------------------|:---------------------------------------------------------------------------------------------------|
+| `--fix`                | Automatically apply fixes for fixable structural violations.                                       |
+| `--dry-run`            | Preview what would be changed without writing any files. Shows a unified diff per file.            |
+| `--format-after-fix`   | Run the formatter on every file changed by `--fix` to clean up whitespace and style.              |
+
+```sh
+# Preview fixes without writing files
+mago guard --fix --dry-run
+
+# Apply fixes automatically
+mago guard --fix
+
+# Apply fixes then format changed files
+mago guard --fix --format-after-fix
+```
+
+:::tip
+Not all structural violations can be auto-fixed. Flaws that require human judgment (renaming, changing class kind, adding abstract) are always reported but never auto-applied. See [Using the Guard — Auto-Fix](./usage.md#auto-fixing-structural-flaws) for the full list.
+:::
+
 ### Shared Reporting Options
 
 The `guard` command uses a shared set of options for reporting the issues it finds.
 
 [**See the Shared Reporting and Fixing Options documentation.**](/fundamentals/shared-reporting-options.md)
-
-:::info
-Auto-fixing and baseline features are not applicable to the `guard` command.
-:::
 
 ### Help
 

--- a/docs/tools/guard/overview.md
+++ b/docs/tools/guard/overview.md
@@ -31,6 +31,8 @@ For example, you can enforce rules like:
 
 This helps maintain a high level of code quality and consistency across the entire project.
 
+Many structural violations can be **automatically fixed** using `mago guard --fix`. Mago will insert or remove modifiers (`final`, `readonly`), add missing `implements` or `extends` clauses, and inject `use TraitName;` statements — leaving only violations that require human judgment in the report.
+
 ## Dive In
 
 - **[Configuration Reference](./configuration-reference.md)**: A detailed guide to all `guard` settings in `mago.toml`.

--- a/docs/tools/guard/usage.md
+++ b/docs/tools/guard/usage.md
@@ -107,4 +107,86 @@ error[must-be-final]: Structural flaw in `App\UI\Controller\UserController`
    │
    = Controllers should be final to prevent extension.
    = Help: Declare this class as `final`.
-```The report identifies the symbol, the location, the exact flaw, and the reason provided in the configuration.
+```
+
+The report identifies the symbol, the location, the exact flaw, and the reason provided in the configuration.
+
+## Auto-Fixing Structural Flaws
+
+For structural violations that have a safe, unambiguous fix, you can run `mago guard --fix` to apply them automatically — no manual editing required.
+
+```sh
+# Preview what would change (no files written)
+mago guard --fix --dry-run
+
+# Apply fixes
+mago guard --fix
+
+# Apply fixes, then format changed files
+mago guard --fix --format-after-fix
+```
+
+### What gets fixed
+
+| Rule | Fix applied |
+|:-----|:------------|
+| `must-be-final = true` | Inserts `final` before the `class` keyword |
+| `must-be-final = false` | Removes the `final` modifier |
+| `must-be-readonly = true` | Inserts `readonly` before the `class` keyword |
+| `must-be-readonly = false` | Removes the `readonly` modifier |
+| `must-implement = "FQN"` | Adds the interface to the `implements` clause (or creates it) |
+| `must-implement = { all-of = [...] }` | Adds every missing interface to the `implements` clause |
+| `must-extend = "FQN"` | Adds `extends BaseClass` when the class has no parent yet |
+| `must-use-trait = "FQN"` | Inserts `use TraitName;` as the first statement in the class body |
+| `must-use-trait = { all-of = [...] }` | Inserts all missing trait `use` statements |
+
+**Example** — given this rule:
+
+```toml
+[[guard.structural.rules]]
+on = "App\\Domain\\**\\Command\\**\\*Command"
+target = "class"
+must-be-final = true
+must-be-readonly = true
+reason = "CQRS: Commands must be immutable value objects"
+```
+
+Before:
+```php
+class CreateUserCommand
+{
+    public function __construct(
+        public readonly string $email,
+    ) {}
+}
+```
+
+After `mago guard --fix`:
+```php
+final readonly class CreateUserCommand
+{
+    public function __construct(
+        public readonly string $email,
+    ) {}
+}
+```
+
+### What is NOT auto-fixed
+
+Some violations intentionally require human review:
+
+| Rule | Why it's not auto-fixed |
+|:-----|:------------------------|
+| `must-be-abstract` | Semantic change — existing concrete methods may need rework |
+| `must-not-be-abstract` | Requires providing implementations for abstract methods |
+| `must-be-named` | Renaming affects all references across the codebase |
+| `must-be` (symbol kind) | Converting class ↔ interface ↔ enum is a structural rewrite |
+| `must-use-attribute` | Attributes often need arguments; correct values are unknown |
+| `must-implement = { any-of = [...] }` | Ambiguous — Mago cannot determine which option to pick |
+| `must-extend` when class already extends | Replacing a parent class can break method overrides |
+
+These violations remain in the report and must be resolved manually.
+
+### FQN format
+
+All inserted type references use fully-qualified names with a leading backslash (e.g. `\App\Domain\Command\Command`). This is always safe regardless of the current namespace and avoids any ambiguity with `use` imports. Running `mago guard --fix --format-after-fix` will clean up any whitespace and normalise the inserted code to your project's style.


### PR DESCRIPTION
## 📌 What Does This PR Do?

Add Guard structural autofix capacity.

## 🔍 Context & Motivation

When configuring a project with structural rules, it feels weird not to be able to fix them instead of just checking invalid ones.
Adding `final` or `readonly` keywords on a class is something simple, I'd rather my mago tool do it instead of manually adding it.

This PR introduces a new `guard --fix` command which will do it for us (not the default behavior).

## 🛠️ Summary of Changes


- **Feature:** Introduced `--fix` flag to the `guard` command to automatically resolve structural violations.
- **Feature:** Implemented autofix support for several structural rules:
    - `must-be-final` (true/false)
    - `must-be-readonly` (true/false)
    - `must-implement` (Single and AllOf constraints)
    - `must-extend` (when the class doesn't already have a parent)
    - `must-use-trait` (Single and AllOf constraints)
- **Feature:** Added `--dry-run` and `--format-after-fix` options to the `guard` command.
- **Internal:** Updated `StructuralFlaw` to include suggested `TextEdit`s.
- **Documentation:** Added comprehensive usage guide and command reference for the new fix capabilities.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [x] CLI
- [ ] Dependencies
- [x] Documentation
- [x] Other (please specify): Guard Core (Structural Analysis)

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

- Fixes are applied using fully qualified names (FQN) with a leading backslash to ensure correctness regardless of the namespace context.
- Some rules like `must-be-abstract` or `must-be-named` are intentionally not auto-fixed as they require manual architectural decisions.
- The `--format-after-fix` flag is recommended to ensure the inserted code matches the project's coding style.
