### PR TITLE
feat(linter/safety): add glob pattern support to no-service-state-mutation namespace filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .mago/
 /corpus/vendor/
 /corpus/composer.lock
+.worktrees

--- a/crates/linter/src/rule/safety/no_service_state_mutation.rs
+++ b/crates/linter/src/rule/safety/no_service_state_mutation.rs
@@ -17,6 +17,7 @@ use crate::integration::Integration;
 use crate::requirements::RuleRequirements;
 use crate::rule::Config;
 use crate::rule::LintRule;
+use crate::rule::utils::namespace_pattern::matches_namespace_pattern;
 use crate::rule_meta::RuleMeta;
 use crate::settings::RuleSettings;
 
@@ -30,7 +31,9 @@ pub struct NoServiceStateMutationRule {
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct NoServiceStateMutationConfig {
     pub level: Level,
+    /// Namespaces to include. Supports glob patterns: `*`, `**`, `{A,B}`.
     pub include_namespaces: Vec<String>,
+    /// Namespaces to exclude. Supports glob patterns: `*`, `**`, `{A,B}`.
     pub exclude_namespaces: Vec<String>,
     pub allowed_methods: Vec<String>,
     pub reset_interfaces: Vec<String>,
@@ -122,6 +125,12 @@ impl LintRule for NoServiceStateMutationRule {
                 array append (`$this->items[] = $item`), and `unset($this->cache)`.
 
                 The `__construct` and `reset` methods are allowed by default.
+
+                Both `include-namespaces` and `exclude-namespaces` support glob patterns: `*` matches a
+                single namespace segment, `**` matches any number of segments, partial wildcards like
+                `*Repository` match within a segment, and brace expansion like `App\{Entity,DTO}\`
+                matches multiple alternatives. Plain prefix patterns (e.g. `App\Entity\`) continue to
+                work as before.
             "},
             good_example: indoc! {r"
                 <?php
@@ -197,17 +206,14 @@ impl LintRule for NoServiceStateMutationRule {
             return;
         }
 
-        let matches_pattern = |ns: &str, pattern: &str| {
-            ns.starts_with(pattern)
-                || (ns.len() + 1 >= pattern.len() && pattern.ends_with('\\') && pattern[..pattern.len() - 1] == *ns)
-        };
-
-        let in_include = self.cfg.include_namespaces.iter().any(|p| matches_pattern(namespace, p.as_str()));
+        let in_include =
+            self.cfg.include_namespaces.iter().any(|p| matches_namespace_pattern(namespace, p.as_str(), false, true));
         if !in_include {
             return;
         }
 
-        let in_exclude = self.cfg.exclude_namespaces.iter().any(|p| matches_pattern(namespace, p.as_str()));
+        let in_exclude =
+            self.cfg.exclude_namespaces.iter().any(|p| matches_namespace_pattern(namespace, p.as_str(), false, true));
         if in_exclude {
             return;
         }
@@ -914,6 +920,100 @@ mod tests {
                         'id' => $this->id,
                         'name' => $this->name,
                     ];
+                }
+            }
+        "#},
+    }
+
+    test_lint_success! {
+        name = exclude_namespaces_double_wildcard,
+        rule = NoServiceStateMutationRule,
+        settings = |s: &mut Settings| {
+            s.integrations.insert(Integration::Symfony);
+            s.rules.no_service_state_mutation.config.include_namespaces = vec!["App\\".to_string()];
+            s.rules.no_service_state_mutation.config.exclude_namespaces = vec!["App\\Domain\\**".to_string()];
+        },
+        code = indoc! {r#"
+            <?php
+
+            namespace App\Domain\Model\User;
+
+            class UserCollection
+            {
+                public function add(): void
+                {
+                    $this->count++;
+                }
+            }
+        "#},
+    }
+
+    test_lint_success! {
+        name = exclude_namespaces_single_wildcard,
+        rule = NoServiceStateMutationRule,
+        settings = |s: &mut Settings| {
+            s.integrations.insert(Integration::Symfony);
+            s.rules.no_service_state_mutation.config.include_namespaces = vec!["App\\".to_string()];
+            s.rules.no_service_state_mutation.config.exclude_namespaces = vec!["App\\*".to_string()];
+        },
+        code = indoc! {r#"
+            <?php
+
+            namespace App\Domain;
+
+            class SomeModel
+            {
+                public function setName(string $name): void
+                {
+                    $this->name = $name;
+                }
+            }
+        "#},
+    }
+
+    test_lint_success! {
+        name = exclude_namespaces_brace_expansion,
+        rule = NoServiceStateMutationRule,
+        settings = |s: &mut Settings| {
+            s.integrations.insert(Integration::Symfony);
+            s.rules.no_service_state_mutation.config.include_namespaces = vec!["App\\".to_string()];
+            s.rules.no_service_state_mutation.config.exclude_namespaces =
+                vec!["App\\{Entity,DTO,ValueObject}\\".to_string()];
+        },
+        code = indoc! {r#"
+            <?php
+
+            namespace App\DTO;
+
+            class OrderData
+            {
+                public function setTotal(int $total): void
+                {
+                    $this->total = $total;
+                }
+            }
+        "#},
+    }
+
+    test_lint_failure! {
+        name = include_namespaces_single_wildcard,
+        rule = NoServiceStateMutationRule,
+        count = 1,
+        settings = |s: &mut Settings| {
+            s.integrations.insert(Integration::Symfony);
+            s.rules.no_service_state_mutation.config.include_namespaces = vec!["App\\*\\Service".to_string()];
+            s.rules.no_service_state_mutation.config.exclude_namespaces = vec![];
+        },
+        code = indoc! {r#"
+            <?php
+
+            namespace App\Billing\Service;
+
+            class InvoiceService
+            {
+                public function process(): void
+                {
+                    $this->count++;
                 }
             }
         "#},

--- a/crates/linter/src/rule/utils/mod.rs
+++ b/crates/linter/src/rule/utils/mod.rs
@@ -3,6 +3,7 @@ pub mod consts;
 pub mod isset;
 pub mod laravel;
 pub mod misc;
+pub mod namespace_pattern;
 pub mod pest;
 pub mod phpunit;
 pub mod security;

--- a/crates/linter/src/rule/utils/namespace_pattern.rs
+++ b/crates/linter/src/rule/utils/namespace_pattern.rs
@@ -1,0 +1,199 @@
+use mago_atom::starts_with_ignore_case;
+
+const SEPARATOR: char = '\\';
+
+pub fn matches_namespace_pattern(fqcn: &str, pattern: &str, is_constant: bool, treat_as_namespace: bool) -> bool {
+    if pattern.contains('{') {
+        return expand_braces(pattern)
+            .iter()
+            .any(|p| matches_namespace_pattern(fqcn, p, is_constant, treat_as_namespace));
+    }
+
+    if !pattern.contains('*') {
+        let p = pattern.trim_matches(SEPARATOR);
+        let f = fqcn.trim_matches(SEPARATOR);
+
+        if p.is_empty() {
+            return f.is_empty();
+        }
+
+        if treat_as_namespace || pattern.ends_with(SEPARATOR) {
+            if !starts_with_ignore_case(f, p) {
+                return false;
+            }
+
+            return f.len() == p.len() || f.as_bytes().get(p.len()) == Some(&(SEPARATOR as u8));
+        }
+
+        if is_constant {
+            let f_last = f.rsplit_once(SEPARATOR);
+            let p_last = p.rsplit_once(SEPARATOR);
+
+            return match (f_last, p_last) {
+                (Some((f_ns, f_name)), Some((p_ns, p_name))) => f_ns.eq_ignore_ascii_case(p_ns) && f_name == p_name,
+                (None, None) => f == p,
+                _ => false,
+            };
+        }
+        return f.eq_ignore_ascii_case(p);
+    }
+
+    let fqcn = fqcn.trim_matches(SEPARATOR);
+    let pattern = pattern.trim_matches(SEPARATOR);
+
+    if pattern == "**" {
+        return true;
+    }
+
+    if pattern == "*" {
+        return !fqcn.contains(SEPARATOR);
+    }
+
+    if fqcn.is_empty() || pattern.is_empty() {
+        return fqcn == pattern;
+    }
+
+    let fqcn_parts: Vec<&str> = fqcn.split(SEPARATOR).collect();
+    let pattern_parts: Vec<&str> = pattern.split(SEPARATOR).collect();
+
+    do_match(&fqcn_parts, &pattern_parts, is_constant)
+}
+
+fn do_match(fqcn_parts: &[&str], pattern_parts: &[&str], is_constant: bool) -> bool {
+    match (fqcn_parts.first(), pattern_parts.first()) {
+        (None, None) => true,
+        (_, Some(&"**")) => {
+            if pattern_parts.len() == 1 {
+                return true;
+            }
+            if fqcn_parts.is_empty() {
+                return do_match(fqcn_parts, &pattern_parts[1..], is_constant);
+            }
+            do_match(fqcn_parts, &pattern_parts[1..], is_constant)
+                || do_match(&fqcn_parts[1..], pattern_parts, is_constant)
+        }
+        (Some(f_part), Some(p_part)) => {
+            let is_last = fqcn_parts.len() == 1 && pattern_parts.len() == 1;
+            let case_sensitive = is_constant && is_last;
+
+            if segment_matches(f_part, p_part, case_sensitive) {
+                do_match(&fqcn_parts[1..], &pattern_parts[1..], is_constant)
+            } else {
+                false
+            }
+        }
+        (None, Some(_)) => pattern_parts.len() == 1 && pattern_parts[0] == "**",
+        _ => false,
+    }
+}
+
+fn segment_matches(fqcn_part: &str, pattern_part: &str, case_sensitive: bool) -> bool {
+    if pattern_part == "*" {
+        return true;
+    }
+    if !pattern_part.contains('*') {
+        return if case_sensitive { fqcn_part == pattern_part } else { fqcn_part.eq_ignore_ascii_case(pattern_part) };
+    }
+
+    let p_chunks: Vec<&str> = pattern_part.split('*').collect();
+    let mut remainder = fqcn_part;
+
+    if !p_chunks[0].is_empty() {
+        if remainder.len() < p_chunks[0].len() {
+            return false;
+        }
+        let prefix = &remainder[..p_chunks[0].len()];
+        if !(if case_sensitive { prefix == p_chunks[0] } else { prefix.eq_ignore_ascii_case(p_chunks[0]) }) {
+            return false;
+        }
+        remainder = &remainder[p_chunks[0].len()..];
+    }
+
+    let last_chunk = p_chunks.last().unwrap();
+    if !last_chunk.is_empty() {
+        if remainder.len() < last_chunk.len() {
+            return false;
+        }
+        let suffix = &remainder[remainder.len() - last_chunk.len()..];
+        if !(if case_sensitive { suffix == *last_chunk } else { suffix.eq_ignore_ascii_case(last_chunk) }) {
+            return false;
+        }
+        remainder = &remainder[..remainder.len() - last_chunk.len()];
+    }
+
+    for chunk in &p_chunks[1..p_chunks.len() - 1] {
+        if chunk.is_empty() {
+            continue;
+        }
+        let found = if case_sensitive { remainder.find(chunk) } else { find_ignore_ascii_case(remainder, chunk) };
+        if let Some(pos) = found {
+            remainder = &remainder[pos + chunk.len()..];
+        } else {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn find_ignore_ascii_case(haystack: &str, needle: &str) -> Option<usize> {
+    if needle.is_empty() {
+        return Some(0);
+    }
+    haystack.as_bytes().windows(needle.len()).position(|window| window.eq_ignore_ascii_case(needle.as_bytes()))
+}
+
+fn expand_braces(pattern: &str) -> Vec<String> {
+    let Some(open) = pattern.find('{') else {
+        return vec![pattern.to_string()];
+    };
+
+    let mut depth = 0;
+    let mut close = None;
+    for (i, ch) in pattern[open..].char_indices() {
+        match ch {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    close = Some(open + i);
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let Some(close) = close else {
+        return vec![pattern.to_string()];
+    };
+
+    let prefix = &pattern[..open];
+    let suffix = &pattern[close + 1..];
+    let alternatives = &pattern[open + 1..close];
+
+    let mut parts = Vec::new();
+    let mut depth = 0;
+    let mut start = 0;
+    for (i, ch) in alternatives.char_indices() {
+        match ch {
+            '{' => depth += 1,
+            '}' => depth -= 1,
+            ',' if depth == 0 => {
+                parts.push(&alternatives[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+
+    parts.push(&alternatives[start..]);
+
+    let mut results = Vec::with_capacity(parts.len());
+    for part in parts {
+        let expanded = format!("{prefix}{part}{suffix}");
+        results.extend(expand_braces(&expanded));
+    }
+
+    results
+}

--- a/crates/linter/src/rule/utils/namespace_pattern.rs
+++ b/crates/linter/src/rule/utils/namespace_pattern.rs
@@ -109,13 +109,13 @@ fn segment_matches(fqcn_part: &str, pattern_part: &str, case_sensitive: bool) ->
         remainder = &remainder[p_chunks[0].len()..];
     }
 
-    let last_chunk = p_chunks.last().unwrap();
+    let last_chunk: &str = p_chunks.last().copied().unwrap_or("");
     if !last_chunk.is_empty() {
         if remainder.len() < last_chunk.len() {
             return false;
         }
         let suffix = &remainder[remainder.len() - last_chunk.len()..];
-        if !(if case_sensitive { suffix == *last_chunk } else { suffix.eq_ignore_ascii_case(last_chunk) }) {
+        if !(if case_sensitive { suffix == last_chunk } else { suffix.eq_ignore_ascii_case(last_chunk) }) {
             return false;
         }
         remainder = &remainder[..remainder.len() - last_chunk.len()];


### PR DESCRIPTION
## Summary

Adds glob pattern support to `include-namespaces` and `exclude-namespaces` in the `no-service-state-mutation` linter rule.

**Motivation:** In Symfony projects, data-container classes (Entities, DTOs, Value Objects) live under namespaces like `App\Entity` or `App\Dto` and naturally mutate state — they should be excluded from this rule. The previous prefix-only matching works for flat namespace structures but breaks down for deeper hierarchies. A project might need to exclude `App\Entity\User\`, `App\Entity\Order\`, etc., which required enumerating every sub-namespace explicitly.

**What changed:**

- New `crates/linter/src/rule/utils/namespace_pattern.rs` — a namespace FQN pattern matcher extracted from the guard crate's `matcher.rs`, supporting `*`, `**`, partial wildcards, and brace expansion. Placed in `rule/utils/` so other linter rules can reuse it.
- `no_service_state_mutation.rs` — replaces the old `starts_with`-based closure with `matches_namespace_pattern(..., false, true)`. Backward-compatible: existing patterns like `App\Entity\` continue to match as namespace prefixes.
- `RuleMeta` description updated to document the new pattern syntax.
- 4 new test cases covering `**`, `*`, brace expansion, and the new `include-namespaces` wildcard path.
- Docs regenerated via `just doc-linter-rules`.

**Example config:**
```toml
[linter.rules.no-service-state-mutation]
exclude-namespaces = [
  "App\\{Entity,DTO,ValueObject}\\",
  "App\\Domain\\**",
]
```

## Test plan

- [x] `cargo test -p mago-linter no_service_state_mutation` — 34 tests pass (30 existing + 4 new)
- [x] `just fix` — no clippy warnings, formatting clean
- [x] `just doc-linter-rules` — docs regenerated, glob paragraph visible in `docs/tools/linter/rules/safety.md`

Closes #1745