### PR TITLE
fix(prelude): `DateTimeInterface::getTimezone()` never returns `false`

### DIFF
--- a/crates/prelude/assets/extensions/date.php
+++ b/crates/prelude/assets/extensions/date.php
@@ -323,7 +323,7 @@ interface DateTimeInterface
 
     public function format(string $format): string;
 
-    public function getTimezone(): DateTimeZone|false;
+    public function getTimezone(): DateTimeZone;
 
     public function getOffset(): int;
 
@@ -383,7 +383,7 @@ class DateTime implements DateTimeInterface
 
     public function sub(DateInterval $interval): DateTime {}
 
-    public function getTimezone(): DateTimeZone|false {}
+    public function getTimezone(): DateTimeZone {}
 
     public function setTimezone(DateTimeZone $timezone): DateTime {}
 
@@ -455,7 +455,7 @@ class DateTimeImmutable implements DateTimeInterface
      *
      * @psalm-ignore-falsable-return
      */
-    public function getTimezone(): DateTimeZone|false {}
+    public function getTimezone(): DateTimeZone {}
 
     /**
      * @psalm-mutation-free


### PR DESCRIPTION
## 📌 What Does This PR Do?

Removes `false` from the return type of `DateTimeInterface::getTimezone()`

## 🔍 Context & Motivation

It appears impossible to get `false` out of `DateTimeInterface::getTimezone()` even though `false` is documented in the union on [PHP's official docs](https://www.php.net/manual/en/datetime.gettimezone.php).

There also appears to be [no tests in `php-src`](https://github.com/php/php-src/tree/2c5dc5d8b1f9c77b706b7e48801a8acd0cdfffb1/ext/date/tests) that produce a false result.

The stubs shipped by Psalm have removed `false` from the return type.

## 📂 Affected Areas

- [x] Analyzer
