### PR TITLE
fix(flake): Fix the nix flake to use the correct rust version and make it indenpendent from global settings

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,5 @@
-use flake
+if has nix; then
+    watch_file flake.nix flake.lock
+    use flake
+fi
+

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Mago - devshell using rustup (stable 1.95.0 + nightly) and php 8.4 + composer";
+  description = "Mago - devshell using rustup and php 8.4 + composer";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
@@ -11,18 +11,15 @@
       let
         pkgs = import nixpkgs { inherit system; };
         isDarwin = pkgs.stdenv.isDarwin;
+        toolchain = "1.95.0";
         php = pkgs.php84;
         composer = pkgs.php84Packages.composer;
       in
       {
         devShells.default = pkgs.mkShell {
           buildInputs = [
-            pkgs.cargo
-            pkgs.rustc
             pkgs.rustup
-            pkgs.rust-analyzer
             pkgs.pkg-config
-            pkgs.openssl
             pkgs.just
             pkgs.wasm-pack
             php
@@ -41,17 +38,11 @@
           CARGO_INCREMENTAL = "1";
 
           shellHook = ''
-            export PATH="$HOME/.cargo/bin:$PATH"
-            if ! command -v rustc >/dev/null 2>&1; then
-              rustup toolchain install 1.95.0 --profile minimal
-              rustup toolchain install nightly --profile minimal
-              rustup default 1.95.0
+            if ! rustup toolchain list | grep -q "^${toolchain}-"; then
+              rustup toolchain install ${toolchain} --no-self-update --profile default --component rust-analyzer >/dev/null
             fi
-            echo "[mago] rustc:     $(rustc --version)"
-            echo "[mago] nightly:   $(rustup run nightly rustc --version)"
-            echo "[mago] php:       $(php -v | head -n1)"
-            echo "[mago] composer:  $(composer --version)"
-            echo "[mago] Run: just build | just test | just check | just fix | just build-wasm"
+
+            rustup override set ${toolchain} >/dev/null
           '';
         };
       });


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fix the project's nix flake for good

## 🔍 Context & Motivation

The current flake for the project falls out of date pretty frequently because of how it was initially designed. It worked initially because the version of `cargo` and `rustc` installed through nixpkgs matched the one used in the project, though once we moved up to rust `1.95.0` it simply stopped working silently, and no one reported it most likely because no one uses it (😹) (I do though, and I did run into the issue, I just chose to ignore it at the time)  
The current setup is definitely flawed, because even though it installs the correct toolchain through rustup in the `shellHook`, as I said both get overridden in the `$PATH` 🤷

Fixed it by not installing either of them through nixpkgs and only use rustup from now on; Also we don't mess anymore with rustup's default toolchain, we use `override` instead which sets the default only for the current directory.

From now on whenever we need to update the rust toolchain we can just bump it in the flake and the changes will be propagated correctly.

I don't want to get much deeper with this because it's a bike shedding rabbit hole but it would be great to finally have something that works reliably 🙏 If you think it's too much of a hassle to maintain a tool you don't use we can of course remove it :+1:

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Nix flake

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
