### PR TITLE
docs: display rule examples on top of each other

### DIFF
--- a/docs/static/css/components.css
+++ b/docs/static/css/components.css
@@ -1429,8 +1429,8 @@
   }
 
   .rule-examples {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
+    display: flex;
+    flex-direction: column;
     gap: var(--s-3);
     margin-block: var(--s-3);
   }


### PR DESCRIPTION
## 📌 What Does This PR Do?

title

Before:
<img width="1135" height="802" alt="image" src="https://github.com/user-attachments/assets/bc2ef5c5-988d-484e-a585-766204e9d4af" />

After:
<img width="1205" height="1093" alt="image" src="https://github.com/user-attachments/assets/085ca459-e353-42dc-a72f-8a60eb67c515" />


## 🔍 Context & Motivation

<!-- Why is this change needed? Is it fixing a bug, adding a feature, or refactoring? -->

## 🛠️ Summary of Changes

- **Feature:** Added `compatibility/new-without-parentheses` rule.
- **Bug Fix:** Fixed incorrect handling of `readonly` properties in PHP 8.2.
- **Refactor:** Improved `mago_ast` structure.
- **Docs:** Updated installation guide.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [x] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
