### PR TITLE
fix(analyzer): declared template defaults not applied at call site

### DIFF
--- a/crates/analyzer/src/invocation/analyzer.rs
+++ b/crates/analyzer/src/invocation/analyzer.rs
@@ -489,6 +489,25 @@ pub fn analyze_invocation<'ctx, 'arena>(
         last_argument_offset = *argument_offset as isize;
     }
 
+    let function_template_types = invocation.target.get_template_types();
+
+    // Apply @template T2 = T1 defaults for templates not yet bound from actual arguments.
+    // This must run before unused-parameter PHP-default inference so that explicit template
+    // defaults take priority (e.g., $x = null must not override T2 = T1 when T1 = string).
+    if let Some(template_types) = function_template_types {
+        for (template_name, template) in template_types {
+            if template_result.has_lower_bound(*template_name, &template.defining_entity) {
+                continue;
+            }
+            if let Some(default) = &template.default {
+                let resolved = inferred_type_replacer::replace(default, template_result, context.codebase);
+                if !resolved.has_template_types() {
+                    template_result.add_lower_bound(*template_name, template.defining_entity, resolved);
+                }
+            }
+        }
+    }
+
     if !has_too_many_arguments {
         loop {
             last_argument_offset += 1;
@@ -583,13 +602,19 @@ pub fn analyze_invocation<'ctx, 'arena>(
         }
     }
 
-    if let Some(template_types) = invocation.target.get_template_types() {
+    if let Some(template_types) = function_template_types {
         for (template_name, template) in template_types {
             if template_result.has_lower_bound(*template_name, &template.defining_entity) {
                 continue;
             }
 
-            template_result.add_lower_bound(*template_name, template.defining_entity, template.constraint.clone());
+            let fallback = if let Some(default) = &template.default {
+                inferred_type_replacer::replace(default, template_result, context.codebase)
+            } else {
+                template.constraint.clone()
+            };
+
+            template_result.add_lower_bound(*template_name, template.defining_entity, fallback);
         }
     }
 

--- a/crates/analyzer/src/invocation/template_inference.rs
+++ b/crates/analyzer/src/invocation/template_inference.rs
@@ -1148,7 +1148,7 @@ pub fn infer_parameter_templates_from_default(
         parameter_type,
         default_type,
         template_result,
-        InferenceOptions { infer_only_if_new: default_type.is_callable(), argument_offset: None, source_span: None },
+        InferenceOptions { infer_only_if_new: true, argument_offset: None, source_span: None },
         &mut Vec::new(),
     );
 }

--- a/crates/analyzer/tests/cases/template_default_references_other_template.php
+++ b/crates/analyzer/tests/cases/template_default_references_other_template.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @template T1
+ * @template T2 = T1
+ *
+ * @param T1                    $value
+ * @param null|callable(T1): T2 $transform
+ *
+ * @return T2
+ */
+function maybe_transform(mixed $value, ?callable $transform = null): mixed
+{
+    if (null === $transform) {
+        return $value;
+    }
+
+    return $transform($value);
+}
+
+// T2 defaults to T1 = string; strtoupper must accept this without error.
+echo strtoupper(maybe_transform('hello'));
+
+// Explicit callable: T2 resolved from callable return type, not default.
+echo strtoupper(maybe_transform('hello', fn(string $s): string => $s));

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -332,6 +332,7 @@ test_case!(template_default_as_modifier);
 test_case!(template_default_array_shape);
 test_case!(template_default_argument_mismatch);
 test_case!(template_default_explicit_arg_violates_constraint);
+test_case!(template_default_references_other_template);
 test_case!(docblock_truthy_string);
 test_case!(docblock_non_falsy_string);
 test_case!(docblock_non_falsy_string_invalid);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes two analyzer bugs that together prevent @template T2 = T1
defaults from taking effect at call sites.

## 🔍 Context & Motivation

Template defaults referencing other templates (T2 = T1) are a
legitimate PHPDoc pattern. The analyzer was silently falling back to
mixed, causing false-positive type errors on otherwise correct code.

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed incorrect handling of template defaults

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Analyzer

## 🔗 Related Issues or PRs

https://discord.com/channels/1316105858295271526/1352414008749199432/1504394862391201853

## 📝 Notes for Reviewers

I had claude guide me here. All seems to make sense to me, but have a close look :)
