### PR TITLE
fix(database): stop watcher from adding new vendor-path files as host files

### DIFF
--- a/crates/database/src/loader.rs
+++ b/crates/database/src/loader.rs
@@ -148,7 +148,11 @@ impl<'config> DatabaseLoader<'config> {
         )?;
 
         let mut all_files: HashMap<FileId, File> = HashMap::default();
-        let mut file_decisions: HashMap<FileId, (FileType, usize)> = HashMap::default();
+        // Per-file maximum specificity for each tier the file matched. `None` in a slot means
+        // the file did not match any configured pattern in that tier; otherwise it carries the
+        // best specificity score that tier could offer, scored by `calculate_pattern_specificity`.
+        let mut file_specificities: HashMap<FileId, (Option<usize>, Option<usize>)> = HashMap::default();
+        let bump_spec = |slot: &mut Option<usize>, s: usize| *slot = Some(slot.map_or(s, |e| e.max(s)));
 
         // Process host files (from paths)
         for file_with_spec in host_files_with_spec {
@@ -156,7 +160,7 @@ impl<'config> DatabaseLoader<'config> {
             let specificity = file_with_spec.specificity;
 
             all_files.insert(file_id, file_with_spec.file);
-            file_decisions.insert(file_id, (FileType::Host, specificity));
+            bump_spec(&mut file_specificities.entry(file_id).or_insert((None, None)).0, specificity);
         }
 
         // When stdin override is set, ensure that the file is in the database
@@ -191,7 +195,7 @@ impl<'config> DatabaseLoader<'config> {
                 if let Entry::Vacant(e) = all_files.entry(file_id) {
                     e.insert(file);
 
-                    file_decisions.insert(file_id, (FileType::Host, usize::MAX));
+                    bump_spec(&mut file_specificities.entry(file_id).or_insert((None, None)).0, usize::MAX);
                 }
             }
         }
@@ -201,22 +205,14 @@ impl<'config> DatabaseLoader<'config> {
             let vendored_specificity = file_with_spec.specificity;
 
             all_files.entry(file_id).or_insert(file_with_spec.file);
-
-            match file_decisions.get(&file_id) {
-                Some((FileType::Host, host_specificity)) if vendored_specificity < *host_specificity => {
-                    // Keep Host
-                }
-                _ => {
-                    file_decisions.insert(file_id, (FileType::Vendored, vendored_specificity));
-                }
-            }
+            bump_spec(&mut file_specificities.entry(file_id).or_insert((None, None)).1, vendored_specificity);
         }
 
-        db.reserve(file_decisions.len() + self.memory_sources.len());
+        db.reserve(file_specificities.len() + self.memory_sources.len());
 
-        for (file_id, (final_type, _)) in file_decisions {
+        for (file_id, specificities) in file_specificities {
             if let Some(mut file) = all_files.remove(&file_id) {
-                file.file_type = final_type;
+                file.file_type = resolve_file_type(specificities);
                 db.add(file);
             }
         }
@@ -297,7 +293,7 @@ impl<'config> DatabaseLoader<'config> {
             let is_glob_pattern = !resolved_path.exists()
                 && (root.contains(&b'*') || root.contains(&b'?') || root.contains(&b'[') || root.contains(&b'{'));
 
-            let specificity = Self::calculate_pattern_specificity(root.as_ref());
+            let specificity = calculate_pattern_specificity(root.as_ref());
             if is_glob_pattern {
                 // Handle as glob pattern
                 let pattern = if root_path.is_absolute() {
@@ -443,38 +439,54 @@ impl<'config> DatabaseLoader<'config> {
 
         Ok(files)
     }
+}
 
-    /// Calculates how specific a pattern is for a given file path.
-    ///
-    /// Examples:
-    ///
-    /// - "src/b.php" matching src/b.php: ~2000 (exact file, 2 components)
-    /// - "src/" matching src/b.php: ~100 (directory, 1 component)
-    /// - "src" matching src/b.php: ~100 (directory, 1 component)
-    fn calculate_pattern_specificity(pattern: &[u8]) -> usize {
-        let pattern_path = bytes_to_path(pattern);
+/// Calculates how specific a pattern is for a given file path.
+///
+/// Examples:
+///
+/// - "src/b.php" matching src/b.php: ~2000 (exact file, 2 components)
+/// - "src/" matching src/b.php: ~100 (directory, 1 component)
+/// - "src" matching src/b.php: ~100 (directory, 1 component)
+pub(crate) fn calculate_pattern_specificity(pattern: &[u8]) -> usize {
+    let pattern_path = bytes_to_path(pattern);
 
-        let component_count = pattern_path.components().count();
-        let is_glob =
-            pattern.contains(&b'*') || pattern.contains(&b'?') || pattern.contains(&b'[') || pattern.contains(&b'{');
+    let component_count = pattern_path.components().count();
+    let is_glob =
+        pattern.contains(&b'*') || pattern.contains(&b'?') || pattern.contains(&b'[') || pattern.contains(&b'{');
 
-        if is_glob {
-            let non_wildcard_components = pattern_path
-                .components()
-                .filter(|c| {
-                    let s = c.as_os_str().to_string_lossy();
-                    !s.contains('*') && !s.contains('?') && !s.contains('[') && !s.contains('{')
-                })
-                .count();
-            non_wildcard_components * 10
-        } else if pattern_path.is_file()
-            || pattern_path.extension().is_some()
-            || pattern.rsplit(|&b| b == b'.').next().is_some_and(|ext| ext.eq_ignore_ascii_case(b"php"))
-        {
-            component_count * 1000
-        } else {
-            component_count * 100
-        }
+    if is_glob {
+        let non_wildcard_components = pattern_path
+            .components()
+            .filter(|c| {
+                let s = c.as_os_str().to_string_lossy();
+                !s.contains('*') && !s.contains('?') && !s.contains('[') && !s.contains('{')
+            })
+            .count();
+        non_wildcard_components * 10
+    } else if pattern_path.is_file()
+        || pattern_path.extension().is_some()
+        || pattern.rsplit(|&b| b == b'.').next().is_some_and(|ext| ext.eq_ignore_ascii_case(b"php"))
+    {
+        component_count * 1000
+    } else {
+        component_count * 100
+    }
+}
+
+/// Picks the final [`FileType`] for a file that matched configured base paths in one or
+/// more tiers.
+///
+/// `host_specificity` and `vendored_specificity` are the maximum specificity scores of any
+/// matching base path in each tier, or `None` if no base path in that tier matched.
+/// Vendored wins over Host at equal-or-more specificity; Host wins only when strictly more
+/// specific. When nothing matches the result is `Host`.
+pub(crate) fn resolve_file_type((host_specificity, vendored_specificity): (Option<usize>, Option<usize>)) -> FileType {
+    match (host_specificity, vendored_specificity) {
+        (Some(h), Some(v)) if v < h => FileType::Host,
+        (_, Some(_)) => FileType::Vendored,
+        (Some(_), None) => FileType::Host,
+        (None, None) => FileType::Host,
     }
 }
 
@@ -515,30 +527,54 @@ mod tests {
     }
 
     #[test]
-    fn test_specificity_calculation_exact_file() {
-        let spec = DatabaseLoader::calculate_pattern_specificity(b"src/b.php");
-        assert!(spec >= 2000, "Exact file should have high specificity, got {spec}");
+    fn defaults_to_host_when_nothing_matches() {
+        assert_eq!(resolve_file_type((None, None)), FileType::Host);
     }
 
     #[test]
-    fn test_specificity_calculation_directory() {
-        let spec = DatabaseLoader::calculate_pattern_specificity(b"src/");
-        assert!((100..1000).contains(&spec), "Directory should have moderate specificity, got {spec}");
+    fn host_only_match_yields_host() {
+        assert_eq!(resolve_file_type((Some(100), None)), FileType::Host);
     }
 
     #[test]
-    fn test_specificity_calculation_glob() {
-        let spec = DatabaseLoader::calculate_pattern_specificity(b"src/*.php");
-        assert!(spec < 100, "Glob pattern should have low specificity, got {spec}");
+    fn vendored_only_match_yields_vendored() {
+        assert_eq!(resolve_file_type((None, Some(100))), FileType::Vendored);
     }
 
     #[test]
-    fn test_specificity_calculation_deeper_path() {
-        let shallow_spec = DatabaseLoader::calculate_pattern_specificity(b"src/");
-        let deep_spec = DatabaseLoader::calculate_pattern_specificity(b"src/foo/bar/");
-        assert!(deep_spec > shallow_spec, "Deeper path should have higher specificity");
+    fn vendored_beats_host_at_equal_specificity() {
+        assert_eq!(resolve_file_type((Some(100), Some(100))), FileType::Vendored);
     }
 
+    #[test]
+    fn vendored_beats_host_when_more_specific() {
+        assert_eq!(resolve_file_type((Some(100), Some(2000))), FileType::Vendored);
+    }
+
+    #[test]
+    fn host_beats_vendored_only_when_strictly_more_specific() {
+        assert_eq!(resolve_file_type((Some(2000), Some(100))), FileType::Host);
+    }
+
+    #[test]
+    fn exact_file_path_beats_directory_at_same_component_count() {
+        assert!(calculate_pattern_specificity(b"src/foo.php") > calculate_pattern_specificity(b"src/foo"));
+    }
+
+    #[test]
+    fn directory_beats_glob_at_same_non_wildcard_count() {
+        assert!(calculate_pattern_specificity(b"src/") > calculate_pattern_specificity(b"src/**/*.php"));
+    }
+
+    #[test]
+    fn deeper_path_beats_shallower_at_same_kind() {
+        assert!(calculate_pattern_specificity(b"src/inner/") > calculate_pattern_specificity(b"src/"));
+    }
+
+    #[test]
+    fn extensionless_phpish_pattern_treated_as_file() {
+        assert_eq!(calculate_pattern_specificity(b"src/foo.PHP"), calculate_pattern_specificity(b"src/foo.php"),);
+    }
     #[test]
     fn test_exact_file_vs_directory() {
         let temp_dir = TempDir::new().unwrap();

--- a/crates/database/src/watcher.rs
+++ b/crates/database/src/watcher.rs
@@ -30,6 +30,8 @@ use crate::exclusion::Exclusion;
 use crate::file::File;
 use crate::file::FileId;
 use crate::file::FileType;
+use crate::loader::calculate_pattern_specificity;
+use crate::loader::resolve_file_type;
 use crate::utils::bytes_to_path;
 
 const DEFAULT_POLL_INTERVAL_MS: u64 = 1000;
@@ -63,13 +65,27 @@ pub struct DatabaseWatcher<'config> {
     watcher: Option<RecommendedWatcher>,
     watched_paths: Vec<PathBuf>,
     receiver: Option<Receiver<Vec<ChangedFile>>>,
+    /// Configured host base paths paired with their loader-style specificity score.
+    ///
+    /// Carrying the score (computed via [`calculate_pattern_specificity`] over the original
+    /// pattern, before stripping any glob suffix) is what lets the watcher and the loader
+    /// agree on which [`FileType`] a newly-added file should get.
+    host_base_paths: Vec<(PathBuf, usize)>,
+    include_base_paths: Vec<(PathBuf, usize)>,
 }
 
 impl<'config> DatabaseWatcher<'config> {
     #[inline]
     #[must_use]
     pub fn new(database: Database<'config>) -> Self {
-        Self { database, watcher: None, watched_paths: Vec::new(), receiver: None }
+        Self {
+            database,
+            watcher: None,
+            watched_paths: Vec::new(),
+            receiver: None,
+            host_base_paths: Vec::new(),
+            include_base_paths: Vec::new(),
+        }
     }
 
     /// Starts watching for file changes in the configured directories.
@@ -130,17 +146,26 @@ impl<'config> DatabaseWatcher<'config> {
         // receive change events for files under that directory).
         let mut unique_watch_paths = HashSet::new();
 
+        let mut host_base_paths = Vec::new();
         for path in &config.paths {
+            // Compute specificity on the original pattern (with glob intact); the watch path
+            // strips trailing globs so the watcher can recurse into a real directory.
+            let specificity = calculate_pattern_specificity(path.as_ref());
             let watch_path = Self::extract_watch_path(path.as_ref());
             let absolute_path = if watch_path.is_absolute() { watch_path } else { config.workspace.join(watch_path) };
 
+            let canonical = absolute_path.canonicalize().unwrap_or_else(|_| absolute_path.clone());
+            host_base_paths.push((canonical, specificity));
             unique_watch_paths.insert(absolute_path);
         }
 
+        let mut include_base_paths = Vec::new();
         for path in &config.includes {
+            let specificity = calculate_pattern_specificity(path.as_ref());
             let watch_path = Self::extract_watch_path(path.as_ref());
             let absolute_path = if watch_path.is_absolute() { watch_path } else { config.workspace.join(watch_path) };
-
+            let canonical = absolute_path.canonicalize().unwrap_or_else(|_| absolute_path.clone());
+            include_base_paths.push((canonical, specificity));
             unique_watch_paths.insert(absolute_path);
         }
 
@@ -182,6 +207,8 @@ impl<'config> DatabaseWatcher<'config> {
         self.watcher = Some(watcher);
         self.watched_paths = watched_paths;
         self.receiver = Some(rx);
+        self.host_base_paths = host_base_paths;
+        self.include_base_paths = include_base_paths;
 
         Ok(())
     }
@@ -197,6 +224,8 @@ impl<'config> DatabaseWatcher<'config> {
         }
         self.watched_paths.clear();
         self.receiver = None;
+        self.host_base_paths.clear();
+        self.include_base_paths.clear();
     }
 
     /// Checks if the watcher is currently active.
@@ -363,7 +392,12 @@ impl<'config> DatabaseWatcher<'config> {
 
                     let Ok(file) = self.database.get(&changed_file.id) else {
                         if changed_file.path.exists() {
-                            match File::read(&workspace, &changed_file.path, FileType::Host) {
+                            let new_file_type = classify_added_file(
+                                &changed_file.path,
+                                &self.host_base_paths,
+                                &self.include_base_paths,
+                            );
+                            match File::read(&workspace, &changed_file.path, new_file_type) {
                                 Ok(file) => {
                                     self.database.add(file);
                                     tracing::debug!("Added new file to database: {}", changed_file.path.display());
@@ -484,5 +518,83 @@ impl Drop for DatabaseWatcher<'_> {
     #[inline]
     fn drop(&mut self) {
         self.stop();
+    }
+}
+
+/// Picks the [`FileType`] for a newly-discovered file based on which configured base path
+/// it lives under.
+///
+/// Computes the per-tier maximum specificity over every base path the file matched (paired
+/// with the pattern's [`calculate_pattern_specificity`] score) and delegates to
+/// [`resolve_file_type`] for the actual conflict resolution. The watcher and the loader
+/// therefore reach the same `FileType` for the same file under the same configuration —
+/// see the helper's docs for the priority rules.
+fn classify_added_file(path: &Path, host_bases: &[(PathBuf, usize)], include_bases: &[(PathBuf, usize)]) -> FileType {
+    let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let max_spec = |bases: &[(PathBuf, usize)]| {
+        bases.iter().filter(|(b, _)| canonical.starts_with(b.as_path())).map(|(_, s)| *s).max()
+    };
+
+    resolve_file_type((max_spec(host_bases), max_spec(include_bases)))
+}
+
+#[cfg(test)]
+mod classify_added_file_tests {
+    use super::*;
+
+    fn bases(items: &[&str]) -> Vec<(PathBuf, usize)> {
+        items.iter().map(|p| (PathBuf::from(p), calculate_pattern_specificity(p.as_bytes()))).collect()
+    }
+
+    #[test]
+    fn defaults_to_host_when_no_base_matches() {
+        let ft = classify_added_file(Path::new("/ws/orphan/foo.php"), &bases(&["/ws/src"]), &bases(&["/ws/stubs"]));
+        assert_eq!(ft, FileType::Host);
+    }
+
+    #[test]
+    fn vendored_when_only_include_matches() {
+        // Regression test: prior to this fix the watcher hardcoded `FileType::Host` for
+        // every newly-discovered file, so a fresh PHP file dropped into an `includes`
+        // directory at runtime was wrongly added as source and linted as such.
+        let ft = classify_added_file(Path::new("/ws/stubs/foo.php"), &bases(&["/ws/src"]), &bases(&["/ws/stubs"]));
+        assert_eq!(ft, FileType::Vendored);
+    }
+
+    #[test]
+    fn host_when_only_host_matches() {
+        let ft = classify_added_file(Path::new("/ws/src/foo.php"), &bases(&["/ws/src"]), &bases(&["/ws/stubs"]));
+        assert_eq!(ft, FileType::Host);
+    }
+
+    #[test]
+    fn matches_loader_at_equal_specificity_for_same_dir_under_both() {
+        // The same directory configured under both `paths` and `includes`: vendored wins,
+        // matching the loader's "vendored beats host at equal specificity" rule. Catches
+        // the divergence the original watcher hit (it was awarding the file to host).
+        let ft = classify_added_file(Path::new("/ws/shared/foo.php"), &bases(&["/ws/shared"]), &bases(&["/ws/shared"]));
+        assert_eq!(ft, FileType::Vendored);
+    }
+
+    #[test]
+    fn include_wins_when_strictly_more_specific() {
+        // An include path nested inside a host path overrides for files under the nested
+        // path. Matches the loader's "vendored beats host when strictly more specific".
+        let ft = classify_added_file(
+            Path::new("/ws/src/vendor/stub.php"),
+            &bases(&["/ws/src"]),
+            &bases(&["/ws/src/vendor"]),
+        );
+        assert_eq!(ft, FileType::Vendored);
+    }
+
+    #[test]
+    fn exact_host_file_beats_directory_include_via_loader_score() {
+        // Catches the second divergence: with the component-count heuristic the watcher
+        // treated `src/` and `src/foo.php` as equally specific (both 2 components) and
+        // gave the file to vendored; the loader-aligned specificity score (file × 1000
+        // beats dir × 100) instead keeps it on host.
+        let ft = classify_added_file(Path::new("/ws/src/foo.php"), &bases(&["/ws/src/foo.php"]), &bases(&["/ws/src"]));
+        assert_eq!(ft, FileType::Host);
     }
 }


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes watch mode reporting issues on vendor files.

## 🔍 Context & Motivation

Currently, adding a file to the vendor paths (say adding/updating a new package) can make `--watch` mode display diagnostics for those vendor files. We don't want that.

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed watch mode reporting issues in newly added vendor files.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [x] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
