### PR TITLE
fix: scope src/ export-ignore to root directory only

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,4 +19,4 @@ flake.nix export-ignore
 flake.lock export-ignore
 mago.toml export-ignore
 scripts/ export-ignore
-src/ export-ignore
+/src/ export-ignore


### PR DESCRIPTION
- Prefix `src/` with `/` in `.gitattributes` so the `export-ignore` rule only matches the root `src/` directory
- Without the leading slash, `src/` matches at any directory level per gitignore pattern rules, which excludes `composer/src/` from dist archives created by `git archive`
- This broke `composer install --prefer-dist` (the default) since 1.27.0, when `composer/functions.php` and `composer/internal.php` were moved to `composer/src/` in 7a59a92

Fixes #1827