### PR TITLE
refactor(language-server): switch from tower_lsp to tower_lsp_server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,28 +148,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "auto_impl"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +243,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "bstr"
@@ -668,11 +652,12 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
+ "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
@@ -871,6 +856,17 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
  "zlib-rs",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
 ]
 
 [[package]]
@@ -1510,16 +1506,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "lsp-types"
-version = "0.94.1"
+name = "ls-types"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
+checksum = "896e16b8e17d8732b9efe4d5b66cb0cc162b3023a2d8122f2aea6f7f185e0a67"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.1",
+ "fluent-uri",
+ "percent-encoding",
  "serde",
  "serde_json",
- "serde_repr",
- "url",
 ]
 
 [[package]]
@@ -1576,7 +1572,7 @@ dependencies = [
  "termtree",
  "tokio",
  "toml",
- "tower-lsp",
+ "tower-lsp-server",
  "tracing",
  "tracing-subscriber",
  "unicode-width",
@@ -2330,26 +2326,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project"
-version = "1.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2999,17 +2975,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_repr"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3203,6 +3168,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "synstructure"
@@ -3470,14 +3441,14 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
-version = "0.4.13"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "pin-project",
  "pin-project-lite",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
 ]
@@ -3489,37 +3460,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
-name = "tower-lsp"
-version = "0.20.0"
+name = "tower-lsp-server"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ba052b54a6627628d9b3c34c176e7eda8359b7da9acd497b9f20998d118508"
+checksum = "2f0e711655c89181a6bc6a2cc348131fcd9680085f5b06b6af13427a393a6e72"
 dependencies = [
- "async-trait",
- "auto_impl",
  "bytes",
  "dashmap",
  "futures",
  "httparse",
- "lsp-types",
+ "ls-types",
  "memchr",
  "serde",
  "serde_json",
  "tokio",
  "tokio-util",
  "tower",
- "tower-lsp-macros",
  "tracing",
-]
-
-[[package]]
-name = "tower-lsp-macros"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -3763,7 +3720,6 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
- "serde_derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -296,7 +296,7 @@ foldhash = { workspace = true, optional = true }
 xxhash-rust = { workspace = true, optional = true }
 memchr = { workspace = true, optional = true }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std", "io-util", "sync", "time", "signal"], optional = true }
-tower-lsp = { version = "0.20", optional = true }
+tower-lsp-server = { version = "0.23.0", optional = true }
 
 [[test]]
 name = "suite"
@@ -318,7 +318,7 @@ mimalloc = { version = "0.1.47" }
 [features]
 dhat-heap = ["dhat"]
 language-server = [
-    "dep:tower-lsp",
+    "dep:tower-lsp-server",
     "dep:tokio",
     "dep:foldhash",
     "dep:xxhash-rust",

--- a/src/language_server/backend/mod.rs
+++ b/src/language_server/backend/mod.rs
@@ -6,10 +6,10 @@
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use tower_lsp::Client;
-use tower_lsp::LanguageServer;
-use tower_lsp::jsonrpc::Result as JsonRpcResult;
-use tower_lsp::lsp_types::*;
+use tower_lsp_server::Client;
+use tower_lsp_server::LanguageServer;
+use tower_lsp_server::jsonrpc::Result as JsonRpcResult;
+use tower_lsp_server::ls_types::*;
 
 use crate::language_server::ServerConfig;
 use crate::language_server::capabilities;
@@ -36,7 +36,6 @@ impl Backend {
     }
 }
 
-#[tower_lsp::async_trait]
 impl LanguageServer for Backend {
     async fn initialize(&self, params: InitializeParams) -> JsonRpcResult<InitializeResult> {
         if let Some(root) = workspace_root(&params) {
@@ -55,6 +54,7 @@ impl LanguageServer for Backend {
                 name: "mago-server".into(),
                 version: Some(env!("CARGO_PKG_VERSION").into()),
             }),
+            offset_encoding: None,
         })
     }
 
@@ -213,7 +213,7 @@ impl LanguageServer for Backend {
         })
     }
 
-    async fn symbol(&self, params: WorkspaceSymbolParams) -> JsonRpcResult<Option<Vec<SymbolInformation>>> {
+    async fn symbol(&self, params: WorkspaceSymbolParams) -> JsonRpcResult<Option<WorkspaceSymbolResponse>> {
         traced("workspace_symbol", || {
             Ok(self.with_workspace(|ws| {
                 capabilities::workspace_symbol::compute(&ws.database, ws.service.codebase(), &params.query)

--- a/src/language_server/backend/sync.rs
+++ b/src/language_server/backend/sync.rs
@@ -7,10 +7,10 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use foldhash::HashMap;
-use tower_lsp::jsonrpc::Result as JsonRpcResult;
-use tower_lsp::lsp_types::Diagnostic;
-use tower_lsp::lsp_types::MessageType;
-use tower_lsp::lsp_types::Url;
+use tower_lsp_server::jsonrpc::Result as JsonRpcResult;
+use tower_lsp_server::ls_types::Diagnostic;
+use tower_lsp_server::ls_types::MessageType;
+use tower_lsp_server::ls_types::Uri;
 
 use mago_database::DatabaseReader;
 use mago_database::file::File as MagoFile;
@@ -151,10 +151,11 @@ impl Backend {
         }
     }
 
-    pub(super) async fn apply_buffer_open(&self, uri: Url, text: String, version: i32) {
-        let Ok(path) = uri.to_file_path() else {
+    pub(super) async fn apply_buffer_open(&self, uri: Uri, text: String, version: i32) {
+        let Some(path) = uri.to_file_path() else {
             return;
         };
+        let path = path.into_owned();
         self.apply_change_atomic(move |workspace| {
             let logical = logical_name_for(&workspace.root, &path);
             let virtual_file = workspace.database.get_id(logical.as_bytes()).is_none();
@@ -162,7 +163,7 @@ impl Backend {
                 let file = MagoFile::new(
                     Cow::Owned(logical.into_bytes()),
                     FileType::Host,
-                    Some(path.clone()),
+                    Some(path),
                     Cow::Owned(text.into_bytes()),
                 );
                 workspace.database.add(file)
@@ -177,7 +178,7 @@ impl Backend {
         .await;
     }
 
-    pub(super) async fn apply_buffer_change(&self, uri: Url, text: String, version: i32) {
+    pub(super) async fn apply_buffer_change(&self, uri: Uri, text: String, version: i32) {
         self.apply_change_atomic(move |workspace| {
             let Some(open) = workspace.open_documents.get_mut(&uri) else {
                 return Vec::new();
@@ -189,10 +190,11 @@ impl Backend {
         .await;
     }
 
-    pub(super) async fn apply_buffer_close(&self, uri: Url) {
-        let Ok(path) = uri.to_file_path() else {
+    pub(super) async fn apply_buffer_close(&self, uri: Uri) {
+        let Some(path) = uri.to_file_path() else {
             return;
         };
+        let path = path.into_owned();
         self.apply_change_atomic(move |workspace| {
             let Some(open) = workspace.open_documents.remove(&uri) else {
                 return Vec::new();
@@ -207,10 +209,11 @@ impl Backend {
         .await;
     }
 
-    pub(super) async fn apply_disk_change(&self, uri: Url) {
-        let Ok(path) = uri.to_file_path() else {
+    pub(super) async fn apply_disk_change(&self, uri: Uri) {
+        let Some(path) = uri.to_file_path() else {
             return;
         };
+        let path = path.into_owned();
         self.apply_change_atomic(move |workspace| {
             if workspace.open_documents.contains_key(&uri) {
                 return Vec::new();
@@ -229,10 +232,11 @@ impl Backend {
         .await;
     }
 
-    pub(super) async fn apply_disk_delete(&self, uri: Url) {
-        let Ok(path) = uri.to_file_path() else {
+    pub(super) async fn apply_disk_delete(&self, uri: Uri) {
+        let Some(path) = uri.to_file_path() else {
             return;
         };
+        let path = path.into_owned();
         self.apply_change_atomic(move |workspace| {
             let id = file_id_for(&workspace.root, &path);
             if workspace.database.delete(id) { vec![id] } else { Vec::new() }
@@ -240,7 +244,7 @@ impl Backend {
         .await;
     }
 
-    pub(super) fn with_file<F, R>(&self, uri: &Url, f: F) -> Option<R>
+    pub(super) fn with_file<F, R>(&self, uri: &Uri, f: F) -> Option<R>
     where
         F: FnOnce(&MagoFile, &WorkspaceState) -> R,
     {
@@ -274,15 +278,15 @@ impl Backend {
         Some(f(workspace))
     }
 
-    async fn publish(&self, diagnostics: HashMap<Url, Vec<Diagnostic>>) {
+    async fn publish(&self, diagnostics: HashMap<Uri, Vec<Diagnostic>>) {
         let (stale, changed) = {
             let mut guard = self.state.lock().unwrap();
             let BackendState::Ready(workspace) = &mut *guard else {
                 return;
             };
-            let stale: Vec<Url> =
+            let stale: Vec<Uri> =
                 workspace.last_diagnostics.keys().filter(|url| !diagnostics.contains_key(*url)).cloned().collect();
-            let changed: Vec<(Url, Vec<Diagnostic>)> = diagnostics
+            let changed: Vec<(Uri, Vec<Diagnostic>)> = diagnostics
                 .into_iter()
                 .filter(|(url, diags)| workspace.last_diagnostics.get(url) != Some(diags))
                 .collect();
@@ -321,8 +325,8 @@ where
     result
 }
 
-pub(super) fn file_for_uri(workspace: &WorkspaceState, uri: &Url) -> Option<Arc<MagoFile>> {
-    let path = uri.to_file_path().ok()?;
+pub(super) fn file_for_uri(workspace: &WorkspaceState, uri: &Uri) -> Option<Arc<MagoFile>> {
+    let path = uri.to_file_path()?;
     let id = file_id_for(&workspace.root, &path);
     workspace.database.get(&id).ok()
 }

--- a/src/language_server/capabilities/code_action.rs
+++ b/src/language_server/capabilities/code_action.rs
@@ -6,15 +6,16 @@
 //! the issue.
 
 use foldhash::HashMap;
-use tower_lsp::lsp_types::CodeAction;
-use tower_lsp::lsp_types::CodeActionKind;
-use tower_lsp::lsp_types::CodeActionOrCommand;
-use tower_lsp::lsp_types::CodeActionParams;
-use tower_lsp::lsp_types::Diagnostic;
-use tower_lsp::lsp_types::Range;
-use tower_lsp::lsp_types::TextEdit;
-use tower_lsp::lsp_types::Url;
-use tower_lsp::lsp_types::WorkspaceEdit;
+use tower_lsp_server::ls_types::CodeAction;
+use tower_lsp_server::ls_types::CodeActionKind;
+use tower_lsp_server::ls_types::CodeActionOrCommand;
+use tower_lsp_server::ls_types::CodeActionParams;
+use tower_lsp_server::ls_types::Diagnostic;
+use tower_lsp_server::ls_types::NumberOrString;
+use tower_lsp_server::ls_types::Range;
+use tower_lsp_server::ls_types::TextEdit;
+use tower_lsp_server::ls_types::Uri;
+use tower_lsp_server::ls_types::WorkspaceEdit;
 
 use mago_database::Database;
 use mago_database::DatabaseReader;
@@ -59,7 +60,7 @@ pub fn compute(workspace: &WorkspaceState, params: &CodeActionParams) -> Vec<Cod
     actions
 }
 
-fn issue_overlaps(workspace: &WorkspaceState, issue: &Issue, uri: &Url, requested: Range) -> bool {
+fn issue_overlaps(workspace: &WorkspaceState, issue: &Issue, uri: &Uri, requested: Range) -> bool {
     let primary = primary_annotation(issue);
     let Some(primary) = primary else {
         return false;
@@ -70,7 +71,7 @@ fn issue_overlaps(workspace: &WorkspaceState, issue: &Issue, uri: &Url, requeste
     let Some(path) = &file.path else {
         return false;
     };
-    let Ok(issue_uri) = Url::from_file_path(path) else {
+    let Some(issue_uri) = Uri::from_file_path(path) else {
         return false;
     };
     if issue_uri != *uri {
@@ -81,11 +82,11 @@ fn issue_overlaps(workspace: &WorkspaceState, issue: &Issue, uri: &Url, requeste
 }
 
 fn issue_to_actions(database: &Database<'_>, issue: &Issue) -> Vec<CodeActionOrCommand> {
-    let mut changes: HashMap<Url, Vec<TextEdit>> = HashMap::default();
+    let mut changes: HashMap<Uri, Vec<TextEdit>> = HashMap::default();
     for (file_id, edits) in &issue.edits {
         let Ok(file) = database.get(file_id) else { continue };
         let Some(path) = &file.path else { continue };
-        let Ok(target_uri) = Url::from_file_path(path) else { continue };
+        let Some(target_uri) = Uri::from_file_path(path) else { continue };
 
         let converted: Vec<TextEdit> = edits.iter().map(|e| convert_edit(&file, e)).collect();
         if converted.is_empty() {
@@ -133,7 +134,7 @@ fn issue_to_diagnostic(database: &Database<'_>, issue: &Issue) -> Option<Diagnos
     Some(Diagnostic {
         range,
         severity: Some(crate::language_server::diagnostics::level_to_severity(issue.level)),
-        code: issue.code.clone().map(tower_lsp::lsp_types::NumberOrString::String),
+        code: issue.code.clone().map(NumberOrString::String),
         source: Some("mago".into()),
         message: issue.message.clone(),
         ..Diagnostic::default()

--- a/src/language_server/capabilities/code_lens.rs
+++ b/src/language_server/capabilities/code_lens.rs
@@ -9,10 +9,10 @@
 
 use mago_database::file::File as MagoFile;
 use mago_database::file::FileId;
-use tower_lsp::lsp_types::CodeLens;
-use tower_lsp::lsp_types::Command;
-use tower_lsp::lsp_types::Position;
-use tower_lsp::lsp_types::Range;
+use tower_lsp_server::ls_types::CodeLens;
+use tower_lsp_server::ls_types::Command;
+use tower_lsp_server::ls_types::Position;
+use tower_lsp_server::ls_types::Range;
 
 use crate::language_server::state::WorkspaceState;
 

--- a/src/language_server/capabilities/completion/items.rs
+++ b/src/language_server/capabilities/completion/items.rs
@@ -12,12 +12,12 @@ use mago_database::file::File as MagoFile;
 use mago_database::file::FileType;
 use mago_span::Span;
 use mago_syntax::token::TokenKind;
-use tower_lsp::lsp_types::CompletionItem;
-use tower_lsp::lsp_types::CompletionItemKind;
-use tower_lsp::lsp_types::Documentation;
-use tower_lsp::lsp_types::InsertTextFormat;
-use tower_lsp::lsp_types::MarkupContent;
-use tower_lsp::lsp_types::MarkupKind;
+use tower_lsp_server::ls_types::CompletionItem;
+use tower_lsp_server::ls_types::CompletionItemKind;
+use tower_lsp_server::ls_types::Documentation;
+use tower_lsp_server::ls_types::InsertTextFormat;
+use tower_lsp_server::ls_types::MarkupContent;
+use tower_lsp_server::ls_types::MarkupKind;
 
 use crate::language_server::capabilities::lookup;
 use crate::language_server::state::ExpressionTypeIndex;

--- a/src/language_server/capabilities/completion/mod.rs
+++ b/src/language_server/capabilities/completion/mod.rs
@@ -16,7 +16,7 @@ use mago_database::Database;
 use mago_database::file::File as MagoFile;
 use mago_syntax::token::Token;
 use mago_syntax::token::TokenKind;
-use tower_lsp::lsp_types::CompletionResponse;
+use tower_lsp_server::ls_types::CompletionResponse;
 
 use crate::language_server::capabilities::lookup;
 use crate::language_server::state::ExpressionTypeIndex;

--- a/src/language_server/capabilities/definition.rs
+++ b/src/language_server/capabilities/definition.rs
@@ -8,8 +8,8 @@ use mago_database::Database;
 use mago_database::DatabaseReader;
 use mago_names::ResolvedNames;
 use mago_span::Span;
-use tower_lsp::lsp_types::Location;
-use tower_lsp::lsp_types::Url;
+use tower_lsp_server::ls_types::Location;
+use tower_lsp_server::ls_types::Uri;
 
 use crate::language_server::position::range_at_offsets;
 
@@ -40,7 +40,7 @@ fn resolve_span(codebase: &CodebaseMetadata, fqcn: &[u8]) -> Option<Span> {
 fn span_to_location(database: &Database<'_>, span: Span) -> Option<Location> {
     let file = database.get(&span.file_id).ok()?;
     let path = file.path.as_ref()?;
-    let url = Url::from_file_path(path).ok()?;
+    let url = Uri::from_file_path(path)?;
     let range = range_at_offsets(&file, span.start.offset, span.end.offset);
     Some(Location { uri: url, range })
 }

--- a/src/language_server/capabilities/document_link.rs
+++ b/src/language_server/capabilities/document_link.rs
@@ -11,8 +11,8 @@ use mago_database::DatabaseReader;
 use mago_database::file::File as MagoFile;
 use mago_span::Span;
 use mago_syntax::token::TokenKind;
-use tower_lsp::lsp_types::DocumentLink;
-use tower_lsp::lsp_types::Url;
+use tower_lsp_server::ls_types::DocumentLink;
+use tower_lsp_server::ls_types::Uri;
 
 use crate::language_server::capabilities::lookup;
 use crate::language_server::position::range_at_offsets;
@@ -106,8 +106,8 @@ fn resolve(codebase: &CodebaseMetadata, kind: UseKind, name: &[u8]) -> Option<Sp
     }
 }
 
-fn file_url(database: &Database<'_>, span: Span) -> Option<Url> {
+fn file_url(database: &Database<'_>, span: Span) -> Option<Uri> {
     let file = database.get(&span.file_id).ok()?;
     let path = file.path.as_ref()?;
-    Url::from_file_path(path).ok()
+    Uri::from_file_path(path)
 }

--- a/src/language_server/capabilities/folding_range.rs
+++ b/src/language_server/capabilities/folding_range.rs
@@ -1,7 +1,7 @@
 //! `textDocument/foldingRange`. Reads pre-computed fold ranges from the
 //! file's [`super::super::file_analysis::FileAnalysis`].
 
-use tower_lsp::lsp_types::FoldingRange;
+use tower_lsp_server::ls_types::FoldingRange;
 
 use crate::language_server::file_analysis::FileAnalysis;
 

--- a/src/language_server/capabilities/formatting.rs
+++ b/src/language_server/capabilities/formatting.rs
@@ -13,9 +13,9 @@ use mago_database::file::File as MagoFile;
 use mago_formatter::Formatter;
 use mago_formatter::settings::FormatSettings;
 use mago_php_version::PHPVersion;
-use tower_lsp::lsp_types::Position;
-use tower_lsp::lsp_types::Range;
-use tower_lsp::lsp_types::TextEdit;
+use tower_lsp_server::ls_types::Position;
+use tower_lsp_server::ls_types::Range;
+use tower_lsp_server::ls_types::TextEdit;
 
 pub fn compute(file: &MagoFile, php_version: PHPVersion, settings: FormatSettings) -> Option<TextEdit> {
     let arena = Bump::new();

--- a/src/language_server/capabilities/hover.rs
+++ b/src/language_server/capabilities/hover.rs
@@ -11,10 +11,10 @@ use mago_codex::symbol::SymbolKind;
 use mago_codex::ttype::TType;
 use mago_database::file::File as MagoFile;
 use mago_names::ResolvedNames;
-use tower_lsp::lsp_types::Hover;
-use tower_lsp::lsp_types::HoverContents;
-use tower_lsp::lsp_types::MarkupContent;
-use tower_lsp::lsp_types::MarkupKind;
+use tower_lsp_server::ls_types::Hover;
+use tower_lsp_server::ls_types::HoverContents;
+use tower_lsp_server::ls_types::MarkupContent;
+use tower_lsp_server::ls_types::MarkupKind;
 
 use crate::language_server::capabilities::lookup;
 use crate::language_server::position::range_at_offsets;

--- a/src/language_server/capabilities/inlay_hint.rs
+++ b/src/language_server/capabilities/inlay_hint.rs
@@ -16,9 +16,9 @@ use mago_database::file::File as MagoFile;
 use mago_names::ResolvedNames;
 use mago_syntax::token::Token;
 use mago_syntax::token::TokenKind;
-use tower_lsp::lsp_types::InlayHint;
-use tower_lsp::lsp_types::InlayHintKind;
-use tower_lsp::lsp_types::InlayHintLabel;
+use tower_lsp_server::ls_types::InlayHint;
+use tower_lsp_server::ls_types::InlayHintKind;
+use tower_lsp_server::ls_types::InlayHintLabel;
 
 use crate::language_server::capabilities::lookup;
 use crate::language_server::position::position_at_offset;

--- a/src/language_server/capabilities/mod.rs
+++ b/src/language_server/capabilities/mod.rs
@@ -14,29 +14,29 @@
 //! 2. Wire it through [`crate::backend::Backend`] alongside the others.
 //! 3. Advertise the capability from [`server_capabilities`].
 
-use tower_lsp::lsp_types::CodeActionKind;
-use tower_lsp::lsp_types::CodeActionOptions;
-use tower_lsp::lsp_types::CodeActionProviderCapability;
-use tower_lsp::lsp_types::CodeLensOptions;
-use tower_lsp::lsp_types::CompletionOptions;
-use tower_lsp::lsp_types::DocumentLinkOptions;
-use tower_lsp::lsp_types::FoldingRangeProviderCapability;
-use tower_lsp::lsp_types::HoverProviderCapability;
-use tower_lsp::lsp_types::OneOf;
-use tower_lsp::lsp_types::RenameOptions;
-use tower_lsp::lsp_types::SelectionRangeProviderCapability;
-use tower_lsp::lsp_types::SemanticTokenType;
-use tower_lsp::lsp_types::SemanticTokensFullOptions;
-use tower_lsp::lsp_types::SemanticTokensLegend;
-use tower_lsp::lsp_types::SemanticTokensOptions;
-use tower_lsp::lsp_types::SemanticTokensServerCapabilities;
-use tower_lsp::lsp_types::ServerCapabilities;
-use tower_lsp::lsp_types::SignatureHelpOptions;
-use tower_lsp::lsp_types::TextDocumentSyncCapability;
-use tower_lsp::lsp_types::TextDocumentSyncKind;
-use tower_lsp::lsp_types::TextDocumentSyncOptions;
-use tower_lsp::lsp_types::TextDocumentSyncSaveOptions;
-use tower_lsp::lsp_types::WorkDoneProgressOptions;
+use tower_lsp_server::ls_types::CodeActionKind;
+use tower_lsp_server::ls_types::CodeActionOptions;
+use tower_lsp_server::ls_types::CodeActionProviderCapability;
+use tower_lsp_server::ls_types::CodeLensOptions;
+use tower_lsp_server::ls_types::CompletionOptions;
+use tower_lsp_server::ls_types::DocumentLinkOptions;
+use tower_lsp_server::ls_types::FoldingRangeProviderCapability;
+use tower_lsp_server::ls_types::HoverProviderCapability;
+use tower_lsp_server::ls_types::OneOf;
+use tower_lsp_server::ls_types::RenameOptions;
+use tower_lsp_server::ls_types::SelectionRangeProviderCapability;
+use tower_lsp_server::ls_types::SemanticTokenType;
+use tower_lsp_server::ls_types::SemanticTokensFullOptions;
+use tower_lsp_server::ls_types::SemanticTokensLegend;
+use tower_lsp_server::ls_types::SemanticTokensOptions;
+use tower_lsp_server::ls_types::SemanticTokensServerCapabilities;
+use tower_lsp_server::ls_types::ServerCapabilities;
+use tower_lsp_server::ls_types::SignatureHelpOptions;
+use tower_lsp_server::ls_types::TextDocumentSyncCapability;
+use tower_lsp_server::ls_types::TextDocumentSyncKind;
+use tower_lsp_server::ls_types::TextDocumentSyncOptions;
+use tower_lsp_server::ls_types::TextDocumentSyncSaveOptions;
+use tower_lsp_server::ls_types::WorkDoneProgressOptions;
 
 pub mod code_action;
 pub mod code_lens;

--- a/src/language_server/capabilities/references.rs
+++ b/src/language_server/capabilities/references.rs
@@ -33,8 +33,8 @@ use mago_database::file::File as MagoFile;
 use mago_database::file::FileType;
 use mago_span::Span;
 use mago_syntax::token::TokenKind;
-use tower_lsp::lsp_types::Location;
-use tower_lsp::lsp_types::Url;
+use tower_lsp_server::ls_types::Location;
+use tower_lsp_server::ls_types::Uri;
 
 use crate::language_server::capabilities::lookup;
 use crate::language_server::position::range_at_offsets;
@@ -73,7 +73,7 @@ pub fn compute(
     for arc_file in candidates {
         let Some(analysis) = workspace.file_analysis_for(arc_file.id) else { continue };
         let Some(path) = arc_file.path.as_ref() else { continue };
-        let Ok(url) = Url::from_file_path(path) else { continue };
+        let Some(url) = Uri::from_file_path(path) else { continue };
 
         for (start, end, name, _) in analysis.resolved().iter() {
             if !name.eq_ignore_ascii_case(target_fqn) {
@@ -125,7 +125,7 @@ fn same_file_variable_locations(file: &MagoFile, raw: &[u8]) -> Vec<Location> {
     let Some(path) = file.path.as_ref() else {
         return Vec::new();
     };
-    let Ok(url) = Url::from_file_path(path) else {
+    let Some(url) = Uri::from_file_path(path) else {
         return Vec::new();
     };
     lookup::lex(file)

--- a/src/language_server/capabilities/rename.rs
+++ b/src/language_server/capabilities/rename.rs
@@ -10,11 +10,11 @@ use foldhash::HashMap;
 
 use mago_database::file::File as MagoFile;
 use mago_names::ResolvedNames;
-use tower_lsp::lsp_types::PrepareRenameResponse;
-use tower_lsp::lsp_types::Range;
-use tower_lsp::lsp_types::TextEdit;
-use tower_lsp::lsp_types::Url;
-use tower_lsp::lsp_types::WorkspaceEdit;
+use tower_lsp_server::ls_types::PrepareRenameResponse;
+use tower_lsp_server::ls_types::Range;
+use tower_lsp_server::ls_types::TextEdit;
+use tower_lsp_server::ls_types::Uri;
+use tower_lsp_server::ls_types::WorkspaceEdit;
 
 use crate::language_server::capabilities::lookup;
 use crate::language_server::position::range_at_offsets;
@@ -55,7 +55,7 @@ pub fn compute(
         return None;
     }
 
-    let mut changes: HashMap<Url, Vec<TextEdit>> = HashMap::default();
+    let mut changes: HashMap<Uri, Vec<TextEdit>> = HashMap::default();
     for loc in locations {
         changes
             .entry(loc.uri)

--- a/src/language_server/capabilities/selection_range.rs
+++ b/src/language_server/capabilities/selection_range.rs
@@ -3,8 +3,8 @@
 //! ([`super::super::file_analysis::FileAnalysis::node_spans`]).
 
 use mago_database::file::File as MagoFile;
-use tower_lsp::lsp_types::Range;
-use tower_lsp::lsp_types::SelectionRange;
+use tower_lsp_server::ls_types::Range;
+use tower_lsp_server::ls_types::SelectionRange;
 
 use crate::language_server::file_analysis::FileAnalysis;
 use crate::language_server::position::range_at_offsets;

--- a/src/language_server/capabilities/semantic_tokens.rs
+++ b/src/language_server/capabilities/semantic_tokens.rs
@@ -8,8 +8,8 @@
 use mago_database::file::File as MagoFile;
 use mago_syntax::token::Token;
 use mago_syntax::token::TokenKind;
-use tower_lsp::lsp_types::SemanticToken;
-use tower_lsp::lsp_types::SemanticTokenType;
+use tower_lsp_server::ls_types::SemanticToken;
+use tower_lsp_server::ls_types::SemanticTokenType;
 
 use crate::language_server::capabilities::lookup;
 

--- a/src/language_server/capabilities/signature_help.rs
+++ b/src/language_server/capabilities/signature_help.rs
@@ -13,10 +13,10 @@ use mago_codex::ttype::TType;
 use mago_database::file::File as MagoFile;
 use mago_names::ResolvedNames;
 use mago_syntax::token::TokenKind;
-use tower_lsp::lsp_types::ParameterInformation;
-use tower_lsp::lsp_types::ParameterLabel;
-use tower_lsp::lsp_types::SignatureHelp;
-use tower_lsp::lsp_types::SignatureInformation;
+use tower_lsp_server::ls_types::ParameterInformation;
+use tower_lsp_server::ls_types::ParameterLabel;
+use tower_lsp_server::ls_types::SignatureHelp;
+use tower_lsp_server::ls_types::SignatureInformation;
 
 use crate::language_server::capabilities::lookup;
 

--- a/src/language_server/capabilities/workspace_symbol.rs
+++ b/src/language_server/capabilities/workspace_symbol.rs
@@ -13,16 +13,17 @@ use mago_database::DatabaseReader;
 use mago_database::file::FileType;
 use mago_span::Span;
 use mago_word::Word;
-use tower_lsp::lsp_types::Location;
-use tower_lsp::lsp_types::SymbolInformation;
-use tower_lsp::lsp_types::SymbolKind as LspSymbolKind;
-use tower_lsp::lsp_types::Url;
+use tower_lsp_server::ls_types::Location;
+use tower_lsp_server::ls_types::SymbolInformation;
+use tower_lsp_server::ls_types::SymbolKind as LspSymbolKind;
+use tower_lsp_server::ls_types::Uri;
+use tower_lsp_server::ls_types::WorkspaceSymbolResponse;
 
 use crate::language_server::position::range_at_offsets;
 
 const MAX_RESULTS: usize = 256;
 
-pub fn compute(database: &Database<'_>, codebase: &CodebaseMetadata, query: &str) -> Vec<SymbolInformation> {
+pub fn compute(database: &Database<'_>, codebase: &CodebaseMetadata, query: &str) -> WorkspaceSymbolResponse {
     let needle = query.as_bytes().to_ascii_lowercase();
     let mut out = Vec::new();
 
@@ -45,7 +46,7 @@ pub fn compute(database: &Database<'_>, codebase: &CodebaseMetadata, query: &str
             });
         }
         if out.len() >= MAX_RESULTS {
-            return out;
+            return WorkspaceSymbolResponse::Flat(out);
         }
     }
 
@@ -71,7 +72,7 @@ pub fn compute(database: &Database<'_>, codebase: &CodebaseMetadata, query: &str
             });
         }
         if out.len() >= MAX_RESULTS {
-            return out;
+            return WorkspaceSymbolResponse::Flat(out);
         }
     }
 
@@ -94,11 +95,11 @@ pub fn compute(database: &Database<'_>, codebase: &CodebaseMetadata, query: &str
             });
         }
         if out.len() >= MAX_RESULTS {
-            return out;
+            return WorkspaceSymbolResponse::Flat(out);
         }
     }
 
-    out
+    WorkspaceSymbolResponse::Flat(out)
 }
 
 /// Substring match against the lowercased FQCN/FQN.
@@ -128,7 +129,7 @@ fn classlike_kind(k: MagoSymbolKind) -> LspSymbolKind {
 fn span_to_location(database: &Database<'_>, span: Span) -> Option<Location> {
     let file = database.get(&span.file_id).ok()?;
     let path = file.path.as_ref()?;
-    let url = Url::from_file_path(path).ok()?;
+    let url = Uri::from_file_path(path)?;
     let range = range_at_offsets(&file, span.start.offset, span.end.offset);
     Some(Location { uri: url, range })
 }

--- a/src/language_server/diagnostics.rs
+++ b/src/language_server/diagnostics.rs
@@ -1,12 +1,12 @@
 //! Issue → LSP `Diagnostic` conversion and publish helpers.
 
 use foldhash::HashMap;
-use tower_lsp::lsp_types::Diagnostic;
-use tower_lsp::lsp_types::DiagnosticRelatedInformation;
-use tower_lsp::lsp_types::DiagnosticSeverity;
-use tower_lsp::lsp_types::Location;
-use tower_lsp::lsp_types::NumberOrString;
-use tower_lsp::lsp_types::Url;
+use tower_lsp_server::ls_types::Diagnostic;
+use tower_lsp_server::ls_types::DiagnosticRelatedInformation;
+use tower_lsp_server::ls_types::DiagnosticSeverity;
+use tower_lsp_server::ls_types::Location;
+use tower_lsp_server::ls_types::NumberOrString;
+use tower_lsp_server::ls_types::Uri;
 
 use mago_analyzer::analysis_result::AnalysisResult;
 use mago_database::Database;
@@ -28,11 +28,11 @@ pub fn build_diagnostics<'a, I>(
     database: &Database<'_>,
     result: &AnalysisResult,
     lint_issues: I,
-) -> HashMap<Url, Vec<Diagnostic>>
+) -> HashMap<Uri, Vec<Diagnostic>>
 where
     I: IntoIterator<Item = &'a IssueCollection>,
 {
-    let mut by_url: HashMap<Url, Vec<Diagnostic>> = HashMap::default();
+    let mut by_url: HashMap<Uri, Vec<Diagnostic>> = HashMap::default();
 
     for issue in result.issues.iter() {
         push_issue(database, &mut by_url, issue);
@@ -47,7 +47,7 @@ where
     by_url
 }
 
-fn push_issue(database: &Database<'_>, by_url: &mut HashMap<Url, Vec<Diagnostic>>, issue: &Issue) {
+fn push_issue(database: &Database<'_>, by_url: &mut HashMap<Uri, Vec<Diagnostic>>, issue: &Issue) {
     let Some(annotation) = primary_annotation(issue) else {
         return;
     };
@@ -60,7 +60,7 @@ fn push_issue(database: &Database<'_>, by_url: &mut HashMap<Url, Vec<Diagnostic>
         return;
     };
 
-    let Ok(url) = Url::from_file_path(path) else {
+    let Some(url) = Uri::from_file_path(path) else {
         return;
     };
 
@@ -107,7 +107,7 @@ fn secondary_related_info(database: &Database<'_>, issue: &Issue) -> Vec<Diagnos
         let Some(path) = &file.path else {
             continue;
         };
-        let Ok(url) = Url::from_file_path(path) else {
+        let Some(url) = Uri::from_file_path(path) else {
             continue;
         };
 

--- a/src/language_server/file_analysis.rs
+++ b/src/language_server/file_analysis.rs
@@ -32,8 +32,8 @@ use mago_syntax::ast::Try;
 use mago_syntax::parser::parse_file_with_settings;
 use mago_syntax::walker::Walker;
 use mago_syntax::walker::walk_program;
-use tower_lsp::lsp_types::FoldingRange;
-use tower_lsp::lsp_types::FoldingRangeKind;
+use tower_lsp_server::ls_types::FoldingRange;
+use tower_lsp_server::ls_types::FoldingRangeKind;
 
 use crate::language_server::linter::LinterContext;
 

--- a/src/language_server/mod.rs
+++ b/src/language_server/mod.rs
@@ -14,8 +14,8 @@ use std::sync::Arc;
 
 use tokio::io::AsyncRead;
 use tokio::io::AsyncWrite;
-use tower_lsp::LspService;
-use tower_lsp::Server;
+use tower_lsp_server::LspService;
+use tower_lsp_server::Server;
 
 mod backend;
 mod capabilities;

--- a/src/language_server/position.rs
+++ b/src/language_server/position.rs
@@ -10,8 +10,8 @@
 //! ship the negotiated `general.positionEncodings` capability.
 
 use mago_database::file::File as MagoFile;
-use tower_lsp::lsp_types::Position;
-use tower_lsp::lsp_types::Range;
+use tower_lsp_server::ls_types::Position;
+use tower_lsp_server::ls_types::Range;
 
 /// Convert a byte offset in `file` to an LSP [`Position`].
 #[must_use]

--- a/src/language_server/state.rs
+++ b/src/language_server/state.rs
@@ -10,8 +10,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use foldhash::HashMap;
-use tower_lsp::lsp_types::Diagnostic;
-use tower_lsp::lsp_types::Url;
+use tower_lsp_server::ls_types::Diagnostic;
+use tower_lsp_server::ls_types::Uri;
 
 use std::borrow::Cow;
 use std::path::Path;
@@ -49,8 +49,8 @@ pub struct WorkspaceState {
     pub service: IncrementalAnalysisService,
     pub linter: LinterContext,
     pub config: Arc<ServerConfig>,
-    pub open_documents: HashMap<Url, OpenDocument>,
-    pub last_diagnostics: HashMap<Url, Vec<Diagnostic>>,
+    pub open_documents: HashMap<Uri, OpenDocument>,
+    pub last_diagnostics: HashMap<Uri, Vec<Diagnostic>>,
     /// Per-file derived data; lint issues, name index, fold ranges,
     /// AST node spans; all built in one parse + resolve pass per
     /// file content change. See [`super::file_analysis::FileAnalysis`].

--- a/src/language_server/workspace.rs
+++ b/src/language_server/workspace.rs
@@ -7,8 +7,8 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use mago_database::file::FileId;
-use tower_lsp::lsp_types::InitializeParams;
-use tower_lsp::lsp_types::Url;
+use tower_lsp_server::ls_types::InitializeParams;
+use tower_lsp_server::ls_types::Uri;
 
 /// Resolve the workspace root from `initialize` params, in the order the
 /// LSP spec recommends: `workspaceFolders`, then deprecated `rootUri`, then
@@ -17,16 +17,16 @@ use tower_lsp::lsp_types::Url;
 pub fn workspace_root(params: &InitializeParams) -> Option<PathBuf> {
     if let Some(folders) = &params.workspace_folders
         && let Some(first) = folders.first()
-        && let Ok(path) = first.uri.to_file_path()
+        && let Some(path) = first.uri.to_file_path()
     {
-        return Some(path);
+        return Some(path.into_owned());
     }
 
     #[allow(deprecated)]
     if let Some(uri) = &params.root_uri
-        && let Ok(path) = uri.to_file_path()
+        && let Some(path) = uri.to_file_path()
     {
-        return Some(path);
+        return Some(path.into_owned());
     }
 
     #[allow(deprecated)]
@@ -52,6 +52,6 @@ pub fn file_id_for(workspace: &Path, path: &Path) -> FileId {
 
 /// Convert a filesystem path to an LSP `file://` URL.
 #[allow(dead_code)]
-pub fn url_for_path(path: &Path) -> Option<Url> {
-    Url::from_file_path(path).ok()
+pub fn url_for_path(path: &Path) -> Option<Uri> {
+    Uri::from_file_path(path)
 }


### PR DESCRIPTION
## 📌 What Does This PR Do?

Switch from tower_lsp to the community fork tower_lsp_server.

## 🔍 Context & Motivation

tower_lsp_server is the community fork of tower_lsp which is maintained while tower_lsp has not seen a release in three years. This fixes, probably besides other thigs, an issue where the server hangs after completing the exit request, doing nothing but holding onto the memory it reserved.

## 🛠️ Summary of Changes

- **Refactor:** Switch from tower_lsp to tower_lsp_server.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): language server

