### PR TITLE
fix(language-server): fix events getting lost during bootstrap

### DIFF
--- a/src/language_server/backend/mod.rs
+++ b/src/language_server/backend/mod.rs
@@ -16,7 +16,6 @@ use crate::language_server::capabilities;
 use crate::language_server::capabilities::server_capabilities;
 use crate::language_server::position::offset_at_position;
 use crate::language_server::state::BackendState;
-use crate::language_server::state::PendingConfig;
 use crate::language_server::workspace::workspace_root;
 
 mod sync;
@@ -45,8 +44,7 @@ impl LanguageServer for Backend {
                 .log_message(MessageType::INFO, format!("mago-server: workspace root = {}", root.display()))
                 .await;
 
-            *self.state.lock().unwrap() =
-                BackendState::Pending(PendingConfig { root, config: Arc::clone(&self.config) });
+            self.bootstrap(root).await;
         } else {
             self.client.log_message(MessageType::WARNING, "mago-server: no workspace root provided").await;
         }
@@ -80,8 +78,6 @@ impl LanguageServer for Backend {
                 client.log_message(MessageType::ERROR, format!("mago-server: register watcher: {err}")).await;
             }
         });
-
-        self.bootstrap().await;
     }
 
     async fn did_open(&self, params: DidOpenTextDocumentParams) {

--- a/src/language_server/backend/sync.rs
+++ b/src/language_server/backend/sync.rs
@@ -3,6 +3,7 @@
 //! (`apply_change_atomic`), and shared utilities.
 
 use std::borrow::Cow;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use foldhash::HashMap;
@@ -28,19 +29,12 @@ use crate::language_server::workspace::logical_name_for;
 use super::Backend;
 
 impl Backend {
-    pub(super) async fn bootstrap(&self) {
-        let pending = match std::mem::replace(&mut *self.state.lock().unwrap(), BackendState::Uninitialized) {
-            BackendState::Pending(config) => config,
-            other => {
-                *self.state.lock().unwrap() = other;
-                return;
-            }
-        };
-
+    pub(super) async fn bootstrap(&self, root: PathBuf) {
         let started = std::time::Instant::now();
-        tracing::info!(root = %pending.root.display(), "bootstrap starting");
+        tracing::info!(root = %root.display(), "bootstrap starting");
 
-        let outcome = tokio::task::spawn_blocking(move || build_workspace(pending)).await;
+        let config = Arc::clone(&self.config);
+        let outcome = tokio::task::spawn_blocking(move || build_workspace(root, config)).await;
 
         match outcome {
             Ok(Ok((mut workspace, mut analysis_result))) => {

--- a/src/language_server/state.rs
+++ b/src/language_server/state.rs
@@ -1,8 +1,7 @@
 //! Backend state lifecycle.
 //!
 //! On startup the backend is [`BackendState::Uninitialized`]. The
-//! `initialize` request transitions it to [`BackendState::Pending`]; the
-//! `initialized` notification triggers a one-shot bootstrap that walks
+//! `initialize` request triggers a one-shot bootstrap that walks
 //! the workspace, builds the database, runs an initial full analysis (if
 //! enabled by the [`super::ServerConfig`]), and transitions to
 //! [`BackendState::Ready`].
@@ -41,13 +40,7 @@ use crate::language_server::linter::LinterContext;
 #[allow(clippy::large_enum_variant)]
 pub enum BackendState {
     Uninitialized,
-    Pending(PendingConfig),
     Ready(WorkspaceState),
-}
-
-pub struct PendingConfig {
-    pub root: PathBuf,
-    pub config: Arc<ServerConfig>,
 }
 
 pub struct WorkspaceState {
@@ -158,8 +151,7 @@ fn build_index(artifacts: &mago_analyzer::artifacts::AnalysisArtifacts) -> Expre
     ExpressionTypeIndex { by_span }
 }
 
-pub fn build_workspace(pending: PendingConfig) -> Result<(WorkspaceState, AnalysisResult), String> {
-    let PendingConfig { root, config } = pending;
+pub fn build_workspace(root: PathBuf, config: Arc<ServerConfig>) -> Result<(WorkspaceState, AnalysisResult), String> {
     let root = root.canonicalize().unwrap_or(root);
     let prelude = Prelude::decode(PRELUDE_BYTES).map_err(|e| format!("decode prelude: {e}"))?;
     let Prelude { database: prelude_db, metadata, symbol_references } = prelude;


### PR DESCRIPTION
## 📌 What Does This PR Do?

Make sure that the server is ready before replying to the `initialize` request, so no events get silently dropped.

## 🔍 Context & Motivation

The server already responds to the `initialize` requests before the bootstrap process is finished, allowing the client to immediately send events like didOpen. But these are then silently dropped until the bootstrap process has finished, causing the client and server to get out of sync. Instead, we should make sure that the bootstrap is finished and we can actually handle events before replying to the `initialize` event.

## 🛠️ Summary of Changes

- **Feature:** Added `compatibility/new-without-parentheses` rule.
- **Bug Fix:** Fixed the LSP server dropping events during bootstrap.
- **Refactor:** Improved `mago_ast` structure.
- **Docs:** Updated installation guide.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): LSP

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
