### PR TITLE
docs(recipes): fix CI short-circuiting and format dry-run in GH Actions recipe

### DIFF
--- a/docs/recipes/github-actions.md
+++ b/docs/recipes/github-actions.md
@@ -40,12 +40,21 @@ jobs:
       - name: Setup Mago
         uses: nhedger/setup-mago@v1
 
-      - name: Run Mago
-        run: |
-          mago format --dry-run
-          mago lint
-          mago analyze
+      - name: Check formatting
+        run: mago format --check
+
+      - name: Lint
+        if: success() || failure()
+        run: mago lint
+
+      - name: Analyze
+        if: success() || failure()
+        run: mago analyze
 ```
+
+:::tip
+Splitting `format`, `lint`, and `analyze` into separate steps (and using `if: success() || failure()` on the later ones) lets a single run surface findings from all three tools even when an earlier one fails. A combined `run:` block short-circuits on the first failure, hiding findings from the later tools. `success() || failure()` runs the step as long as the job was not cancelled, unlike `always()` which would also run it after a failure in job setup. Use `mago format --check` (not `--dry-run`) so the step actually fails CI when code is not formatted — `--dry-run` only prints a diff and always exits `0`.
+:::
 
 :::tip
 Mago automatically detects GitHub Actions via the `GITHUB_ACTIONS` environment variable and defaults to `--reporting-format=github`, producing native PR annotations. No extra configuration needed.
@@ -76,13 +85,15 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Check Formatting
+      - name: Check formatting
         run: mago fmt --check
 
       - name: Lint
+        if: success() || failure()
         run: mago lint
 
       - name: Analyze
+        if: success() || failure()
         run: mago analyze
 ```
 


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes two small issues in `docs/recipes/github-actions.md` that make the copy-pasted recipe less useful in real CI:

1. **`mago format --dry-run` never fails CI.** `--dry-run` prints a diff and always exits `0`. `mago --help` itself says `--check` is "ideal for CI environments" (exit 1 on unformatted code). The Docker recipe further down the same page already uses `--check` — this just makes the two consistent.
2. **Running `format` + `lint` + `analyze` in one `run:` block short-circuits on the first failure.** A first-time adopter typically has findings from all three tools; hiding two of them behind the first makes the PoC harder to evaluate. Splitting them into separate steps with `if: success() || failure()` on the later two surfaces everything in a single run.

## 🔍 Context & Motivation

Ran the recipe as-is against a ~2 MLOC PHP codebase as a proof of concept. Hit both of these friction points:

- Format-check "passed" in CI even though the tree wasn't formatted — because `--dry-run` exits 0.
- Lint and analyze never ran because format aborted the combined block, so the evaluator only saw the first tool's output.

Both are one-line/one-block fixes that keep the shape of the recipe intact.

## 🛠️ Summary of Changes

- **Docs:** `mago format --dry-run` → `mago format --check` in the setup-mago recipe (Docker recipe already had `--check`).
- **Docs:** Split the combined `Run Mago` block into `Check formatting` / `Lint` / `Analyze` steps; apply `if: success() || failure()` to `Lint` and `Analyze` so they run after a format failure but not after setup failure or cancellation.
- **Docs:** Same step-split treatment to the Docker recipe below.
- **Docs:** Tip explaining both choices (why `--check`, why `success() || failure()` instead of `always()`).

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [x] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Recipe originally added in #79. No duplicate PR or open issue covering this.

## 📝 Notes for Reviewers

- Deliberately **not** adding `--reporting-format=github` — the existing `:::tip` already notes Mago auto-detects `GITHUB_ACTIONS` and defaults to it on 1.18+.
- Deliberately **not** pinning `nhedger/setup-mago@v1` to a specific Mago version in the recipe; that's a project choice and the action's composer-lock auto-detection handles it well for most users.
- `if: success() || failure()` is preferred over `always()` so a cancelled job or broken setup-mago step aborts cleanly rather than running Mago commands against a half-configured runner.

Drafted as a draft PR — happy to rework, split, or close if the trade-offs don't match the project's taste.
