### PR TITLE
ci: use signed API commits in update-nightly workflow

### DIFF
--- a/.github/workflows/update-nightly.yml
+++ b/.github/workflows/update-nightly.yml
@@ -16,59 +16,32 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Determine latest and current nightly
+      - name: Determine latest nightly
         id: versions
         run: |
           LATEST_DATE=$(curl -sSf https://static.rust-lang.org/dist/channel-rust-nightly.toml \
             | grep '^date = ' | head -1 | sed 's/date = "\([^"]*\)"/\1/')
-          LATEST="nightly-${LATEST_DATE}"
           CURRENT=$(cat nightly-version)
-          echo "latest=${LATEST}" >> $GITHUB_OUTPUT
+          echo "latest=nightly-${LATEST_DATE}" >> $GITHUB_OUTPUT
           echo "current=${CURRENT}" >> $GITHUB_OUTPUT
-          if [ "${CURRENT}" != "${LATEST}" ]; then
-            echo "needed=true" >> $GITHUB_OUTPUT
-          else
-            echo "needed=false" >> $GITHUB_OUTPUT
-            echo "Already pinned to ${CURRENT}, nothing to do."
-          fi
 
-      - name: Configure git
-        if: steps.versions.outputs.needed == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Create or reset update branch
-        if: steps.versions.outputs.needed == 'true'
-        run: git checkout -B chore/update-nightly-toolchain origin/main
-
-      - name: Update nightly-version
-        if: steps.versions.outputs.needed == 'true'
-        run: |
-          echo "${{ steps.versions.outputs.latest }}" > nightly-version
-          git add nightly-version
-          git commit -m "chore: update pinned nightly toolchain to ${{ steps.versions.outputs.latest }}"
-
-      - name: Push branch
-        if: steps.versions.outputs.needed == 'true'
-        run: git push origin chore/update-nightly-toolchain --force
+      - name: Update nightly-version file
+        run: echo "${{ steps.versions.outputs.latest }}" > nightly-version
 
       - name: Create or update pull request
-        if: steps.versions.outputs.needed == 'true'
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ github.token }}
+          sign-commits: true
+          branch: chore/update-nightly-toolchain
+          base: main
+          title: "chore: update pinned nightly toolchain to ${{ steps.versions.outputs.latest }}"
+          body: "Updates the pinned nightly Rust toolchain from `${{ steps.versions.outputs.current }}` to `${{ steps.versions.outputs.latest }}`."
+          commit-message: "chore: update pinned nightly toolchain to ${{ steps.versions.outputs.latest }}"
+
+      - name: Enable auto-merge
+        if: steps.cpr.outputs.pull-request-number != ''
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          CURRENT="${{ steps.versions.outputs.current }}"
-          LATEST="${{ steps.versions.outputs.latest }}"
-          TITLE="chore: update pinned nightly toolchain to ${LATEST}"
-          BODY="Updates the pinned nightly Rust toolchain from \`${CURRENT}\` to \`${LATEST}\`."
-
-          EXISTING=$(gh pr list --head chore/update-nightly-toolchain --json number --jq '.[0].number // ""')
-          if [ -n "${EXISTING}" ]; then
-            gh pr edit "${EXISTING}" --title "${TITLE}" --body "${BODY}"
-          else
-            gh pr create --title "${TITLE}" --body "${BODY}" \
-              --head chore/update-nightly-toolchain --base main
-            EXISTING=$(gh pr list --head chore/update-nightly-toolchain --json number --jq '.[0].number')
-          fi
-          gh pr merge "${EXISTING}" --auto --squash
+        run: gh pr merge "${{ steps.cpr.outputs.pull-request-number }}" --auto --squash


### PR DESCRIPTION
## 📌 What Does This PR Do?

Switch to `peter-evans/create-pull-request` with `sign-commits: true`, which creates commits via the GitHub GraphQL API; GitHub signs those on its own behalf. The action is also idempotent when the file content is unchanged, so the explicit `needed` gate is no longer required.

## 🔍 Context & Motivation

The workflow uses plain `git commit`, which produces unsigned commits that a signed-commits ruleset blocks from merging.

## 🛠️ Summary of Changes

- **Feature:** Added `compatibility/new-without-parentheses` rule.
- **Bug Fix:** Fixed incorrect handling of `readonly` properties in PHP 8.2.
- **Refactor:** Improved `mago_ast` structure.
- **Docs:** Updated installation guide.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): CI

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

This might need adjustment in the project settings, see https://github.com/peter-evans/create-pull-request#workflow-permissions 
