### PR TITLE
fix(formatter): restore indent alignment for mid-line echo tags witho…

### DIFF
--- a/crates/formatter/src/internal/format/statement.rs
+++ b/crates/formatter/src/internal/format/statement.rs
@@ -173,8 +173,36 @@ fn print_statement_slice<'ctx, 'arena>(
             if let Some(line_start_offset) = f.file.get_line_start_offset(line) {
                 let c = &f.source_text[line_start_offset as usize..offset as usize];
                 let ws = c.chars().take_while(|c| c.is_whitespace()).collect::<String>();
-                let should_apply_align =
-                    !ws.is_empty() && (matches!(stmt, Statement::OpeningTag(_)) || c.len() == ws.len());
+                let c_ends_in_html = {
+                    let (mut in_php, mut i, mut ok_to_align) = (false, 0usize, true);
+                    let b = c.as_bytes();
+                    let ws_len = ws.len();
+                    while i < b.len() {
+                        if !in_php && b[i..].starts_with(b"<?") {
+                            in_php = true;
+                            i += 2;
+                        } else if in_php && b[i..].starts_with(b"?>") {
+                            in_php = false;
+                            i += 2;
+                        } else if !in_php && b[i..].starts_with(b"?>") {
+                            // `?>` seen while not in tracked PHP context: the line started
+                            // inside PHP code. Only allow alignment if the tail between the
+                            // leading whitespace and this `?>` is purely closing syntax
+                            // (`)`, `]`, `}`, `;`, whitespace), i.e. the leftover of a
+                            // broken multi-line expression — not actual statement code.
+                            let tail = &b[ws_len..i];
+                            if !tail.iter().all(|&byte| matches!(byte, b')' | b']' | b'}' | b';' | b' ' | b'\t')) {
+                                ok_to_align = false;
+                            }
+                            i += 2;
+                        } else {
+                            i += 1;
+                        }
+                    }
+                    !in_php && ok_to_align
+                };
+                let should_apply_align = !ws.is_empty()
+                    && (matches!(stmt, Statement::OpeningTag(_)) || c.len() == ws.len() || c_ends_in_html);
                 if should_apply_align {
                     if matches!(stmt, Statement::OpeningTag(_)) {
                         let mut j = i + 1;

--- a/crates/formatter/tests/cases/idempotency_inline_echo_mid_line_call/after.php
+++ b/crates/formatter/tests/cases/idempotency_inline_echo_mid_line_call/after.php
@@ -1,0 +1,7 @@
+<legend>Legend</legend>
+<h5>
+    Some long text here that forces the call to break <?= CHtml::link(
+        'link',
+        Yii::app()->createAbsoluteUrl('/billing'),
+    ) ?> more text. <br/>
+</h5>

--- a/crates/formatter/tests/cases/idempotency_inline_echo_mid_line_call/before.php
+++ b/crates/formatter/tests/cases/idempotency_inline_echo_mid_line_call/before.php
@@ -1,0 +1,7 @@
+<legend>Legend</legend>
+<h5>
+    Some long text here that forces the call to break <?= CHtml::link(
+        'link',
+        Yii::app()->createAbsoluteUrl('/billing'),
+    ) ?> more text. <br/>
+</h5>

--- a/crates/formatter/tests/cases/idempotency_inline_echo_mid_line_call/settings.inc
+++ b/crates/formatter/tests/cases/idempotency_inline_echo_mid_line_call/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings::default()

--- a/crates/formatter/tests/cases/idempotency_inline_echo_mid_line_ternary/after.php
+++ b/crates/formatter/tests/cases/idempotency_inline_echo_mid_line_ternary/after.php
@@ -1,0 +1,6 @@
+<legend>xxxxxxxxxxxxxxxxxxxx</legend>
+<p>
+    xx xxxxxx <?= $xxxxxxxxx->xxxxxxxxxxxxxxx() ?> xxxxxxxxxxx <?= $xxxxxxxxx->xxxxxxxxxxxxxx()
+        ? 'xxxxxx'
+        : 'xxxxxxxx' ?> xxxxxxxxxx.
+</p>

--- a/crates/formatter/tests/cases/idempotency_inline_echo_mid_line_ternary/before.php
+++ b/crates/formatter/tests/cases/idempotency_inline_echo_mid_line_ternary/before.php
@@ -1,0 +1,6 @@
+<legend>xxxxxxxxxxxxxxxxxxxx</legend>
+<p>
+    xx xxxxxx <?= $xxxxxxxxx->xxxxxxxxxxxxxxx() ?> xxxxxxxxxxx <?= $xxxxxxxxx->xxxxxxxxxxxxxx()
+        ? 'xxxxxx'
+        : 'xxxxxxxx' ?> xxxxxxxxxx.
+</p>

--- a/crates/formatter/tests/cases/idempotency_inline_echo_mid_line_ternary/settings.inc
+++ b/crates/formatter/tests/cases/idempotency_inline_echo_mid_line_ternary/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings::default()

--- a/crates/formatter/tests/cases/idempotency_inline_echo_multi_break_mid_line/after.php
+++ b/crates/formatter/tests/cases/idempotency_inline_echo_multi_break_mid_line/after.php
@@ -1,0 +1,9 @@
+<h5>
+    Some long text here that forces the call to break <?= CHtml::link(
+        'link',
+        Yii::app()->createAbsoluteUrl('/billing'),
+    ) ?> more text here <?= CHtml::link(
+        'another link',
+        Yii::app()->createAbsoluteUrl('/billing/history/view/show/details'),
+    ) ?> end.
+</h5>

--- a/crates/formatter/tests/cases/idempotency_inline_echo_multi_break_mid_line/before.php
+++ b/crates/formatter/tests/cases/idempotency_inline_echo_multi_break_mid_line/before.php
@@ -1,0 +1,3 @@
+<h5>
+    Some long text here that forces the call to break <?= CHtml::link('link', Yii::app()->createAbsoluteUrl('/billing')) ?> more text here <?= CHtml::link('another link', Yii::app()->createAbsoluteUrl('/billing/history/view/show/details')) ?> end.
+</h5>

--- a/crates/formatter/tests/cases/idempotency_inline_echo_multi_break_mid_line/settings.inc
+++ b/crates/formatter/tests/cases/idempotency_inline_echo_multi_break_mid_line/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings::default()

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -442,6 +442,9 @@ test_case!(idempotency_comment_before_call_args);
 test_case!(idempotency_mixed_breaking_logical_chain);
 test_case!(idempotency_docblock_before_parameter);
 test_case!(idempotency_html_echo_ternary_break);
+test_case!(idempotency_inline_echo_mid_line_call);
+test_case!(idempotency_inline_echo_mid_line_ternary);
+test_case!(idempotency_inline_echo_multi_break_mid_line);
 
 // Full-file idempotency fixtures sourced from the corpus. When a corpus
 // file stops being idempotent, copy it here so the formatter test suite


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes a regression where function call arguments inside a `<?= ... ?>`
echo tag lost their indentation when the tag appeared after other HTML
content on a line with leading whitespace.

## 🔍 Context & Motivation

715db54b7 "fix(formatter): converge corpus idempotency on a single pass"
tightened the `should_apply_align` condition in `statement.rs` to only
apply `Document::Align` (which provides the indentation context for PHP
line continuations) to opening tags and tags whose entire line prefix is
whitespace. This was correct for the idempotency case it fixed, but it
also stopped applying alignment to legitimate mid-line echo tags,
causing argument continuation lines to lose the HTML indentation context:

## 🛠️ Summary of Changes

- **Bug Fix:** The formatter now preserves indentation for multi-line
  function calls inside inline echo tags that appear mid-line after
  HTML content.- **Refactor:** Improved `mago_ast` structure.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
