### PR TITLE
refactor(codex): use Vec instead of HashMap for template_variance

### DIFF
--- a/crates/analyzer/src/statement/class_like/mod.rs
+++ b/crates/analyzer/src/statement/class_like/mod.rs
@@ -1690,7 +1690,7 @@ fn check_template_parameters<'ctx>(
 
             if parent_metadata
                 .template_variance
-                .get(&i)
+                .get(i)
                 .is_some_and(mago_codex::ttype::template::variance::Variance::is_invariant)
             {
                 for extended_type_atomic in extended_type.types.as_ref() {
@@ -1708,7 +1708,7 @@ fn check_template_parameters<'ctx>(
 
                     if class_like_metadata
                         .template_variance
-                        .get(&local_offset)
+                        .get(local_offset)
                         .is_some_and(mago_codex::ttype::template::variance::Variance::is_covariant)
                     {
                         let child_template_name = generic_parameter.parameter_name;

--- a/crates/codex/src/metadata/class_like.rs
+++ b/crates/codex/src/metadata/class_like.rs
@@ -1,4 +1,3 @@
-use foldhash::HashMap;
 use foldhash::fast::RandomState;
 use indexmap::IndexMap;
 use serde::Deserialize;
@@ -54,7 +53,7 @@ pub struct ClassLikeMetadata {
     pub kind: SymbolKind,
     pub template_types: TemplateTypes,
     pub template_readonly: AtomSet,
-    pub template_variance: HashMap<usize, Variance>,
+    pub template_variance: Vec<Variance>,
     pub template_extended_offsets: AtomMap<Vec<TUnion>>,
     pub template_extended_parameters: AtomMap<IndexMap<Atom, TUnion, RandomState>>,
     pub template_type_extends_count: AtomMap<usize>,
@@ -132,7 +131,7 @@ impl ClassLikeMetadata {
             overridden_method_ids: AtomMap::default(),
             overridden_property_ids: AtomMap::default(),
             properties: AtomMap::default(),
-            template_variance: HashMap::default(),
+            template_variance: Vec::new(),
             template_type_extends_count: AtomMap::default(),
             template_extended_parameters: AtomMap::default(),
             template_extended_offsets: AtomMap::default(),
@@ -304,10 +303,10 @@ impl ClassLikeMetadata {
         self.template_types.insert(name, constraint);
     }
 
-    /// Adds or updates the variance for a specific parameter index. Returns the previous variance if one existed.
+    /// Set the variance for the template parameters
     #[inline]
-    pub fn add_template_variance_parameter(&mut self, index: usize, variance: Variance) -> Option<Variance> {
-        self.template_variance.insert(index, variance)
+    pub fn set_template_variance(&mut self, template_variance: Vec<Variance>) {
+        self.template_variance = template_variance;
     }
 
     /// Adds or replaces the offset types for a specific template parameter name.

--- a/crates/codex/src/scanner/class_like.rs
+++ b/crates/codex/src/scanner/class_like.rs
@@ -464,7 +464,8 @@ fn scan_class_like<'arena>(
         class_like_metadata.has_sealed_methods = docblock.has_sealed_methods;
         class_like_metadata.has_sealed_properties = docblock.has_sealed_properties;
 
-        for (i, template) in docblock.templates.iter().enumerate() {
+        let mut template_variance = Vec::new();
+        for template in &docblock.templates {
             let template_name = atom(&template.name);
             let template_as_type = if let Some(type_string) = &template.type_string {
                 match builder::get_type_from_string(
@@ -511,8 +512,10 @@ fn scan_class_like<'arena>(
                 class_like_metadata.template_readonly.insert(template_name);
             }
 
-            class_like_metadata.add_template_variance_parameter(i, variance);
+            template_variance.push(variance);
         }
+
+        class_like_metadata.set_template_variance(template_variance);
 
         // Process imported type aliases first so they're available when building
         // type alias definitions AND when resolving @template-extends/@template-implements

--- a/crates/codex/src/ttype/combiner.rs
+++ b/crates/codex/src/ttype/combiner.rs
@@ -1416,7 +1416,7 @@ fn get_combiner_key(name: Atom, type_params: &[TUnion], codebase: &CodebaseMetad
             estimated_len += 2; // ", "
         }
 
-        if covariants.get(&i) == Some(&Variance::Covariant) {
+        if covariants.get(i) == Some(&Variance::Covariant) {
             estimated_len += 1; // "*"
         } else {
             estimated_len += tunion.get_id().len();
@@ -1439,7 +1439,7 @@ fn get_combiner_key(name: Atom, type_params: &[TUnion], codebase: &CodebaseMetad
                 pos += 2;
             }
             let param_str =
-                if covariants.get(&i) == Some(&Variance::Covariant) { "*" } else { tunion.get_id().as_str() };
+                if covariants.get(i) == Some(&Variance::Covariant) { "*" } else { tunion.get_id().as_str() };
             buffer[pos..pos + param_str.len()].copy_from_slice(param_str.as_bytes());
             pos += param_str.len();
         }
@@ -1458,7 +1458,7 @@ fn get_combiner_key(name: Atom, type_params: &[TUnion], codebase: &CodebaseMetad
         if i > 0 {
             result.push_str(", ");
         }
-        if covariants.get(&i) == Some(&Variance::Covariant) {
+        if covariants.get(i) == Some(&Variance::Covariant) {
             result.push('*');
         } else {
             result.push_str(tunion.get_id().as_str());

--- a/crates/codex/src/ttype/comparator/generic_comparator.rs
+++ b/crates/codex/src/ttype/comparator/generic_comparator.rs
@@ -75,7 +75,7 @@ pub(crate) fn is_contained_by(
             false,
             &mut parameter_comparison_result,
         ) {
-            if let Some(Variance::Contravariant) = container_metadata.template_variance.get(&parameter_offset)
+            if let Some(Variance::Contravariant) = container_metadata.template_variance.get(parameter_offset)
                 && union_comparator::is_contained_by(
                     codebase,
                     container_type_parameter,

--- a/crates/codex/src/ttype/template/standin_type_replacer.rs
+++ b/crates/codex/src/ttype/template/standin_type_replacer.rs
@@ -397,7 +397,7 @@ fn replace_atomic(
                     };
 
                     let is_covariant = if let Some(class_like_metadata) = codebase.get_class_like(&object_name) {
-                        matches!(class_like_metadata.template_variance.get(&offset), Some(Variance::Covariant))
+                        matches!(class_like_metadata.template_variance.get(offset), Some(Variance::Covariant))
                     } else {
                         false
                     };


### PR DESCRIPTION
## 📌 What Does This PR Do?

Replace `HashMap<usize, Variance>` with `Vec<Variance>` for the
`template_variance` field in `ClassLikeMetadata`.

## 🔍 Context & Motivation
Template parameter indices are always 0..N (positions in the
`template_types` IndexMap), so the keys are never sparse. Using a
`HashMap` allocates more than necessary and requires hashing for what
are effectively sequential slot lookups.

## 🛠️ Summary of Changes

- **Refactor:** Replaced `HashMap<usize, Variance>` with `Vec<Variance>`
  in `ClassLikeMetadata` and updated all affected call sites.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [x] Other: codex / type system internals

## 🔗 Related Issues or PRs

noppidy

## 📝 Notes for Reviewers

:train: 