### PR TITLE
fix(analyzer): report non-existent-class-like for `::class` on undefined classes

### DIFF
--- a/crates/analyzer/src/expression/access/class_constant_access.rs
+++ b/crates/analyzer/src/expression/access/class_constant_access.rs
@@ -190,6 +190,18 @@ mod tests {
     }
 
     test_analysis! {
+        name = class_magic_constant_on_undefined_class,
+        code = indoc! {"
+            <?php
+
+            $_ = NonExistentClass::class;
+        "},
+        issues = [
+            IssueCode::NonExistentClassLike,
+        ]
+    }
+
+    test_analysis! {
         name = const_access_on_generic_object_type,
         code = indoc! {"
             <?php

--- a/crates/analyzer/src/resolver/class_constant.rs
+++ b/crates/analyzer/src/resolver/class_constant.rs
@@ -174,6 +174,12 @@ fn handle_class_magic_constant<'ctx, 'ast, 'arena>(
 
     let class_string = match class_resolution.fqcn {
         Some(fq_class_id) => {
+            if matches!(class_resolution.origin, ResolutionOrigin::Named { is_self: false, is_parent: false })
+                && context.codebase.get_class_like(&fq_class_id).is_none()
+            {
+                report_non_existent_class(context, fq_class_id, class_expr.span());
+            }
+
             artifacts.symbol_references.add_reference_to_symbol(&block_context.scope, fq_class_id, false);
 
             if class_resolution.is_final


### PR DESCRIPTION
## 📌 What Does This PR Do?

Modifies the analyzer to report `non-existent-class-like` when `Foo::class` refers to a class that doesn't exist.

## 🔍 Context & Motivation

It's a mistake in 99% of cases to refer to a class that doesn't exist like this. The other 1% is when trying to dynamically detect the existence of a class due to an optional dependency or similar.

Reporting this as an error is consistent with PHPStan and Psalm.

## 🛠️ Summary of Changes

- **Bug Fix:** Report `non-existent-class-like` for `::class` on undefined classes

## 📂 Affected Areas

- [x] Analyzer
- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

None

## 📝 Notes for Reviewers

Claude Code was used to help author this PR.
