### PR TITLE
fix(incremental): re-analyze global-scope files when dependencies change

### DIFF
--- a/crates/codex/src/metadata/mod.rs
+++ b/crates/codex/src/metadata/mod.rs
@@ -908,14 +908,11 @@ impl CodebaseMetadata {
     /// * `references` - Symbol reference graph from previous run
     ///
     /// # Returns
-    ///
-    /// `true` if safe symbols were successfully marked, or `false` if the cascade was too large to compute.
-    pub fn mark_safe_symbols(&mut self, diff: &CodebaseDiff, references: &SymbolReferences) -> bool {
-        // Get invalid symbols with propagation through reference graph
-        let Some((invalid_symbols, partially_invalid)) = references.get_invalid_symbols(diff) else {
-            // Propagation too expensive (>5000 steps)
-            return false;
-        };
+    /// Returns `Some(global_scope_invalid)` on success, where `global_scope_invalid`
+    /// is `true` when global-scope code (the `(empty, empty)` pseudo-symbol) references
+    /// something that changed. Returns `None` if the cascade was too large to compute.
+    pub fn mark_safe_symbols(&mut self, diff: &CodebaseDiff, references: &SymbolReferences) -> Option<bool> {
+        let (invalid_symbols, partially_invalid) = references.get_invalid_symbols(diff)?;
 
         // Mark all symbols in 'keep' set as safe (unless invalidated by cascade)
         for keep_symbol in diff.get_keep() {
@@ -932,7 +929,7 @@ impl CodebaseMetadata {
             }
         }
 
-        true
+        Some(invalid_symbols.contains(&(empty_atom(), empty_atom())))
     }
 
     /// Merges information from another `CodebaseMetadata` into this one.

--- a/crates/orchestrator/src/service/incremental_analysis.rs
+++ b/crates/orchestrator/src/service/incremental_analysis.rs
@@ -630,11 +630,11 @@ impl IncrementalAnalysisService {
         merged_codebase.safe_symbols.clear();
         merged_codebase.safe_symbol_members.clear();
 
-        if !merged_codebase.mark_safe_symbols(&diff, &self.symbol_references) {
+        let Some(global_scope_invalid) = merged_codebase.mark_safe_symbols(&diff, &self.symbol_references) else {
             tracing::warn!("Invalidation cascade too expensive (>5000 steps), falling back to full analysis");
 
             return self.analyze();
-        }
+        };
 
         // Ensure classes that depend on changed class_likes are not marked safe.
         // This handles cases where reference graph edges were lost (e.g., a parent
@@ -699,13 +699,22 @@ impl IncrementalAnalysisService {
         let mut files_to_skip: HashSet<FileId> = HashSet::default();
         for &file_id in &unchanged_file_ids {
             if let Some(sig) = merged_codebase.get_file_signature(&file_id) {
-                let all_safe = sig.ast_nodes.iter().all(|node| {
-                    let symbol_safe = node.name.is_empty() || merged_codebase.safe_symbols.contains(&node.name);
-                    let children_safe = node.children.iter().all(|child| {
-                        child.name.is_empty() || merged_codebase.safe_symbol_members.contains(&(node.name, child.name))
-                    });
-                    symbol_safe && children_safe
-                });
+                let all_safe = if sig.ast_nodes.is_empty() {
+                    // A file with no named top-level symbols contains only
+                    // global-scope code. Global-scope code is tracked under the
+                    // (empty, empty) pseudo-symbol in the reference graph, so
+                    // check whether that pseudo-symbol was invalidated.
+                    !global_scope_invalid
+                } else {
+                    sig.ast_nodes.iter().all(|node| {
+                        let symbol_safe = node.name.is_empty() || merged_codebase.safe_symbols.contains(&node.name);
+                        let children_safe = node.children.iter().all(|child| {
+                            child.name.is_empty()
+                                || merged_codebase.safe_symbol_members.contains(&(node.name, child.name))
+                        });
+                        symbol_safe && children_safe
+                    })
+                };
 
                 if all_safe {
                     files_to_skip.insert(file_id);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes watch mode for files that have code just running in the global namespace.

## 🔍 Context & Motivation

Testing changes on mago itself. I often don't want to bother with writing class files and stuff and just have a `src.php` that just has a code snippet to play around with. Currently that doesn't work with watch mode.

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed watch mode for simple script-like files.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [x] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Nope

## 📝 Notes for Reviewers

:asterisk: 