### PR TITLE
refactor(codex): extract MetadataFlags creation by file type

### DIFF
--- a/crates/codex/src/metadata/flags.rs
+++ b/crates/codex/src/metadata/flags.rs
@@ -1,3 +1,4 @@
+use mago_database::file::FileType;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -323,6 +324,16 @@ impl MetadataFlags {
     #[must_use]
     pub const fn is_polyfill(self) -> bool {
         self.contains(Self::POLYFILL)
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn origin_flags(file_type: FileType) -> Self {
+        match file_type {
+            FileType::Host => Self::USER_DEFINED,
+            FileType::Builtin => Self::BUILTIN,
+            FileType::Vendored => Self::empty(),
+        }
     }
 }
 

--- a/crates/codex/src/scanner/class_like.rs
+++ b/crates/codex/src/scanner/class_like.rs
@@ -315,12 +315,7 @@ fn scan_class_like<'arena>(
         return None;
     }
 
-    let mut flags = MetadataFlags::empty();
-    if context.file.file_type.is_host() {
-        flags |= MetadataFlags::USER_DEFINED;
-    } else if context.file.file_type.is_builtin() {
-        flags |= MetadataFlags::BUILTIN;
-    }
+    let flags = MetadataFlags::origin_flags(context.file.file_type);
 
     let mut class_like_metadata = ClassLikeMetadata::new(name, original_name, span, name_span, flags);
 

--- a/crates/codex/src/scanner/class_like_constant.rs
+++ b/crates/codex/src/scanner/class_like_constant.rs
@@ -43,11 +43,7 @@ pub fn scan_class_like_constants<'arena>(
         constant.hint.as_ref().map(|h| get_type_metadata_from_hint(h, Some(class_like_metadata.name), context));
 
     let mut flags = if is_final { MetadataFlags::FINAL } else { MetadataFlags::empty() };
-    if context.file.file_type.is_host() {
-        flags |= MetadataFlags::USER_DEFINED;
-    } else if context.file.file_type.is_builtin() {
-        flags |= MetadataFlags::BUILTIN;
-    }
+    flags |= MetadataFlags::origin_flags(context.file.file_type);
 
     let docblock = match ConstantDocblockComment::create(context, constant) {
         Ok(docblock) => docblock,

--- a/crates/codex/src/scanner/constant.rs
+++ b/crates/codex/src/scanner/constant.rs
@@ -31,12 +31,7 @@ pub fn scan_constant<'arena>(
     let attributes = scan_attribute_lists(&constant.attribute_lists, context);
     let docblock = ConstantDocblockComment::create(context, constant);
 
-    let mut flags = MetadataFlags::empty();
-    if context.file.file_type.is_host() {
-        flags |= MetadataFlags::USER_DEFINED;
-    } else if context.file.file_type.is_builtin() {
-        flags |= MetadataFlags::BUILTIN;
-    }
+    let flags = MetadataFlags::origin_flags(context.file.file_type);
 
     constant
         .items
@@ -86,12 +81,7 @@ pub fn scan_defined_constant<'arena>(
     let docblock = ConstantDocblockComment::create(context, define);
 
     let name = ascii_lowercase_constant_name_atom(name_string.value?);
-    let mut flags = MetadataFlags::empty();
-    if context.file.file_type.is_host() {
-        flags |= MetadataFlags::USER_DEFINED;
-    } else if context.file.file_type.is_builtin() {
-        flags |= MetadataFlags::BUILTIN;
-    }
+    let flags = MetadataFlags::origin_flags(context.file.file_type);
 
     let mut metadata = ConstantMetadata::new(name, define.span(), flags);
     metadata.inferred_type = infer(context, scope, value_arg.value(), None);

--- a/crates/codex/src/scanner/enum_case.rs
+++ b/crates/codex/src/scanner/enum_case.rs
@@ -26,11 +26,7 @@ pub fn scan_enum_case<'arena>(
     match &case.item {
         EnumCaseItem::Unit(item) => {
             let mut flags = MetadataFlags::UNIT_ENUM_CASE;
-            if context.file.file_type.is_host() {
-                flags |= MetadataFlags::USER_DEFINED;
-            } else if context.file.file_type.is_builtin() {
-                flags |= MetadataFlags::BUILTIN;
-            }
+            flags |= MetadataFlags::origin_flags(context.file.file_type);
 
             let mut meta = EnumCaseMetadata::new(atom(item.name.value), item.name.span, span, flags);
 
@@ -40,11 +36,7 @@ pub fn scan_enum_case<'arena>(
         }
         EnumCaseItem::Backed(item) => {
             let mut flags = MetadataFlags::BACKED_ENUM_CASE;
-            if context.file.file_type.is_host() {
-                flags |= MetadataFlags::USER_DEFINED;
-            } else if context.file.file_type.is_builtin() {
-                flags |= MetadataFlags::BUILTIN;
-            }
+            flags |= MetadataFlags::origin_flags(context.file.file_type);
 
             let mut meta = EnumCaseMetadata::new(atom(item.name.value), item.name.span, span, flags);
 

--- a/crates/codex/src/scanner/function_like.rs
+++ b/crates/codex/src/scanner/function_like.rs
@@ -61,12 +61,7 @@ pub fn scan_method<'arena>(
 ) -> FunctionLikeMetadata {
     let span = method.span();
 
-    let mut flags = MetadataFlags::empty();
-    if context.file.file_type.is_host() {
-        flags |= MetadataFlags::USER_DEFINED;
-    } else if context.file.file_type.is_builtin() {
-        flags |= MetadataFlags::BUILTIN;
-    }
+    let mut flags = MetadataFlags::origin_flags(context.file.file_type);
 
     if method.ampersand.is_some() {
         flags |= MetadataFlags::BY_REFERENCE;
@@ -151,12 +146,7 @@ pub fn scan_function<'arena>(
     type_resolution_context: TypeResolutionContext,
     constants: Option<&AtomMap<ConstantMetadata>>,
 ) -> FunctionLikeMetadata {
-    let mut flags = MetadataFlags::empty();
-    if context.file.file_type.is_host() {
-        flags |= MetadataFlags::USER_DEFINED;
-    } else if context.file.file_type.is_builtin() {
-        flags |= MetadataFlags::BUILTIN;
-    }
+    let mut flags = MetadataFlags::origin_flags(context.file.file_type);
 
     if utils::block_has_yield(&function.body) {
         flags |= MetadataFlags::HAS_YIELD;
@@ -217,12 +207,7 @@ pub fn scan_closure<'arena>(
 ) -> FunctionLikeMetadata {
     let span = closure.span();
 
-    let mut flags = MetadataFlags::empty();
-    if context.file.file_type.is_host() {
-        flags |= MetadataFlags::USER_DEFINED;
-    } else if context.file.file_type.is_builtin() {
-        flags |= MetadataFlags::BUILTIN;
-    }
+    let mut flags = MetadataFlags::origin_flags(context.file.file_type);
 
     if utils::block_has_yield(&closure.body) {
         flags |= MetadataFlags::HAS_YIELD;
@@ -269,12 +254,7 @@ pub fn scan_arrow_function<'arena>(
 ) -> FunctionLikeMetadata {
     let span = arrow_function.span();
 
-    let mut flags = MetadataFlags::empty();
-    if context.file.file_type.is_host() {
-        flags |= MetadataFlags::USER_DEFINED;
-    } else if context.file.file_type.is_builtin() {
-        flags |= MetadataFlags::BUILTIN;
-    }
+    let mut flags = MetadataFlags::origin_flags(context.file.file_type);
 
     if utils::expression_has_yield(arrow_function.expression) {
         flags |= MetadataFlags::HAS_YIELD;

--- a/crates/codex/src/scanner/mod.rs
+++ b/crates/codex/src/scanner/mod.rs
@@ -683,11 +683,7 @@ fn finalize_class_like(scanner: &mut Scanner, context: &Context<'_, '_>) {
         class_like_metadata.inheritable_method_ids.insert(constructor_name, constructor_method_id);
 
         let mut flags = MetadataFlags::PURE;
-        if context.file.file_type.is_host() {
-            flags |= MetadataFlags::USER_DEFINED;
-        } else if context.file.file_type.is_builtin() {
-            flags |= MetadataFlags::BUILTIN;
-        }
+        flags |= MetadataFlags::origin_flags(context.file.file_type);
 
         scanner.codebase.function_likes.insert(
             (class_like_metadata.name, constructor_name),

--- a/crates/codex/src/scanner/parameter.rs
+++ b/crates/codex/src/scanner/parameter.rs
@@ -33,12 +33,7 @@ pub fn scan_function_like_parameter_with_constants<'arena>(
     scope: &NamespaceScope,
     constants: Option<&AtomMap<ConstantMetadata>>,
 ) -> FunctionLikeParameterMetadata {
-    let mut flags = MetadataFlags::empty();
-    if context.file.file_type.is_host() {
-        flags |= MetadataFlags::USER_DEFINED;
-    } else if context.file.file_type.is_builtin() {
-        flags |= MetadataFlags::BUILTIN;
-    }
+    let mut flags = MetadataFlags::origin_flags(context.file.file_type);
 
     if parameter.ellipsis.is_some() {
         flags |= MetadataFlags::VARIADIC;

--- a/crates/codex/src/scanner/property.rs
+++ b/crates/codex/src/scanner/property.rs
@@ -44,11 +44,7 @@ pub fn scan_promoted_property<'arena>(
     let name_span = parameter_metadata.get_name_span();
 
     let mut flags = MetadataFlags::PROMOTED_PROPERTY;
-    if context.file.file_type.is_host() {
-        flags |= MetadataFlags::USER_DEFINED;
-    } else if context.file.file_type.is_builtin() {
-        flags |= MetadataFlags::BUILTIN;
-    }
+    flags |= MetadataFlags::origin_flags(context.file.file_type);
 
     if parameter_metadata.flags.has_default() {
         flags |= MetadataFlags::HAS_DEFAULT;
@@ -174,12 +170,7 @@ pub fn scan_properties<'arena>(
         }
     };
 
-    let mut flags = MetadataFlags::empty();
-    if context.file.file_type.is_host() {
-        flags |= MetadataFlags::USER_DEFINED;
-    } else if context.file.file_type.is_builtin() {
-        flags |= MetadataFlags::BUILTIN;
-    }
+    let mut flags = MetadataFlags::origin_flags(context.file.file_type);
 
     match property {
         Property::Plain(plain_property) => plain_property


### PR DESCRIPTION
## 📌 What Does This PR Do?

Adds `MetadataFlags::origin_flags(file_type: FileType) -> Self` and                                                                                   
replaces the repeated if/else chains that set `USER_DEFINED` or                                                                                       
`BUILTIN` flags with calls to this single method.

## 🔍 Context & Motivation

The same five-line if/else block — check `is_host()`, set                                                                                             
`USER_DEFINED`; check `is_builtin()`, set `BUILTIN` — is duplicated
across every scanner: class-likes, constants, enum cases, function-likes,                                                                             
parameters, properties, and the synthesised constructor. The duplication                                                                              
is pure boilerplate with no per-site variation, making it a clear                                                                                     
candidate for extraction.

## 🛠️ Summary of Changes

- **Refactor:** extracted MetadataFlags creation into `MetadataFlags::origin_flags()`

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): scanner/metadata

## 🔗 Related Issues or PRs

none

## 📝 Notes for Reviewers

Pure refactor — no behaviour change. The `Vendored` arm returns                                                                                       
`MetadataFlags::empty()`, matching the implicit fall-through in the
original code.                                                                                                                                        