### PR TITLE
chore(ci): Run clippy on all targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,6 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: cargo clippy
-        if: matrix.os == 'macos-latest'
         run: cargo clippy --workspace --all-features -- -D warnings
 
       - name: cargo test


### PR DESCRIPTION
## 📌 What Does This PR Do?

Runs clippy on all targets in CI.

## 🔍 Context & Motivation

The CI call of clippy does not include --all-targets, and the macos runners don't get to run nightly, so we're missing out on a few things. Also, --all-targets seems not to capture all issues, as locally running clippy on an actual x86_64 system with AVX2 support produces issues not seen on ARM hardware on MacOS.

## 🛠️ Summary of Changes

- **Bug Fix:** Run clippy on all targets in CI to catch more issues.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): CI

## 🔗 Related Issues or PRs

none

## 📝 Notes for Reviewers

Hello :wave:
