### PR TITLE
fix(analyzer): propagate parent class docblock changes

### DIFF
--- a/crates/analyzer/src/context/mod.rs
+++ b/crates/analyzer/src/context/mod.rs
@@ -141,9 +141,7 @@ impl<'ctx, 'arena> Context<'ctx, 'arena> {
     pub fn get_parsed_docblocks(&mut self) -> Vec<Element<'arena>> {
         let mut elements = vec![];
         let mut start = self.statement_span.start.offset;
-        while let Some(trivia) =
-            comments::docblock::get_docblock_before_position(self.source_file, self.comments, start)
-        {
+        while let Some(trivia) = comments::docblock::get_docblock_before_position(self.comments, start) {
             match mago_docblock::parse_trivia(self.arena, trivia) {
                 Ok(document) => elements.extend(document.elements),
                 Err(error) => {

--- a/crates/analyzer/src/context/mod.rs
+++ b/crates/analyzer/src/context/mod.rs
@@ -15,7 +15,7 @@ use mago_span::HasSpan;
 use mago_span::Span;
 use mago_syntax::ast::Identifier;
 use mago_syntax::ast::Trivia;
-use mago_syntax::comments;
+use mago_syntax::comments::docblock::PrecedingDocblocks;
 
 use crate::analysis_result::AnalysisResult;
 use crate::artifacts::AnalysisArtifacts;
@@ -140,8 +140,7 @@ impl<'ctx, 'arena> Context<'ctx, 'arena> {
 
     pub fn get_parsed_docblocks(&mut self) -> Vec<Element<'arena>> {
         let mut elements = vec![];
-        let mut start = self.statement_span.start.offset;
-        while let Some(trivia) = comments::docblock::get_docblock_before_position(self.comments, start) {
+        for trivia in PrecedingDocblocks::new(self.comments, self.statement_span.start.offset) {
             match mago_docblock::parse_trivia(self.arena, trivia) {
                 Ok(document) => elements.extend(document.elements),
                 Err(error) => {
@@ -170,7 +169,6 @@ impl<'ctx, 'arena> Context<'ctx, 'arena> {
                     self.collector.report_with_code(IssueCode::InvalidDocblock, issue);
                 }
             }
-            start = trivia.span.start.offset;
         }
 
         elements

--- a/crates/codex/src/populator/docblock.rs
+++ b/crates/codex/src/populator/docblock.rs
@@ -43,7 +43,9 @@ fn should_inherit_docblock_type(
     has_explicit_inheritdoc: bool,
     codebase: &CodebaseMetadata,
 ) -> bool {
-    if child_docblock.is_some() {
+    // Allow re-inheritance when the existing child type was itself inherited (not user-written).
+    // Inherited types are marked `inferred: true`; user-written docblock types are `inferred: false`.
+    if child_docblock.is_some_and(|m| !m.inferred) {
         return false;
     }
 
@@ -487,7 +489,7 @@ fn apply_inheritance_work(codebase: &mut CodebaseMetadata, mut inheritance_work:
                 type_union
             };
 
-            Some(TypeMetadata { type_union: narrowed_type, span, from_docblock, inferred: false })
+            Some(TypeMetadata { type_union: narrowed_type, span, from_docblock, inferred: true })
         } else {
             None
         };
@@ -505,7 +507,7 @@ fn apply_inheritance_work(codebase: &mut CodebaseMetadata, mut inheritance_work:
                 && let Some(child_param) = child_method.parameters.get_mut(i)
                 && let Some((type_union, span, from_docblock)) = substituted_param
             {
-                child_param.type_metadata = Some(TypeMetadata { type_union, span, from_docblock, inferred: false });
+                child_param.type_metadata = Some(TypeMetadata { type_union, span, from_docblock, inferred: true });
             }
         }
 

--- a/crates/codex/src/scanner/mod.rs
+++ b/crates/codex/src/scanner/mod.rs
@@ -109,7 +109,7 @@ impl<'ctx, 'arena> Context<'ctx, 'arena> {
     }
 
     pub fn get_docblock(&self, node: impl HasSpan) -> Option<&'arena Trivia<'arena>> {
-        get_docblock_for_node(self.program, self.file, node)
+        get_docblock_for_node(self.program, node)
     }
 }
 

--- a/crates/codex/src/signature_builder.rs
+++ b/crates/codex/src/signature_builder.rs
@@ -18,6 +18,7 @@ use mago_syntax::ast::Program;
 use mago_syntax::ast::Property;
 use mago_syntax::ast::PropertyItem;
 use mago_syntax::ast::Trait;
+use mago_syntax::ast::Trivia;
 use mago_syntax::walker::MutWalker;
 
 use crate::signature::DefSignatureNode;
@@ -40,7 +41,7 @@ pub fn build_file_signature<'arena>(
     program: &'arena Program<'arena>,
     resolved_names: &'arena ResolvedNames<'arena>,
 ) -> FileSignature {
-    let mut builder = SignatureBuilder::new(file, resolved_names);
+    let mut builder = SignatureBuilder::new(file, resolved_names, &program.trivia.nodes);
     builder.walk_program(program, &mut ());
 
     let hash = program.fingerprint(resolved_names, &builder.fingerprint_options);
@@ -52,15 +53,15 @@ pub fn build_file_signature<'arena>(
 struct SignatureBuilder<'file, 'arena> {
     file: &'file File,
     resolved_names: &'arena ResolvedNames<'arena>,
-    fingerprint_options: FingerprintOptions<'static>,
-    sig_only_options: FingerprintOptions<'static>,
+    fingerprint_options: FingerprintOptions<'arena>,
+    sig_only_options: FingerprintOptions<'arena>,
     class_stack: Vec<DefSignatureNode>,
     ast_nodes: Vec<DefSignatureNode>,
 }
 
 impl<'file, 'arena> SignatureBuilder<'file, 'arena> {
-    fn new(file: &'file File, resolved_names: &'arena ResolvedNames<'arena>) -> Self {
-        let fingerprint_options = FingerprintOptions::default();
+    fn new(file: &'file File, resolved_names: &'arena ResolvedNames<'arena>, trivia: &'arena [Trivia<'arena>]) -> Self {
+        let fingerprint_options = FingerprintOptions::default().with_trivia_context(trivia);
         let sig_only_options = FingerprintOptions { signature_only: true, ..fingerprint_options };
 
         Self {

--- a/crates/fingerprint/Cargo.toml
+++ b/crates/fingerprint/Cargo.toml
@@ -13,10 +13,10 @@ rust-version.workspace = true
 mago-syntax = { workspace = true }
 mago-names = { workspace = true }
 mago-atom = { workspace = true }
+mago-span = { workspace = true }
 foldhash = { workspace = true }
 
 [dev-dependencies]
-mago-span = { workspace = true }
 mago-database = { workspace = true }
 bumpalo = { workspace = true }
 pretty_assertions = { workspace = true }

--- a/crates/fingerprint/src/class_like/mod.rs
+++ b/crates/fingerprint/src/class_like/mod.rs
@@ -1,6 +1,7 @@
 use std::hash::Hash;
 
 use mago_names::ResolvedNames;
+use mago_span::HasSpan;
 use mago_syntax::ast::AnonymousClass;
 use mago_syntax::ast::Class;
 use mago_syntax::ast::ClassLikeConstant;
@@ -29,6 +30,7 @@ use mago_syntax::ast::TraitUseAbsoluteMethodReference;
 use mago_syntax::ast::TraitUseAdaptation;
 use mago_syntax::ast::TraitUseMethodReference;
 use mago_syntax::ast::TraitUseSpecification;
+use mago_syntax::comments::docblock::PrecedingDocblocks;
 
 use crate::FingerprintOptions;
 use crate::Fingerprintable;
@@ -435,6 +437,13 @@ impl Fingerprintable for Method<'_> {
         resolved_names: &ResolvedNames,
         options: &FingerprintOptions<'_>,
     ) {
+        if let Some(trivia) = options.trivia_context {
+            for t in PrecedingDocblocks::new(trivia, self.span().start.offset)
+                .important_only(options.important_comment_patterns)
+            {
+                t.value.hash(hasher);
+            }
+        }
         "method".hash(hasher);
         for attribute_list in &self.attribute_lists {
             attribute_list.fingerprint_with_hasher(hasher, resolved_names, options);
@@ -479,6 +488,13 @@ impl Fingerprintable for Class<'_> {
         resolved_names: &ResolvedNames,
         options: &FingerprintOptions<'_>,
     ) {
+        if let Some(trivia) = options.trivia_context {
+            for t in PrecedingDocblocks::new(trivia, self.span().start.offset)
+                .important_only(options.important_comment_patterns)
+            {
+                t.value.hash(hasher);
+            }
+        }
         "class".hash(hasher);
         for attribute_list in &self.attribute_lists {
             attribute_list.fingerprint_with_hasher(hasher, resolved_names, options);
@@ -500,6 +516,13 @@ impl Fingerprintable for Interface<'_> {
         resolved_names: &ResolvedNames,
         options: &FingerprintOptions<'_>,
     ) {
+        if let Some(trivia) = options.trivia_context {
+            for t in PrecedingDocblocks::new(trivia, self.span().start.offset)
+                .important_only(options.important_comment_patterns)
+            {
+                t.value.hash(hasher);
+            }
+        }
         "interface".hash(hasher);
         for attribute_list in &self.attribute_lists {
             attribute_list.fingerprint_with_hasher(hasher, resolved_names, options);
@@ -519,6 +542,13 @@ impl Fingerprintable for Trait<'_> {
         resolved_names: &ResolvedNames,
         options: &FingerprintOptions<'_>,
     ) {
+        if let Some(trivia) = options.trivia_context {
+            for t in PrecedingDocblocks::new(trivia, self.span().start.offset)
+                .important_only(options.important_comment_patterns)
+            {
+                t.value.hash(hasher);
+            }
+        }
         "trait".hash(hasher);
         for attribute_list in &self.attribute_lists {
             attribute_list.fingerprint_with_hasher(hasher, resolved_names, options);
@@ -537,6 +567,13 @@ impl Fingerprintable for Enum<'_> {
         resolved_names: &ResolvedNames,
         options: &FingerprintOptions<'_>,
     ) {
+        if let Some(trivia) = options.trivia_context {
+            for t in PrecedingDocblocks::new(trivia, self.span().start.offset)
+                .important_only(options.important_comment_patterns)
+            {
+                t.value.hash(hasher);
+            }
+        }
         "enum".hash(hasher);
         for attribute_list in &self.attribute_lists {
             attribute_list.fingerprint_with_hasher(hasher, resolved_names, options);

--- a/crates/fingerprint/src/function_like/mod.rs
+++ b/crates/fingerprint/src/function_like/mod.rs
@@ -1,6 +1,7 @@
 use std::hash::Hash;
 
 use mago_names::ResolvedNames;
+use mago_span::HasSpan;
 use mago_syntax::ast::ArrowFunction;
 use mago_syntax::ast::Closure;
 use mago_syntax::ast::ClosureUseClause;
@@ -10,6 +11,7 @@ use mago_syntax::ast::FunctionLikeParameter;
 use mago_syntax::ast::FunctionLikeParameterDefaultValue;
 use mago_syntax::ast::FunctionLikeParameterList;
 use mago_syntax::ast::FunctionLikeReturnTypeHint;
+use mago_syntax::comments::docblock::PrecedingDocblocks;
 
 use crate::FingerprintOptions;
 use crate::Fingerprintable;
@@ -69,6 +71,13 @@ impl Fingerprintable for Function<'_> {
         resolved_names: &ResolvedNames,
         options: &FingerprintOptions<'_>,
     ) {
+        if let Some(trivia) = options.trivia_context {
+            for t in PrecedingDocblocks::new(trivia, self.span().start.offset)
+                .important_only(options.important_comment_patterns)
+            {
+                t.value.hash(hasher);
+            }
+        }
         "function".hash(hasher);
         for attribute_list in &self.attribute_lists {
             attribute_list.fingerprint_with_hasher(hasher, resolved_names, options);

--- a/crates/fingerprint/src/lib.rs
+++ b/crates/fingerprint/src/lib.rs
@@ -4,6 +4,7 @@ use std::hash::Hasher;
 use foldhash::fast::FixedState;
 
 use mago_names::ResolvedNames;
+use mago_syntax::ast::Trivia;
 
 pub mod access;
 pub mod argument;
@@ -102,6 +103,7 @@ pub struct FingerprintOptions<'a> {
     pub include_use_statements: bool,
     pub important_comment_patterns: &'a [&'a str],
     pub signature_only: bool,
+    pub trivia_context: Option<&'a [Trivia<'a>]>,
 }
 
 impl Default for FingerprintOptions<'_> {
@@ -110,6 +112,7 @@ impl Default for FingerprintOptions<'_> {
             include_use_statements: false,
             important_comment_patterns: DEFAULT_IMPORTANT_COMMENT_PATTERNS,
             signature_only: false,
+            trivia_context: None,
         }
     }
 }
@@ -122,7 +125,18 @@ impl<'a> FingerprintOptions<'a> {
 
     #[must_use]
     pub fn strict() -> Self {
-        Self { include_use_statements: true, important_comment_patterns: &[], signature_only: false }
+        Self {
+            include_use_statements: true,
+            important_comment_patterns: &[],
+            signature_only: false,
+            trivia_context: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_trivia_context(mut self, trivia: &'a [Trivia<'a>]) -> Self {
+        self.trivia_context = Some(trivia);
+        self
     }
 
     #[must_use]

--- a/crates/linter/src/rule/clarity/missing_docs.rs
+++ b/crates/linter/src/rule/clarity/missing_docs.rs
@@ -215,7 +215,7 @@ impl MissingDocsRule {
         node: &'a impl HasSpan,
         subject: &'static str,
     ) {
-        let trivia = get_docblock_for_node(program, ctx.source_file, node);
+        let trivia = get_docblock_for_node(program, node);
 
         if trivia.is_none_or(|t| !t.kind.is_docblock()) {
             ctx.collector.report(

--- a/crates/syntax/src/comments/docblock.rs
+++ b/crates/syntax/src/comments/docblock.rs
@@ -1,4 +1,3 @@
-use mago_database::file::File;
 use mago_span::HasSpan;
 
 use crate::ast::Program;
@@ -14,7 +13,6 @@ use crate::ast::TriviaKind;
 /// # Arguments
 ///
 /// * `program` - The program containing the trivia.
-/// * `file` - The file from which the trivia is derived.
 /// * `node` - The node for which to find the preceding docblock comment.
 ///
 /// # Returns
@@ -24,10 +22,9 @@ use crate::ast::TriviaKind;
 #[inline]
 pub fn get_docblock_for_node<'arena>(
     program: &'arena Program<'arena>,
-    file: &File,
     node: impl HasSpan,
 ) -> Option<&'arena Trivia<'arena>> {
-    get_docblock_before_position(file, program.trivia.as_slice(), node.span().start.offset)
+    get_docblock_before_position(program.trivia.as_slice(), node.span().start.offset)
 }
 
 /// Retrieves the docblock comment that appears before a specific position in the source code.
@@ -38,7 +35,6 @@ pub fn get_docblock_for_node<'arena>(
 ///
 /// # Arguments
 ///
-/// * `file` - The file from which the trivia is derived.
 /// * `trivias` - A slice of trivia associated with the source code.
 /// * `node_start_offset` - The start offset of the node for which to find the preceding docblock comment.
 ///
@@ -46,7 +42,6 @@ pub fn get_docblock_for_node<'arena>(
 ///
 /// An `Option` containing a reference to the `Trivia` representing the docblock comment if found,
 pub fn get_docblock_before_position<'arena>(
-    file: &File,
     trivias: &'arena [Trivia<'arena>],
     node_start_offset: u32,
 ) -> Option<&'arena Trivia<'arena>> {
@@ -58,18 +53,16 @@ pub fn get_docblock_before_position<'arena>(
     // Track the earliest position we've "covered" by trivia.
     // Start from node_start_offset and work backwards.
     // As we iterate, we verify that each trivia connects to the next (no code gaps).
+    // Since the parser captures all whitespace as WhiteSpace trivia, any gap not covered
+    // by a trivia node is actual code, so we just check for contiguity.
     let mut covered_from = node_start_offset;
 
     for i in (0..candidate_partition_idx).rev() {
         let trivia = &trivias[i];
         let trivia_end = trivia.span.end_offset();
 
-        // Check if there's a gap between this trivia and our covered region.
-        // If there's non-whitespace content in the gap, there's actual code between them.
-        let gap_slice = file.contents.as_bytes().get(trivia_end as usize..covered_from as usize).unwrap_or(&[]);
-
-        if !gap_slice.iter().all(u8::is_ascii_whitespace) {
-            // There's actual code in the gap. No docblock applies.
+        if trivia_end != covered_from {
+            // Gap between this trivia and our covered region contains code.
             return None;
         }
 
@@ -89,4 +82,40 @@ pub fn get_docblock_before_position<'arena>(
 
     // Iterated through all preceding trivia without finding a suitable docblock.
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use bumpalo::Bump;
+    use mago_database::file::FileId;
+    use mago_span::HasSpan;
+
+    use crate::parser::parse_file_content;
+
+    use super::get_docblock_before_position;
+
+    #[test]
+    fn whitespace_between_docblock_and_class_is_trivia() {
+        // The parser emits WhiteSpace trivia for all whitespace, so there is no
+        // code gap between the docblock's end offset and the class's start offset.
+        // This verifies the assumption that strict trivia contiguity == no code gap.
+        let arena = Bump::new();
+        let program = parse_file_content(&arena, FileId::zero(), "<?php\n\n/** @return int */\n\nclass Foo {}");
+        // statements[0] is the <?php opening tag; statements[1] is the class.
+        let class_start = program.statements.iter().nth(1).unwrap().span().start.offset;
+        let docblock = get_docblock_before_position(program.trivia.as_slice(), class_start);
+        assert!(docblock.is_some(), "expected docblock to be found across whitespace");
+        assert!(docblock.unwrap().value.contains("@return int"));
+    }
+
+    #[test]
+    fn code_between_docblock_and_function_blocks_attribution() {
+        let arena = Bump::new();
+        let program =
+            parse_file_content(&arena, FileId::zero(), "<?php\n/** @return int */\necho 1;\nfunction foo() {}");
+        // statements: [0]=OpeningTag, [1]=Echo, [2]=Function
+        let func_start = program.statements.iter().nth(2).unwrap().span().start.offset;
+        let docblock = get_docblock_before_position(program.trivia.as_slice(), func_start);
+        assert!(docblock.is_none(), "expected no docblock when code intervenes");
+    }
 }

--- a/crates/syntax/src/comments/docblock.rs
+++ b/crates/syntax/src/comments/docblock.rs
@@ -4,6 +4,48 @@ use crate::ast::Program;
 use crate::ast::Trivia;
 use crate::ast::TriviaKind;
 
+/// An iterator that yields docblock trivia nodes preceding a position, walking
+/// backwards through stacked docblocks using the same gap-checking logic as
+/// `get_docblock_before_position`.
+///
+/// By default all docblocks are yielded. Call `important_only(patterns)` to
+/// restrict the iterator to docblocks whose text contains at least one of the
+/// given substrings, skipping non-matching entries rather than stopping.
+pub struct PrecedingDocblocks<'arena, 'pat> {
+    trivia: &'arena [Trivia<'arena>],
+    start: u32,
+    important_patterns: &'pat [&'pat str],
+}
+
+impl<'arena> PrecedingDocblocks<'arena, 'static> {
+    pub fn new(trivia: &'arena [Trivia<'arena>], start_offset: u32) -> Self {
+        Self { trivia, start: start_offset, important_patterns: &[] }
+    }
+}
+
+impl<'arena, 'pat> PrecedingDocblocks<'arena, 'pat> {
+    /// Restrict this iterator to docblocks whose text contains at least one of
+    /// `patterns`. Non-matching docblocks are skipped; the search continues
+    /// backward past them.
+    pub fn important_only<'new_pat>(self, patterns: &'new_pat [&'new_pat str]) -> PrecedingDocblocks<'arena, 'new_pat> {
+        PrecedingDocblocks { trivia: self.trivia, start: self.start, important_patterns: patterns }
+    }
+}
+
+impl<'arena, 'pat> Iterator for PrecedingDocblocks<'arena, 'pat> {
+    type Item = &'arena Trivia<'arena>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let trivia = get_docblock_before_position(self.trivia, self.start)?;
+            self.start = trivia.span.start_offset();
+            if self.important_patterns.is_empty() || self.important_patterns.iter().any(|p| trivia.value.contains(*p)) {
+                return Some(trivia);
+            }
+        }
+    }
+}
+
 /// Retrieves the docblock comment associated with a given node in the program.
 /// If the node is preceded by a docblock comment, it returns that comment.
 ///


### PR DESCRIPTION
## 📌 What Does This PR Do?

This fixes changes to parent class docblocks not propagating to child classes in watch mode. This base issue is that changes to the docblock did not affect the class/method signature, so no propagation was triggered. This can be fixed by incorporating the docblock into the fingerprint for the relevant elements. Additionally, the types on the child classes need to be marked as inferred, otherwise they wouldn't re-inherit the parent docblock on subsequent analysis runs.

## 🔍 Context & Motivation

Watch mode currently doesn't pick up on those changes, giving false results.

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed docblock changes not propagating to child classes in watch mode.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): analyzer

## 🔗 Related Issues or PRs

none

## 📝 Notes for Reviewers

ty for the hints on the implementation, hope I didn't butcher it too much :D
