### PR TITLE
feat(phpdoc-syntax): introduce a new phpdoc parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,6 +1751,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mago-phpdoc-syntax"
+version = "1.29.0"
+dependencies = [
+ "bumpalo",
+ "indoc",
+ "mago-database",
+ "mago-span",
+ "mago-syntax-core",
+ "memchr",
+ "ordered-float",
+ "serde",
+ "strum 0.28.0",
+]
+
+[[package]]
 name = "mago-prelude"
 version = "1.29.0"
 dependencies = [

--- a/Justfile
+++ b/Justfile
@@ -89,6 +89,7 @@ publish:
     cargo publish -p mago-span
     cargo publish -p mago-reporting
     cargo publish -p mago-syntax-core
+    cargo publish -p mago-phpdoc-syntax
     cargo publish -p mago-syntax
     cargo publish -p mago-collector
     cargo publish -p mago-type-syntax

--- a/crates/phpdoc-syntax/Cargo.toml
+++ b/crates/phpdoc-syntax/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "mago-phpdoc-syntax"
+description = "A unified parser for PHPDoc comments and their embedded type and constant expressions."
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+mago-database = { workspace = true }
+mago-span = { workspace = true }
+mago-syntax-core = { workspace = true }
+bumpalo = { workspace = true }
+memchr = { workspace = true }
+serde = { workspace = true }
+strum = { workspace = true }
+ordered-float = { workspace = true, features = ["serde", "rand"] }
+
+[dev-dependencies]
+indoc = { workspace = true }

--- a/crates/phpdoc-syntax/src/cst/element.rs
+++ b/crates/phpdoc-syntax/src/cst/element.rs
@@ -1,0 +1,23 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::tag::Tag;
+use crate::cst::text::Text;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+#[serde(tag = "kind", content = "value")]
+pub enum Element<'arena> {
+    Tag(&'arena Tag<'arena>),
+    Text(Text<'arena>),
+}
+
+impl HasSpan for Element<'_> {
+    fn span(&self) -> Span {
+        match self {
+            Element::Tag(tag) => tag.span(),
+            Element::Text(text) => text.span(),
+        }
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/expression/access.rs
+++ b/crates/phpdoc-syntax/src/cst/expression/access.rs
@@ -1,0 +1,30 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::identifier::Identifier;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct ConstantAccessExpression<'arena> {
+    pub name: Identifier<'arena>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct ClassLikeConstantAccessExpression<'arena> {
+    pub class: Identifier<'arena>,
+    pub double_colon: Span,
+    pub constant: Identifier<'arena>,
+}
+
+impl HasSpan for ConstantAccessExpression<'_> {
+    fn span(&self) -> Span {
+        self.name.span()
+    }
+}
+
+impl HasSpan for ClassLikeConstantAccessExpression<'_> {
+    fn span(&self) -> Span {
+        self.class.span().join(self.constant.span())
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/expression/array.rs
+++ b/crates/phpdoc-syntax/src/cst/expression/array.rs
@@ -1,0 +1,40 @@
+use mago_syntax_core::ast::TokenSeparatedSequence;
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::expression::ConstantExpression;
+use crate::cst::keyword::Keyword;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct ArrayConstant<'arena> {
+    pub keyword: Option<Keyword<'arena>>,
+    pub left_delimiter: Span,
+    pub items: TokenSeparatedSequence<'arena, ArrayConstantItem<'arena>, Span>,
+    pub right_delimiter: Span,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct ArrayConstantItem<'arena> {
+    pub key: Option<&'arena ConstantExpression<'arena>>,
+    pub double_arrow: Option<Span>,
+    pub value: &'arena ConstantExpression<'arena>,
+}
+
+impl HasSpan for ArrayConstant<'_> {
+    fn span(&self) -> Span {
+        match &self.keyword {
+            Some(keyword) => keyword.span().join(self.right_delimiter),
+            None => self.left_delimiter.join(self.right_delimiter),
+        }
+    }
+}
+
+impl HasSpan for ArrayConstantItem<'_> {
+    fn span(&self) -> Span {
+        let start = self.key.map_or_else(|| self.value.span(), HasSpan::span);
+
+        start.join(self.value.span())
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/expression/literal.rs
+++ b/crates/phpdoc-syntax/src/cst/expression/literal.rs
@@ -1,0 +1,44 @@
+use ordered_float::OrderedFloat;
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct IntegerConstant<'arena> {
+    pub span: Span,
+    pub value: u64,
+    pub raw: &'arena [u8],
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct FloatConstant<'arena> {
+    pub span: Span,
+    pub value: OrderedFloat<f64>,
+    pub raw: &'arena [u8],
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct StringConstant<'arena> {
+    pub span: Span,
+    pub value: &'arena [u8],
+    pub raw: &'arena [u8],
+}
+
+impl HasSpan for IntegerConstant<'_> {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl HasSpan for FloatConstant<'_> {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl HasSpan for StringConstant<'_> {
+    fn span(&self) -> Span {
+        self.span
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/expression/mod.rs
+++ b/crates/phpdoc-syntax/src/cst/expression/mod.rs
@@ -1,0 +1,48 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::keyword::Keyword;
+
+pub use crate::cst::expression::access::*;
+pub use crate::cst::expression::array::*;
+pub use crate::cst::expression::literal::*;
+pub use crate::cst::expression::unary::*;
+
+pub mod access;
+pub mod array;
+pub mod literal;
+pub mod unary;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+#[serde(tag = "kind", content = "value")]
+pub enum ConstantExpression<'arena> {
+    Integer(IntegerConstant<'arena>),
+    Float(FloatConstant<'arena>),
+    String(StringConstant<'arena>),
+    True(Keyword<'arena>),
+    False(Keyword<'arena>),
+    Null(Keyword<'arena>),
+    UnaryPrefix(UnaryPrefixConstantExpression<'arena>),
+    ConstantAccess(ConstantAccessExpression<'arena>),
+    ClassLikeConstantAccess(ClassLikeConstantAccessExpression<'arena>),
+    Array(ArrayConstant<'arena>),
+}
+
+impl HasSpan for ConstantExpression<'_> {
+    fn span(&self) -> Span {
+        match self {
+            ConstantExpression::Integer(expression) => expression.span(),
+            ConstantExpression::Float(expression) => expression.span(),
+            ConstantExpression::String(expression) => expression.span(),
+            ConstantExpression::True(keyword) => keyword.span(),
+            ConstantExpression::False(keyword) => keyword.span(),
+            ConstantExpression::Null(keyword) => keyword.span(),
+            ConstantExpression::UnaryPrefix(expression) => expression.span(),
+            ConstantExpression::ConstantAccess(expression) => expression.span(),
+            ConstantExpression::ClassLikeConstantAccess(expression) => expression.span(),
+            ConstantExpression::Array(expression) => expression.span(),
+        }
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/expression/unary.rs
+++ b/crates/phpdoc-syntax/src/cst/expression/unary.rs
@@ -1,0 +1,34 @@
+use serde::Serialize;
+use strum::Display;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::expression::ConstantExpression;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord, Display)]
+#[serde(tag = "type", content = "value")]
+pub enum UnaryPrefixConstantOperator {
+    Plus(Span),
+    Negation(Span),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct UnaryPrefixConstantExpression<'arena> {
+    pub operator: UnaryPrefixConstantOperator,
+    pub operand: &'arena ConstantExpression<'arena>,
+}
+
+impl HasSpan for UnaryPrefixConstantOperator {
+    fn span(&self) -> Span {
+        match self {
+            Self::Plus(span) | Self::Negation(span) => *span,
+        }
+    }
+}
+
+impl HasSpan for UnaryPrefixConstantExpression<'_> {
+    fn span(&self) -> Span {
+        self.operator.span().join(self.operand.span())
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/identifier.rs
+++ b/crates/phpdoc-syntax/src/cst/identifier.rs
@@ -1,0 +1,33 @@
+use serde::Serialize;
+
+use mago_database::file::FileId;
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::token::Token;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct Identifier<'arena> {
+    pub span: Span,
+    pub value: &'arena [u8],
+}
+
+impl HasSpan for Identifier<'_> {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl<'arena> Identifier<'arena> {
+    #[inline]
+    #[must_use]
+    pub fn from_token(token: Token<'arena>, file_id: FileId) -> Self {
+        Identifier { span: token.span_for(file_id), value: token.value }
+    }
+}
+
+impl std::fmt::Display for Identifier<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&String::from_utf8_lossy(self.value))
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/inherit_doc.rs
+++ b/crates/phpdoc-syntax/src/cst/inherit_doc.rs
@@ -1,0 +1,15 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct InheritDoc {
+    pub span: Span,
+}
+
+impl HasSpan for InheritDoc {
+    fn span(&self) -> Span {
+        self.span
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/keyword.rs
+++ b/crates/phpdoc-syntax/src/cst/keyword.rs
@@ -1,0 +1,36 @@
+use serde::Serialize;
+
+use mago_database::file::FileId;
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::token::Token;
+use crate::token::TokenKind;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct Keyword<'arena> {
+    pub span: Span,
+    pub value: &'arena [u8],
+}
+
+impl HasSpan for Keyword<'_> {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl<'arena> Keyword<'arena> {
+    #[inline]
+    #[must_use]
+    pub fn from_token(token: Token<'arena>, file_id: FileId) -> Self {
+        debug_assert_eq!(token.kind, TokenKind::Identifier, "expected an identifier token for a keyword");
+
+        Keyword { span: token.span_for(file_id), value: token.value }
+    }
+}
+
+impl std::fmt::Display for Keyword<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&String::from_utf8_lossy(self.value))
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/mod.rs
+++ b/crates/phpdoc-syntax/src/cst/mod.rs
@@ -1,0 +1,58 @@
+use bumpalo::collections::Vec as BVec;
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+use mago_syntax_core::ast::Sequence;
+
+use crate::error::ParseError;
+
+pub use crate::cst::element::*;
+pub use crate::cst::expression::*;
+pub use crate::cst::identifier::*;
+pub use crate::cst::inherit_doc::*;
+pub use crate::cst::keyword::*;
+pub use crate::cst::tag::*;
+pub use crate::cst::text::*;
+pub use crate::cst::trivia::*;
+pub use crate::cst::variable::*;
+
+pub mod element;
+pub mod expression;
+pub mod identifier;
+pub mod inherit_doc;
+pub mod keyword;
+pub mod tag;
+pub mod text;
+pub mod trivia;
+pub mod r#type;
+pub mod variable;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct Document<'arena> {
+    pub span: Span,
+    pub trivia: Sequence<'arena, Trivia<'arena>>,
+    pub elements: Sequence<'arena, Element<'arena>>,
+    pub inherit_docs: Sequence<'arena, InheritDoc>,
+    pub errors: BVec<'arena, ParseError>,
+}
+
+impl Document<'_> {
+    #[inline]
+    #[must_use]
+    pub fn has_errors(&self) -> bool {
+        !self.errors.is_empty()
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn has_inherit_doc(&self) -> bool {
+        !self.inherit_docs.is_empty()
+    }
+}
+
+impl HasSpan for Document<'_> {
+    fn span(&self) -> Span {
+        self.span
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/tag/assert.rs
+++ b/crates/phpdoc-syntax/src/cst/tag/assert.rs
@@ -1,0 +1,111 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::identifier::Identifier;
+use crate::cst::text::Text;
+use crate::cst::r#type::Type;
+use crate::cst::variable::Variable;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct AssertTagValue<'arena> {
+    pub bang: Option<Span>,
+    pub equals: Option<Span>,
+    pub r#type: &'arena Type<'arena>,
+    pub parameter: Variable<'arena>,
+    pub description: Option<Text<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct AssertTagMethodValue<'arena> {
+    pub bang: Option<Span>,
+    pub equals: Option<Span>,
+    pub r#type: &'arena Type<'arena>,
+    pub parameter: Variable<'arena>,
+    pub arrow: Span,
+    pub method: Identifier<'arena>,
+    pub left_parenthesis: Span,
+    pub right_parenthesis: Span,
+    pub description: Option<Text<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct AssertTagPropertyValue<'arena> {
+    pub bang: Option<Span>,
+    pub equals: Option<Span>,
+    pub r#type: &'arena Type<'arena>,
+    pub parameter: Variable<'arena>,
+    pub arrow: Span,
+    pub property: Identifier<'arena>,
+    pub description: Option<Text<'arena>>,
+}
+
+impl AssertTagValue<'_> {
+    #[inline]
+    #[must_use]
+    pub const fn is_negated(&self) -> bool {
+        self.bang.is_some()
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn is_equality(&self) -> bool {
+        self.equals.is_some()
+    }
+}
+
+impl AssertTagMethodValue<'_> {
+    #[inline]
+    #[must_use]
+    pub const fn is_negated(&self) -> bool {
+        self.bang.is_some()
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn is_equality(&self) -> bool {
+        self.equals.is_some()
+    }
+}
+
+impl AssertTagPropertyValue<'_> {
+    #[inline]
+    #[must_use]
+    pub const fn is_negated(&self) -> bool {
+        self.bang.is_some()
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn is_equality(&self) -> bool {
+        self.equals.is_some()
+    }
+}
+
+impl HasSpan for AssertTagValue<'_> {
+    fn span(&self) -> Span {
+        let start = self.bang.or(self.equals).unwrap_or_else(|| self.r#type.span());
+        let end = self.description.as_ref().map_or_else(|| self.parameter.span(), HasSpan::span);
+
+        start.join(end)
+    }
+}
+
+impl HasSpan for AssertTagMethodValue<'_> {
+    fn span(&self) -> Span {
+        let start = self.bang.or(self.equals).unwrap_or_else(|| self.r#type.span());
+        let end = self.description.as_ref().map_or(self.right_parenthesis, HasSpan::span);
+
+        start.join(end)
+    }
+}
+
+impl HasSpan for AssertTagPropertyValue<'_> {
+    fn span(&self) -> Span {
+        let start = self.bang.or(self.equals).unwrap_or_else(|| self.r#type.span());
+        let end = self.description.as_ref().map_or_else(|| self.property.span(), HasSpan::span);
+
+        start.join(end)
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/tag/inheritance.rs
+++ b/crates/phpdoc-syntax/src/cst/tag/inheritance.rs
@@ -1,0 +1,82 @@
+use mago_syntax_core::ast::TokenSeparatedSequence;
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::identifier::Identifier;
+use crate::cst::text::Text;
+use crate::cst::r#type::Type;
+use crate::token::Token;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct ExtendsTagValue<'arena> {
+    pub r#type: &'arena Type<'arena>,
+    pub description: Option<Text<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct ImplementsTagValue<'arena> {
+    pub r#type: &'arena Type<'arena>,
+    pub description: Option<Text<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct UsesTagValue<'arena> {
+    pub r#type: &'arena Type<'arena>,
+    pub description: Option<Text<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct RequireExtendsTagValue<'arena> {
+    pub r#type: &'arena Type<'arena>,
+    pub description: Option<Text<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct RequireImplementsTagValue<'arena> {
+    pub r#type: &'arena Type<'arena>,
+    pub description: Option<Text<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct SealedTagValue<'arena> {
+    pub r#type: &'arena Type<'arena>,
+    pub description: Option<Text<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct InheritorsTagValue<'arena> {
+    pub span: Span,
+    pub inheritors: TokenSeparatedSequence<'arena, Identifier<'arena>, Token<'arena>>,
+}
+
+impl HasSpan for InheritorsTagValue<'_> {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+macro_rules! single_type_with_description {
+    ($($name:ident),+ $(,)?) => {
+        $(
+            impl HasSpan for $name<'_> {
+                fn span(&self) -> Span {
+                    match &self.description {
+                        Some(description) => self.r#type.span().join(description.span()),
+                        None => self.r#type.span(),
+                    }
+                }
+            }
+        )+
+    };
+}
+
+single_type_with_description!(
+    ExtendsTagValue,
+    ImplementsTagValue,
+    UsesTagValue,
+    RequireExtendsTagValue,
+    RequireImplementsTagValue,
+    SealedTagValue,
+);

--- a/crates/phpdoc-syntax/src/cst/tag/meta.rs
+++ b/crates/phpdoc-syntax/src/cst/tag/meta.rs
@@ -1,0 +1,65 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::text::Text;
+use crate::cst::variable::Variable;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct DeprecatedTagValue<'arena> {
+    pub description: Text<'arena>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct PureUnlessCallableIsImpureTagValue<'arena> {
+    pub parameter: Variable<'arena>,
+    pub description: Option<Text<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct GenericTagValue<'arena> {
+    pub value: Text<'arena>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct InvalidTagValue<'arena> {
+    pub value: Text<'arena>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct InheritDocTagValue<'arena> {
+    pub description: Text<'arena>,
+}
+
+impl HasSpan for DeprecatedTagValue<'_> {
+    fn span(&self) -> Span {
+        self.description.span()
+    }
+}
+
+impl HasSpan for InheritDocTagValue<'_> {
+    fn span(&self) -> Span {
+        self.description.span()
+    }
+}
+
+impl HasSpan for PureUnlessCallableIsImpureTagValue<'_> {
+    fn span(&self) -> Span {
+        let end = self.description.as_ref().map_or_else(|| self.parameter.span(), HasSpan::span);
+
+        self.parameter.span().join(end)
+    }
+}
+
+impl HasSpan for GenericTagValue<'_> {
+    fn span(&self) -> Span {
+        self.value.span()
+    }
+}
+
+impl HasSpan for InvalidTagValue<'_> {
+    fn span(&self) -> Span {
+        self.value.span()
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/tag/method.rs
+++ b/crates/phpdoc-syntax/src/cst/tag/method.rs
@@ -1,0 +1,136 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+use mago_syntax_core::ast::Sequence;
+
+use crate::cst::expression::ConstantExpression;
+use crate::cst::identifier::Identifier;
+use crate::cst::tag::template::TemplateTagValue;
+use crate::cst::text::Text;
+use crate::cst::r#type::Type;
+use crate::cst::variable::Variable;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct MethodTagValue<'arena> {
+    pub r#static: Option<Span>,
+    pub return_type: Option<&'arena Type<'arena>>,
+    pub name: Identifier<'arena>,
+    pub templates: Option<&'arena MethodTemplateParameterList<'arena>>,
+    pub parameters: &'arena MethodParameterList<'arena>,
+    pub description: Option<Text<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct MethodTemplateParameterList<'arena> {
+    pub less_than: Span,
+    pub entries: Sequence<'arena, MethodTemplateParameter<'arena>>,
+    pub greater_than: Span,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct MethodTemplateParameter<'arena> {
+    pub template: TemplateTagValue<'arena>,
+    pub comma: Option<Span>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct MethodParameterList<'arena> {
+    pub left_parenthesis: Span,
+    pub entries: Sequence<'arena, MethodTagValueParameter<'arena>>,
+    pub right_parenthesis: Span,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct MethodTagValueParameter<'arena> {
+    pub r#type: Option<&'arena Type<'arena>>,
+    pub ampersand: Option<Span>,
+    pub ellipsis: Option<Span>,
+    pub parameter: Variable<'arena>,
+    pub default: Option<MethodTagValueParameterDefault<'arena>>,
+    pub comma: Option<Span>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct MethodTagValueParameterDefault<'arena> {
+    pub equals: Span,
+    pub value: &'arena ConstantExpression<'arena>,
+}
+
+impl MethodTagValue<'_> {
+    #[inline]
+    #[must_use]
+    pub const fn is_static(&self) -> bool {
+        self.r#static.is_some()
+    }
+}
+
+impl MethodTagValueParameter<'_> {
+    #[inline]
+    #[must_use]
+    pub const fn is_by_reference(&self) -> bool {
+        self.ampersand.is_some()
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn is_variadic(&self) -> bool {
+        self.ellipsis.is_some()
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn is_optional(&self) -> bool {
+        self.default.is_some()
+    }
+}
+
+impl HasSpan for MethodTagValue<'_> {
+    fn span(&self) -> Span {
+        let start = self.r#static.or_else(|| self.return_type.map(HasSpan::span)).unwrap_or_else(|| self.name.span());
+        let end = self.description.as_ref().map_or_else(|| self.parameters.span(), HasSpan::span);
+
+        start.join(end)
+    }
+}
+
+impl HasSpan for MethodTemplateParameterList<'_> {
+    fn span(&self) -> Span {
+        self.less_than.join(self.greater_than)
+    }
+}
+
+impl HasSpan for MethodTemplateParameter<'_> {
+    fn span(&self) -> Span {
+        match &self.comma {
+            Some(comma) => self.template.span().join(*comma),
+            None => self.template.span(),
+        }
+    }
+}
+
+impl HasSpan for MethodParameterList<'_> {
+    fn span(&self) -> Span {
+        self.left_parenthesis.join(self.right_parenthesis)
+    }
+}
+
+impl HasSpan for MethodTagValueParameter<'_> {
+    fn span(&self) -> Span {
+        let start = match &self.r#type {
+            Some(r#type) => r#type.span(),
+            None => self.ampersand.or(self.ellipsis).unwrap_or_else(|| self.parameter.span()),
+        };
+
+        let end =
+            self.comma.or_else(|| self.default.as_ref().map(HasSpan::span)).unwrap_or_else(|| self.parameter.span());
+
+        start.join(end)
+    }
+}
+
+impl HasSpan for MethodTagValueParameterDefault<'_> {
+    fn span(&self) -> Span {
+        self.equals.join(self.value.span())
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/tag/mod.rs
+++ b/crates/phpdoc-syntax/src/cst/tag/mod.rs
@@ -1,0 +1,119 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::identifier::Identifier;
+
+pub use crate::cst::tag::assert::*;
+pub use crate::cst::tag::inheritance::*;
+pub use crate::cst::tag::meta::*;
+pub use crate::cst::tag::method::*;
+pub use crate::cst::tag::param::*;
+pub use crate::cst::tag::property::*;
+pub use crate::cst::tag::template::*;
+pub use crate::cst::tag::type_alias::*;
+pub use crate::cst::tag::value::*;
+pub use crate::cst::tag::vendor::*;
+pub use crate::cst::tag::where_clause::*;
+
+pub mod assert;
+pub mod inheritance;
+pub mod meta;
+pub mod method;
+pub mod param;
+pub mod property;
+pub mod template;
+pub mod type_alias;
+pub mod value;
+pub mod vendor;
+pub mod where_clause;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct Tag<'arena> {
+    pub name: Identifier<'arena>,
+    pub vendor: Option<TagVendor>,
+    pub value: TagValue<'arena>,
+}
+
+impl HasSpan for Tag<'_> {
+    fn span(&self) -> Span {
+        self.name.span().join(self.value.span())
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+#[serde(tag = "kind", content = "value")]
+pub enum TagValue<'arena> {
+    Param(ParamTagValue<'arena>),
+    TypelessParam(TypelessParamTagValue<'arena>),
+    ParamOut(ParamOutTagValue<'arena>),
+    ParamClosureThis(ParamClosureThisTagValue<'arena>),
+    ParamImmediatelyInvokedCallable(ParamImmediatelyInvokedCallableTagValue<'arena>),
+    ParamLaterInvokedCallable(ParamLaterInvokedCallableTagValue<'arena>),
+    Return(ReturnTagValue<'arena>),
+    Var(VarTagValue<'arena>),
+    Throws(ThrowsTagValue<'arena>),
+    Mixin(MixinTagValue<'arena>),
+    SelfOut(SelfOutTagValue<'arena>),
+    Template(TemplateTagValue<'arena>),
+    Extends(ExtendsTagValue<'arena>),
+    Implements(ImplementsTagValue<'arena>),
+    Uses(UsesTagValue<'arena>),
+    RequireExtends(RequireExtendsTagValue<'arena>),
+    RequireImplements(RequireImplementsTagValue<'arena>),
+    Sealed(SealedTagValue<'arena>),
+    Inheritors(InheritorsTagValue<'arena>),
+    Method(MethodTagValue<'arena>),
+    Property(PropertyTagValue<'arena>),
+    Assert(AssertTagValue<'arena>),
+    AssertMethod(AssertTagMethodValue<'arena>),
+    AssertProperty(AssertTagPropertyValue<'arena>),
+    Where(WhereTagValue<'arena>),
+    Deprecated(DeprecatedTagValue<'arena>),
+    InheritDoc(InheritDocTagValue<'arena>),
+    TypeAlias(TypeAliasTagValue<'arena>),
+    TypeAliasImport(TypeAliasImportTagValue<'arena>),
+    PureUnlessCallableIsImpure(PureUnlessCallableIsImpureTagValue<'arena>),
+    Generic(GenericTagValue<'arena>),
+    Invalid(InvalidTagValue<'arena>),
+}
+
+impl HasSpan for TagValue<'_> {
+    fn span(&self) -> Span {
+        match self {
+            TagValue::Param(value) => value.span(),
+            TagValue::TypelessParam(value) => value.span(),
+            TagValue::ParamOut(value) => value.span(),
+            TagValue::ParamClosureThis(value) => value.span(),
+            TagValue::ParamImmediatelyInvokedCallable(value) => value.span(),
+            TagValue::ParamLaterInvokedCallable(value) => value.span(),
+            TagValue::Return(value) => value.span(),
+            TagValue::Var(value) => value.span(),
+            TagValue::Throws(value) => value.span(),
+            TagValue::Mixin(value) => value.span(),
+            TagValue::SelfOut(value) => value.span(),
+            TagValue::Template(value) => value.span(),
+            TagValue::Extends(value) => value.span(),
+            TagValue::Implements(value) => value.span(),
+            TagValue::Uses(value) => value.span(),
+            TagValue::RequireExtends(value) => value.span(),
+            TagValue::RequireImplements(value) => value.span(),
+            TagValue::Sealed(value) => value.span(),
+            TagValue::Inheritors(value) => value.span(),
+            TagValue::Method(value) => value.span(),
+            TagValue::Property(value) => value.span(),
+            TagValue::Assert(value) => value.span(),
+            TagValue::AssertMethod(value) => value.span(),
+            TagValue::AssertProperty(value) => value.span(),
+            TagValue::Where(value) => value.span(),
+            TagValue::Deprecated(value) => value.span(),
+            TagValue::InheritDoc(value) => value.span(),
+            TagValue::TypeAlias(value) => value.span(),
+            TagValue::TypeAliasImport(value) => value.span(),
+            TagValue::PureUnlessCallableIsImpure(value) => value.span(),
+            TagValue::Generic(value) => value.span(),
+            TagValue::Invalid(value) => value.span(),
+        }
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/tag/param.rs
+++ b/crates/phpdoc-syntax/src/cst/tag/param.rs
@@ -1,0 +1,128 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::text::Text;
+use crate::cst::r#type::Type;
+use crate::cst::variable::Variable;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct ParamTagValue<'arena> {
+    pub r#type: &'arena Type<'arena>,
+    pub ampersand: Option<Span>,
+    pub ellipsis: Option<Span>,
+    pub parameter: Variable<'arena>,
+    pub description: Option<Text<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct TypelessParamTagValue<'arena> {
+    pub ampersand: Option<Span>,
+    pub ellipsis: Option<Span>,
+    pub parameter: Variable<'arena>,
+    pub description: Option<Text<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct ParamOutTagValue<'arena> {
+    pub r#type: &'arena Type<'arena>,
+    pub parameter: Variable<'arena>,
+    pub description: Option<Text<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct ParamClosureThisTagValue<'arena> {
+    pub r#type: &'arena Type<'arena>,
+    pub parameter: Variable<'arena>,
+    pub description: Option<Text<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct ParamImmediatelyInvokedCallableTagValue<'arena> {
+    pub parameter: Variable<'arena>,
+    pub description: Option<Text<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct ParamLaterInvokedCallableTagValue<'arena> {
+    pub parameter: Variable<'arena>,
+    pub description: Option<Text<'arena>>,
+}
+
+impl ParamTagValue<'_> {
+    #[inline]
+    #[must_use]
+    pub const fn is_by_reference(&self) -> bool {
+        self.ampersand.is_some()
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn is_variadic(&self) -> bool {
+        self.ellipsis.is_some()
+    }
+}
+
+impl TypelessParamTagValue<'_> {
+    #[inline]
+    #[must_use]
+    pub const fn is_by_reference(&self) -> bool {
+        self.ampersand.is_some()
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn is_variadic(&self) -> bool {
+        self.ellipsis.is_some()
+    }
+}
+
+impl HasSpan for ParamTagValue<'_> {
+    fn span(&self) -> Span {
+        let end = self.description.as_ref().map_or_else(|| self.parameter.span(), HasSpan::span);
+
+        self.r#type.span().join(end)
+    }
+}
+
+impl HasSpan for TypelessParamTagValue<'_> {
+    fn span(&self) -> Span {
+        let start = self.ampersand.or(self.ellipsis).unwrap_or_else(|| self.parameter.span());
+        let end = self.description.as_ref().map_or_else(|| self.parameter.span(), HasSpan::span);
+
+        start.join(end)
+    }
+}
+
+impl HasSpan for ParamOutTagValue<'_> {
+    fn span(&self) -> Span {
+        let end = self.description.as_ref().map_or_else(|| self.parameter.span(), HasSpan::span);
+
+        self.r#type.span().join(end)
+    }
+}
+
+impl HasSpan for ParamClosureThisTagValue<'_> {
+    fn span(&self) -> Span {
+        let end = self.description.as_ref().map_or_else(|| self.parameter.span(), HasSpan::span);
+
+        self.r#type.span().join(end)
+    }
+}
+
+impl HasSpan for ParamImmediatelyInvokedCallableTagValue<'_> {
+    fn span(&self) -> Span {
+        let end = self.description.as_ref().map_or_else(|| self.parameter.span(), HasSpan::span);
+
+        self.parameter.span().join(end)
+    }
+}
+
+impl HasSpan for ParamLaterInvokedCallableTagValue<'_> {
+    fn span(&self) -> Span {
+        let end = self.description.as_ref().map_or_else(|| self.parameter.span(), HasSpan::span);
+
+        self.parameter.span().join(end)
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/tag/property.rs
+++ b/crates/phpdoc-syntax/src/cst/tag/property.rs
@@ -1,0 +1,23 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::text::Text;
+use crate::cst::r#type::Type;
+use crate::cst::variable::Variable;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct PropertyTagValue<'arena> {
+    pub r#type: &'arena Type<'arena>,
+    pub variable: Variable<'arena>,
+    pub description: Option<Text<'arena>>,
+}
+
+impl HasSpan for PropertyTagValue<'_> {
+    fn span(&self) -> Span {
+        let end = self.description.as_ref().map_or_else(|| self.variable.span(), HasSpan::span);
+
+        self.r#type.span().join(end)
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/tag/template.rs
+++ b/crates/phpdoc-syntax/src/cst/tag/template.rs
@@ -1,0 +1,69 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::identifier::Identifier;
+use crate::cst::keyword::Keyword;
+use crate::cst::text::Text;
+use crate::cst::r#type::Type;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct TemplateTagValue<'arena> {
+    pub name: Identifier<'arena>,
+    pub bound: Option<TemplateTagValueBound<'arena>>,
+    pub lower_bound: Option<TemplateTagValueLowerBound<'arena>>,
+    pub default: Option<TemplateTagValueDefault<'arena>>,
+    pub description: Option<Text<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct TemplateTagValueBound<'arena> {
+    pub keyword: Keyword<'arena>,
+    pub r#type: &'arena Type<'arena>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct TemplateTagValueLowerBound<'arena> {
+    pub keyword: Keyword<'arena>,
+    pub r#type: &'arena Type<'arena>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct TemplateTagValueDefault<'arena> {
+    pub equals: Span,
+    pub r#type: &'arena Type<'arena>,
+}
+
+impl HasSpan for TemplateTagValue<'_> {
+    fn span(&self) -> Span {
+        let end = self
+            .description
+            .as_ref()
+            .map(HasSpan::span)
+            .or_else(|| self.default.as_ref().map(HasSpan::span))
+            .or_else(|| self.lower_bound.as_ref().map(HasSpan::span))
+            .or_else(|| self.bound.as_ref().map(HasSpan::span))
+            .unwrap_or_else(|| self.name.span());
+
+        self.name.span().join(end)
+    }
+}
+
+impl HasSpan for TemplateTagValueBound<'_> {
+    fn span(&self) -> Span {
+        self.keyword.span().join(self.r#type.span())
+    }
+}
+
+impl HasSpan for TemplateTagValueLowerBound<'_> {
+    fn span(&self) -> Span {
+        self.keyword.span().join(self.r#type.span())
+    }
+}
+
+impl HasSpan for TemplateTagValueDefault<'_> {
+    fn span(&self) -> Span {
+        self.equals.join(self.r#type.span())
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/tag/type_alias.rs
+++ b/crates/phpdoc-syntax/src/cst/tag/type_alias.rs
@@ -1,0 +1,49 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::identifier::Identifier;
+use crate::cst::keyword::Keyword;
+use crate::cst::r#type::Type;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct TypeAliasTagValue<'arena> {
+    pub alias: Identifier<'arena>,
+    pub equals: Option<Span>,
+    pub r#type: &'arena Type<'arena>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct TypeAliasImportTagValue<'arena> {
+    pub imported_alias: Identifier<'arena>,
+    pub from_keyword: Keyword<'arena>,
+    pub imported_from: Identifier<'arena>,
+    pub imported_as: Option<TypeAliasImportTagValueAs<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct TypeAliasImportTagValueAs<'arena> {
+    pub keyword: Keyword<'arena>,
+    pub local: Identifier<'arena>,
+}
+
+impl HasSpan for TypeAliasTagValue<'_> {
+    fn span(&self) -> Span {
+        self.alias.span().join(self.r#type.span())
+    }
+}
+
+impl HasSpan for TypeAliasImportTagValue<'_> {
+    fn span(&self) -> Span {
+        let end = self.imported_as.as_ref().map_or_else(|| self.imported_from.span(), HasSpan::span);
+
+        self.imported_alias.span().join(end)
+    }
+}
+
+impl HasSpan for TypeAliasImportTagValueAs<'_> {
+    fn span(&self) -> Span {
+        self.keyword.span().join(self.local.span())
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/tag/value.rs
+++ b/crates/phpdoc-syntax/src/cst/tag/value.rs
@@ -1,0 +1,88 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::text::Text;
+use crate::cst::r#type::Type;
+use crate::cst::variable::Variable;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct ReturnTagValue<'arena> {
+    pub r#type: &'arena Type<'arena>,
+    pub description: Option<Text<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct ThrowsTagValue<'arena> {
+    pub r#type: &'arena Type<'arena>,
+    pub description: Option<Text<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct VarTagValue<'arena> {
+    pub r#type: &'arena Type<'arena>,
+    pub variable: Option<Variable<'arena>>,
+    pub description: Option<Text<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct MixinTagValue<'arena> {
+    pub r#type: &'arena Type<'arena>,
+    pub description: Option<Text<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct SelfOutTagValue<'arena> {
+    pub r#type: &'arena Type<'arena>,
+    pub description: Option<Text<'arena>>,
+}
+
+impl HasSpan for ReturnTagValue<'_> {
+    fn span(&self) -> Span {
+        match &self.description {
+            Some(description) => self.r#type.span().join(description.span()),
+            None => self.r#type.span(),
+        }
+    }
+}
+
+impl HasSpan for ThrowsTagValue<'_> {
+    fn span(&self) -> Span {
+        match &self.description {
+            Some(description) => self.r#type.span().join(description.span()),
+            None => self.r#type.span(),
+        }
+    }
+}
+
+impl HasSpan for VarTagValue<'_> {
+    fn span(&self) -> Span {
+        let end = self
+            .description
+            .as_ref()
+            .map(HasSpan::span)
+            .or_else(|| self.variable.as_ref().map(HasSpan::span))
+            .unwrap_or_else(|| self.r#type.span());
+
+        self.r#type.span().join(end)
+    }
+}
+
+impl HasSpan for MixinTagValue<'_> {
+    fn span(&self) -> Span {
+        match &self.description {
+            Some(description) => self.r#type.span().join(description.span()),
+            None => self.r#type.span(),
+        }
+    }
+}
+
+impl HasSpan for SelfOutTagValue<'_> {
+    fn span(&self) -> Span {
+        match &self.description {
+            Some(description) => self.r#type.span().join(description.span()),
+            None => self.r#type.span(),
+        }
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/tag/vendor.rs
+++ b/crates/phpdoc-syntax/src/cst/tag/vendor.rs
@@ -1,0 +1,41 @@
+use serde::Serialize;
+use strum::Display;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord, Display)]
+#[serde(rename_all = "lowercase")]
+pub enum TagVendor {
+    Psalm,
+    PhpStan,
+    Phan,
+    Mago,
+}
+
+impl TagVendor {
+    #[inline]
+    #[must_use]
+    pub const fn prefix(self) -> &'static str {
+        match self {
+            TagVendor::Psalm => "psalm",
+            TagVendor::PhpStan => "phpstan",
+            TagVendor::Phan => "phan",
+            TagVendor::Mago => "mago",
+        }
+    }
+
+    #[must_use]
+    pub fn from_name(name: &[u8]) -> Option<TagVendor> {
+        let name = name.strip_prefix(b"@").unwrap_or(name);
+
+        if name.starts_with(b"psalm-") {
+            Some(TagVendor::Psalm)
+        } else if name.starts_with(b"phpstan-") {
+            Some(TagVendor::PhpStan)
+        } else if name.starts_with(b"phan-") {
+            Some(TagVendor::Phan)
+        } else if name.starts_with(b"mago-") {
+            Some(TagVendor::Mago)
+        } else {
+            None
+        }
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/tag/where_clause.rs
+++ b/crates/phpdoc-syntax/src/cst/tag/where_clause.rs
@@ -1,0 +1,37 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::identifier::Identifier;
+use crate::cst::keyword::Keyword;
+use crate::cst::r#type::Type;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct WhereTagValue<'arena> {
+    pub name: Identifier<'arena>,
+    pub modifier: WhereTagValueModifier<'arena>,
+    pub r#type: &'arena Type<'arena>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+#[serde(tag = "kind", content = "value")]
+pub enum WhereTagValueModifier<'arena> {
+    Is(Keyword<'arena>),
+    Colon(Span),
+}
+
+impl HasSpan for WhereTagValue<'_> {
+    fn span(&self) -> Span {
+        self.name.span().join(self.r#type.span())
+    }
+}
+
+impl HasSpan for WhereTagValueModifier<'_> {
+    fn span(&self) -> Span {
+        match self {
+            WhereTagValueModifier::Is(keyword) => keyword.span(),
+            WhereTagValueModifier::Colon(span) => *span,
+        }
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/text.rs
+++ b/crates/phpdoc-syntax/src/cst/text.rs
@@ -1,0 +1,33 @@
+use serde::Serialize;
+
+use mago_database::file::FileId;
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::token::Token;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct Text<'arena> {
+    pub span: Span,
+    pub value: &'arena [u8],
+}
+
+impl<'arena> Text<'arena> {
+    #[inline]
+    #[must_use]
+    pub const fn new(span: Span, value: &'arena [u8]) -> Self {
+        Text { span, value }
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn from_token(token: Token<'arena>, file_id: FileId) -> Self {
+        Text { span: token.span_for(file_id), value: token.value }
+    }
+}
+
+impl HasSpan for Text<'_> {
+    fn span(&self) -> Span {
+        self.span
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/trivia.rs
+++ b/crates/phpdoc-syntax/src/cst/trivia.rs
@@ -1,0 +1,40 @@
+use serde::Serialize;
+use strum::Display;
+
+use mago_database::file::FileId;
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::token::Token;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord, Display)]
+#[serde(tag = "type", content = "value")]
+pub enum TriviaKind {
+    OpeningMarker,
+    ClosingMarker,
+    Trailing,
+    Asterisk,
+    Whitespace,
+    LineComment,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct Trivia<'arena> {
+    pub kind: TriviaKind,
+    pub span: Span,
+    pub value: &'arena [u8],
+}
+
+impl<'arena> Trivia<'arena> {
+    #[inline]
+    #[must_use]
+    pub fn from_token(kind: TriviaKind, token: Token<'arena>, file_id: FileId) -> Self {
+        Trivia { kind, span: token.span_for(file_id), value: token.value }
+    }
+}
+
+impl HasSpan for Trivia<'_> {
+    fn span(&self) -> Span {
+        self.span
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/type/alias_reference.rs
+++ b/crates/phpdoc-syntax/src/cst/type/alias_reference.rs
@@ -1,0 +1,51 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::identifier::Identifier;
+use crate::cst::keyword::Keyword;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub enum AliasName<'arena> {
+    Identifier(Identifier<'arena>),
+    Keyword(Keyword<'arena>),
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct AliasReferenceType<'arena> {
+    pub exclamation: Span,
+    pub class: Identifier<'arena>,
+    pub double_colon: Span,
+    pub alias: AliasName<'arena>,
+}
+
+impl HasSpan for AliasName<'_> {
+    fn span(&self) -> Span {
+        match self {
+            AliasName::Identifier(identifier) => identifier.span,
+            AliasName::Keyword(keyword) => keyword.span,
+        }
+    }
+}
+
+impl HasSpan for AliasReferenceType<'_> {
+    fn span(&self) -> Span {
+        self.exclamation.join(self.alias.span())
+    }
+}
+
+impl std::fmt::Display for AliasName<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AliasName::Identifier(identifier) => write!(f, "{identifier}"),
+            AliasName::Keyword(keyword) => write!(f, "{keyword}"),
+        }
+    }
+}
+
+impl std::fmt::Display for AliasReferenceType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "!{}::{}", self.class, self.alias)
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/type/array.rs
+++ b/crates/phpdoc-syntax/src/cst/type/array.rs
@@ -1,0 +1,132 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::keyword::Keyword;
+use crate::cst::r#type::generics::GenericParameters;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct ArrayType<'arena> {
+    pub keyword: Keyword<'arena>,
+    pub parameters: Option<GenericParameters<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct NonEmptyArrayType<'arena> {
+    pub keyword: Keyword<'arena>,
+    pub parameters: Option<GenericParameters<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct AssociativeArrayType<'arena> {
+    pub keyword: Keyword<'arena>,
+    pub parameters: Option<GenericParameters<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct ListType<'arena> {
+    pub keyword: Keyword<'arena>,
+    pub parameters: Option<GenericParameters<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct NonEmptyListType<'arena> {
+    pub keyword: Keyword<'arena>,
+    pub parameters: Option<GenericParameters<'arena>>,
+}
+
+impl HasSpan for ArrayType<'_> {
+    fn span(&self) -> Span {
+        match &self.parameters {
+            Some(parameters) => self.keyword.span.join(parameters.span()),
+            None => self.keyword.span,
+        }
+    }
+}
+
+impl HasSpan for NonEmptyArrayType<'_> {
+    fn span(&self) -> Span {
+        match &self.parameters {
+            Some(parameters) => self.keyword.span.join(parameters.span()),
+            None => self.keyword.span,
+        }
+    }
+}
+
+impl HasSpan for AssociativeArrayType<'_> {
+    fn span(&self) -> Span {
+        match &self.parameters {
+            Some(parameters) => self.keyword.span.join(parameters.span()),
+            None => self.keyword.span,
+        }
+    }
+}
+
+impl HasSpan for ListType<'_> {
+    fn span(&self) -> Span {
+        match &self.parameters {
+            Some(parameters) => self.keyword.span.join(parameters.span()),
+            None => self.keyword.span,
+        }
+    }
+}
+
+impl HasSpan for NonEmptyListType<'_> {
+    fn span(&self) -> Span {
+        match &self.parameters {
+            Some(parameters) => self.keyword.span.join(parameters.span()),
+            None => self.keyword.span,
+        }
+    }
+}
+
+impl std::fmt::Display for ArrayType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(parameters) = &self.parameters {
+            write!(f, "{}{}", self.keyword, parameters)
+        } else {
+            write!(f, "{}", self.keyword)
+        }
+    }
+}
+
+impl std::fmt::Display for NonEmptyArrayType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(parameters) = &self.parameters {
+            write!(f, "{}{}", self.keyword, parameters)
+        } else {
+            write!(f, "{}", self.keyword)
+        }
+    }
+}
+
+impl std::fmt::Display for AssociativeArrayType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(parameters) = &self.parameters {
+            write!(f, "{}{}", self.keyword, parameters)
+        } else {
+            write!(f, "{}", self.keyword)
+        }
+    }
+}
+
+impl std::fmt::Display for ListType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(parameters) = &self.parameters {
+            write!(f, "{}{}", self.keyword, parameters)
+        } else {
+            write!(f, "{}", self.keyword)
+        }
+    }
+}
+
+impl std::fmt::Display for NonEmptyListType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(parameters) = &self.parameters {
+            write!(f, "{}{}", self.keyword, parameters)
+        } else {
+            write!(f, "{}", self.keyword)
+        }
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/type/callable.rs
+++ b/crates/phpdoc-syntax/src/cst/type/callable.rs
@@ -1,0 +1,208 @@
+use serde::Serialize;
+use strum::Display;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+use mago_syntax_core::ast::Sequence;
+
+use crate::cst::keyword::Keyword;
+use crate::cst::r#type::Type;
+use crate::cst::variable::Variable;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord, Display)]
+#[serde(tag = "type", content = "value")]
+pub enum CallableTypeKind {
+    Callable,
+    PureCallable,
+    Closure,
+    PureClosure,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct CallableType<'arena> {
+    pub kind: CallableTypeKind,
+    pub keyword: Keyword<'arena>,
+    pub specification: Option<CallableTypeSpecification<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct CallableTypeSpecification<'arena> {
+    pub parameters: CallableTypeParameters<'arena>,
+    pub return_type: Option<CallableTypeReturnType<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct CallableTypeParameters<'arena> {
+    pub left_parenthesis: Span,
+    pub entries: Sequence<'arena, CallableTypeParameter<'arena>>,
+    pub right_parenthesis: Span,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct CallableTypeParameter<'arena> {
+    pub parameter_type: Option<Type<'arena>>,
+    pub ampersand: Option<Span>,
+    pub equals: Option<Span>,
+    pub ellipsis: Option<Span>,
+    pub variable: Option<Variable<'arena>>,
+    pub comma: Option<Span>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct CallableTypeReturnType<'arena> {
+    pub colon: Span,
+    pub return_type: &'arena Type<'arena>,
+}
+
+impl CallableTypeKind {
+    #[inline]
+    #[must_use]
+    pub fn is_pure(&self) -> bool {
+        matches!(self, CallableTypeKind::PureCallable | CallableTypeKind::PureClosure)
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn is_closure(&self) -> bool {
+        matches!(self, CallableTypeKind::Closure | CallableTypeKind::PureClosure)
+    }
+}
+
+impl CallableTypeParameter<'_> {
+    #[inline]
+    #[must_use]
+    pub const fn is_variadic(&self) -> bool {
+        self.ellipsis.is_some()
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn is_optional(&self) -> bool {
+        self.equals.is_some()
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn is_by_reference(&self) -> bool {
+        self.ampersand.is_some()
+    }
+}
+
+impl HasSpan for CallableType<'_> {
+    fn span(&self) -> Span {
+        match &self.specification {
+            Some(specification) => self.keyword.span.join(specification.span()),
+            None => self.keyword.span,
+        }
+    }
+}
+
+impl HasSpan for CallableTypeSpecification<'_> {
+    fn span(&self) -> Span {
+        match &self.return_type {
+            Some(return_type) => self.parameters.span().join(return_type.span()),
+            None => self.parameters.span(),
+        }
+    }
+}
+
+impl HasSpan for CallableTypeParameters<'_> {
+    fn span(&self) -> Span {
+        self.left_parenthesis.join(self.right_parenthesis)
+    }
+}
+
+impl HasSpan for CallableTypeParameter<'_> {
+    fn span(&self) -> Span {
+        let start = match &self.parameter_type {
+            Some(parameter_type) => parameter_type.span(),
+            None => self
+                .ampersand
+                .or(self.equals)
+                .or(self.ellipsis)
+                .or(self.variable.as_ref().map(mago_span::HasSpan::span))
+                .or(self.comma)
+                .unwrap_or_else(Span::zero),
+        };
+
+        let end = self
+            .comma
+            .or(self.variable.as_ref().map(mago_span::HasSpan::span))
+            .or(self.ellipsis)
+            .or(self.equals)
+            .or(self.ampersand)
+            .unwrap_or(start);
+
+        start.join(end)
+    }
+}
+
+impl HasSpan for CallableTypeReturnType<'_> {
+    fn span(&self) -> Span {
+        self.colon.join(self.return_type.span())
+    }
+}
+
+impl std::fmt::Display for CallableTypeReturnType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, ": {}", self.return_type)
+    }
+}
+
+impl std::fmt::Display for CallableTypeParameter<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(parameter_type) = &self.parameter_type {
+            write!(f, "{parameter_type}")?;
+        }
+
+        if self.ampersand.is_some() {
+            write!(f, " &")?;
+        }
+
+        if self.equals.is_some() {
+            write!(f, "=")?;
+        } else if self.ellipsis.is_some() {
+            write!(f, "...")?;
+        }
+
+        if let Some(variable) = &self.variable {
+            write!(f, " {variable}")?;
+        }
+
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for CallableTypeParameters<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "(")?;
+        for (i, entry) in self.entries.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{entry}")?;
+        }
+        write!(f, ")")?;
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for CallableTypeSpecification<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.parameters)?;
+        if let Some(return_type) = &self.return_type {
+            write!(f, "{return_type}")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for CallableType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.keyword)?;
+        if let Some(specification) = &self.specification {
+            write!(f, "{specification}")?;
+        }
+        Ok(())
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/type/class_like_string.rs
+++ b/crates/phpdoc-syntax/src/cst/type/class_like_string.rs
@@ -1,0 +1,107 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::keyword::Keyword;
+use crate::cst::r#type::generics::SingleGenericParameter;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct ClassStringType<'arena> {
+    pub keyword: Keyword<'arena>,
+    pub parameter: Option<SingleGenericParameter<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct InterfaceStringType<'arena> {
+    pub keyword: Keyword<'arena>,
+    pub parameter: Option<SingleGenericParameter<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct EnumStringType<'arena> {
+    pub keyword: Keyword<'arena>,
+    pub parameter: Option<SingleGenericParameter<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct TraitStringType<'arena> {
+    pub keyword: Keyword<'arena>,
+    pub parameter: Option<SingleGenericParameter<'arena>>,
+}
+
+impl HasSpan for ClassStringType<'_> {
+    fn span(&self) -> Span {
+        match &self.parameter {
+            Some(parameter) => self.keyword.span.join(parameter.span()),
+            None => self.keyword.span,
+        }
+    }
+}
+
+impl HasSpan for InterfaceStringType<'_> {
+    fn span(&self) -> Span {
+        match &self.parameter {
+            Some(parameter) => self.keyword.span.join(parameter.span()),
+            None => self.keyword.span,
+        }
+    }
+}
+
+impl HasSpan for EnumStringType<'_> {
+    fn span(&self) -> Span {
+        match &self.parameter {
+            Some(parameter) => self.keyword.span.join(parameter.span()),
+            None => self.keyword.span,
+        }
+    }
+}
+
+impl HasSpan for TraitStringType<'_> {
+    fn span(&self) -> Span {
+        match &self.parameter {
+            Some(parameter) => self.keyword.span.join(parameter.span()),
+            None => self.keyword.span,
+        }
+    }
+}
+
+impl std::fmt::Display for ClassStringType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(parameter) = &self.parameter {
+            write!(f, "{}<{}>", self.keyword, parameter)
+        } else {
+            write!(f, "{}", self.keyword)
+        }
+    }
+}
+
+impl std::fmt::Display for InterfaceStringType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(parameter) = &self.parameter {
+            write!(f, "{}<{}>", self.keyword, parameter)
+        } else {
+            write!(f, "{}", self.keyword)
+        }
+    }
+}
+
+impl std::fmt::Display for EnumStringType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(parameter) = &self.parameter {
+            write!(f, "{}<{}>", self.keyword, parameter)
+        } else {
+            write!(f, "{}", self.keyword)
+        }
+    }
+}
+
+impl std::fmt::Display for TraitStringType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(parameter) = &self.parameter {
+            write!(f, "{}<{}>", self.keyword, parameter)
+        } else {
+            write!(f, "{}", self.keyword)
+        }
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/type/composite.rs
+++ b/crates/phpdoc-syntax/src/cst/type/composite.rs
@@ -1,0 +1,99 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::r#type::Type;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct ParenthesizedType<'arena> {
+    pub left_parenthesis: Span,
+    pub inner: &'arena Type<'arena>,
+    pub right_parenthesis: Span,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct UnionType<'arena> {
+    pub left: &'arena Type<'arena>,
+    pub pipe: Span,
+    pub right: &'arena Type<'arena>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct IntersectionType<'arena> {
+    pub left: &'arena Type<'arena>,
+    pub ampersand: Span,
+    pub right: &'arena Type<'arena>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct NullableType<'arena> {
+    pub question_mark: Span,
+    pub inner: &'arena Type<'arena>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct TrailingPipeType<'arena> {
+    pub inner: &'arena Type<'arena>,
+    pub pipe: Span,
+}
+
+impl HasSpan for ParenthesizedType<'_> {
+    fn span(&self) -> Span {
+        self.left_parenthesis.join(self.right_parenthesis)
+    }
+}
+
+impl HasSpan for UnionType<'_> {
+    fn span(&self) -> Span {
+        self.left.span().join(self.right.span())
+    }
+}
+
+impl HasSpan for IntersectionType<'_> {
+    fn span(&self) -> Span {
+        self.left.span().join(self.right.span())
+    }
+}
+
+impl HasSpan for NullableType<'_> {
+    fn span(&self) -> Span {
+        self.question_mark.join(self.inner.span())
+    }
+}
+
+impl HasSpan for TrailingPipeType<'_> {
+    fn span(&self) -> Span {
+        self.inner.span().join(self.pipe)
+    }
+}
+
+impl std::fmt::Display for ParenthesizedType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "({})", self.inner)
+    }
+}
+
+impl std::fmt::Display for UnionType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} | {}", self.left, self.right)
+    }
+}
+
+impl std::fmt::Display for IntersectionType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} & {}", self.left, self.right)
+    }
+}
+
+impl std::fmt::Display for NullableType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "?{}", self.inner)
+    }
+}
+
+impl std::fmt::Display for TrailingPipeType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}|", self.inner)
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/type/conditional.rs
+++ b/crates/phpdoc-syntax/src/cst/type/conditional.rs
@@ -1,0 +1,47 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::keyword::Keyword;
+use crate::cst::r#type::Type;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct ConditionalType<'arena> {
+    pub subject: &'arena Type<'arena>,
+    pub is: Keyword<'arena>,
+    pub not: Option<Keyword<'arena>>,
+    pub target: &'arena Type<'arena>,
+    pub question_mark: Span,
+    pub then: &'arena Type<'arena>,
+    pub colon: Span,
+    pub otherwise: &'arena Type<'arena>,
+}
+
+impl ConditionalType<'_> {
+    #[must_use]
+    pub fn is_negated(&self) -> bool {
+        self.not.is_some()
+    }
+}
+
+impl HasSpan for ConditionalType<'_> {
+    fn span(&self) -> Span {
+        self.subject.span().join(self.otherwise.span())
+    }
+}
+
+impl std::fmt::Display for ConditionalType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} {}{} {} ? {} : {}",
+            self.subject,
+            self.is,
+            self.not.as_ref().map(|k| format!(" {k}")).unwrap_or_default(),
+            self.target,
+            self.then,
+            self.otherwise
+        )
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/type/generics.rs
+++ b/crates/phpdoc-syntax/src/cst/type/generics.rs
@@ -1,0 +1,74 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+use mago_syntax_core::ast::Sequence;
+
+use crate::cst::r#type::Type;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct GenericParameterEntry<'arena> {
+    pub inner: Type<'arena>,
+    pub comma: Option<Span>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct GenericParameters<'arena> {
+    pub less_than: Span,
+    pub entries: Sequence<'arena, GenericParameterEntry<'arena>>,
+    pub greater_than: Span,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct SingleGenericParameter<'arena> {
+    pub less_than: Span,
+    pub entry: &'arena GenericParameterEntry<'arena>,
+    pub greater_than: Span,
+}
+
+impl HasSpan for GenericParameterEntry<'_> {
+    fn span(&self) -> Span {
+        match &self.comma {
+            Some(comma) => self.inner.span().join(*comma),
+            None => self.inner.span(),
+        }
+    }
+}
+
+impl HasSpan for GenericParameters<'_> {
+    fn span(&self) -> Span {
+        self.less_than.join(self.greater_than)
+    }
+}
+
+impl HasSpan for SingleGenericParameter<'_> {
+    fn span(&self) -> Span {
+        self.less_than.join(self.greater_than)
+    }
+}
+
+impl std::fmt::Display for GenericParameterEntry<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
+impl std::fmt::Display for SingleGenericParameter<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "<{}>", self.entry)
+    }
+}
+
+impl std::fmt::Display for GenericParameters<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "<")?;
+        for (i, entry) in self.entries.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+
+            write!(f, "{entry}")?;
+        }
+        write!(f, ">")
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/type/index_access.rs
+++ b/crates/phpdoc-syntax/src/cst/type/index_access.rs
@@ -1,0 +1,26 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::r#type::Type;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct IndexAccessType<'arena> {
+    pub target: &'arena Type<'arena>,
+    pub left_bracket: Span,
+    pub index: &'arena Type<'arena>,
+    pub right_bracket: Span,
+}
+
+impl HasSpan for IndexAccessType<'_> {
+    fn span(&self) -> Span {
+        self.target.span().join(self.right_bracket)
+    }
+}
+
+impl std::fmt::Display for IndexAccessType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}[{}]", self.target, self.index)
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/type/int_mask.rs
+++ b/crates/phpdoc-syntax/src/cst/type/int_mask.rs
@@ -1,0 +1,44 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::keyword::Keyword;
+use crate::cst::r#type::generics::GenericParameters;
+use crate::cst::r#type::generics::SingleGenericParameter;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct IntMaskType<'arena> {
+    pub keyword: Keyword<'arena>,
+    pub parameters: GenericParameters<'arena>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct IntMaskOfType<'arena> {
+    pub keyword: Keyword<'arena>,
+    pub parameter: SingleGenericParameter<'arena>,
+}
+
+impl HasSpan for IntMaskType<'_> {
+    fn span(&self) -> Span {
+        self.keyword.span().join(self.parameters.span())
+    }
+}
+
+impl HasSpan for IntMaskOfType<'_> {
+    fn span(&self) -> Span {
+        self.keyword.span().join(self.parameter.span())
+    }
+}
+
+impl std::fmt::Display for IntMaskType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}{}", self.keyword, self.parameters)
+    }
+}
+
+impl std::fmt::Display for IntMaskOfType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}{}", self.keyword, self.parameter)
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/type/int_range.rs
+++ b/crates/phpdoc-syntax/src/cst/type/int_range.rs
@@ -1,0 +1,57 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::keyword::Keyword;
+use crate::cst::r#type::literal::LiteralIntType;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+#[serde(tag = "type", content = "value")]
+pub enum IntOrKeyword<'arena> {
+    NegativeInt { minus: Span, int: LiteralIntType<'arena> },
+    Int(LiteralIntType<'arena>),
+    Keyword(Keyword<'arena>),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct IntRangeType<'arena> {
+    pub keyword: Keyword<'arena>,
+    pub less_than: Span,
+    pub min: IntOrKeyword<'arena>,
+    pub comma: Span,
+    pub max: IntOrKeyword<'arena>,
+    pub greater_than: Span,
+}
+
+impl HasSpan for IntOrKeyword<'_> {
+    fn span(&self) -> Span {
+        match self {
+            IntOrKeyword::NegativeInt { minus, int } => minus.join(int.span()),
+            IntOrKeyword::Int(literal) => literal.span(),
+            IntOrKeyword::Keyword(keyword) => keyword.span(),
+        }
+    }
+}
+
+impl HasSpan for IntRangeType<'_> {
+    fn span(&self) -> Span {
+        self.keyword.span().join(self.greater_than.span())
+    }
+}
+
+impl std::fmt::Display for IntRangeType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}<{}..{}>", self.keyword, self.min, self.max)
+    }
+}
+
+impl std::fmt::Display for IntOrKeyword<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IntOrKeyword::NegativeInt { int, .. } => write!(f, "-{int}"),
+            IntOrKeyword::Int(int) => write!(f, "{int}"),
+            IntOrKeyword::Keyword(keyword) => write!(f, "{keyword}"),
+        }
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/type/iterable.rs
+++ b/crates/phpdoc-syntax/src/cst/type/iterable.rs
@@ -1,0 +1,32 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::keyword::Keyword;
+use crate::cst::r#type::generics::GenericParameters;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct IterableType<'arena> {
+    pub keyword: Keyword<'arena>,
+    pub parameters: Option<GenericParameters<'arena>>,
+}
+
+impl HasSpan for IterableType<'_> {
+    fn span(&self) -> Span {
+        match &self.parameters {
+            Some(parameters) => self.keyword.span.join(parameters.span()),
+            None => self.keyword.span,
+        }
+    }
+}
+
+impl std::fmt::Display for IterableType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(parameters) = &self.parameters {
+            write!(f, "{}{}", self.keyword, parameters)
+        } else {
+            write!(f, "{}", self.keyword)
+        }
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/type/key_of.rs
+++ b/crates/phpdoc-syntax/src/cst/type/key_of.rs
@@ -1,0 +1,25 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::keyword::Keyword;
+use crate::cst::r#type::generics::SingleGenericParameter;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct KeyOfType<'arena> {
+    pub keyword: Keyword<'arena>,
+    pub parameter: SingleGenericParameter<'arena>,
+}
+
+impl HasSpan for KeyOfType<'_> {
+    fn span(&self) -> Span {
+        self.keyword.span().join(self.parameter.span())
+    }
+}
+
+impl std::fmt::Display for KeyOfType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}<{}>", self.keyword, self.parameter)
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/type/literal.rs
+++ b/crates/phpdoc-syntax/src/cst/type/literal.rs
@@ -1,0 +1,86 @@
+use ordered_float::OrderedFloat;
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct LiteralIntType<'arena> {
+    pub span: Span,
+    pub value: u64,
+    pub raw: &'arena [u8],
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct LiteralFloatType<'arena> {
+    pub span: Span,
+    pub value: OrderedFloat<f64>,
+    pub raw: &'arena [u8],
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub enum LiteralIntOrFloatType<'arena> {
+    Int(LiteralIntType<'arena>),
+    Float(LiteralFloatType<'arena>),
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct LiteralStringType<'arena> {
+    pub span: Span,
+    pub value: &'arena [u8],
+    pub raw: &'arena [u8],
+}
+
+impl HasSpan for LiteralFloatType<'_> {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl HasSpan for LiteralIntType<'_> {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl HasSpan for LiteralIntOrFloatType<'_> {
+    fn span(&self) -> Span {
+        match self {
+            LiteralIntOrFloatType::Int(int) => int.span(),
+            LiteralIntOrFloatType::Float(float) => float.span(),
+        }
+    }
+}
+
+impl HasSpan for LiteralStringType<'_> {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl std::fmt::Display for LiteralIntType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&String::from_utf8_lossy(self.raw))
+    }
+}
+
+impl std::fmt::Display for LiteralFloatType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&String::from_utf8_lossy(self.raw))
+    }
+}
+
+impl std::fmt::Display for LiteralIntOrFloatType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LiteralIntOrFloatType::Int(int) => write!(f, "{int}"),
+            LiteralIntOrFloatType::Float(float) => write!(f, "{float}"),
+        }
+    }
+}
+
+impl std::fmt::Display for LiteralStringType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&String::from_utf8_lossy(self.raw))
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/type/mod.rs
+++ b/crates/phpdoc-syntax/src/cst/type/mod.rs
@@ -1,0 +1,309 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::keyword::Keyword;
+use crate::cst::variable::Variable;
+
+pub use crate::cst::r#type::alias_reference::*;
+pub use crate::cst::r#type::array::*;
+pub use crate::cst::r#type::callable::*;
+pub use crate::cst::r#type::class_like_string::*;
+pub use crate::cst::r#type::composite::*;
+pub use crate::cst::r#type::conditional::*;
+pub use crate::cst::r#type::generics::*;
+pub use crate::cst::r#type::index_access::*;
+pub use crate::cst::r#type::int_mask::*;
+pub use crate::cst::r#type::int_range::*;
+pub use crate::cst::r#type::iterable::*;
+pub use crate::cst::r#type::key_of::*;
+pub use crate::cst::r#type::literal::*;
+pub use crate::cst::r#type::new::*;
+pub use crate::cst::r#type::object::*;
+pub use crate::cst::r#type::properties_of::*;
+pub use crate::cst::r#type::reference::*;
+pub use crate::cst::r#type::shape::*;
+pub use crate::cst::r#type::slice::*;
+pub use crate::cst::r#type::template_type::*;
+pub use crate::cst::r#type::unary::*;
+pub use crate::cst::r#type::value_of::*;
+pub use crate::cst::r#type::wildcard::*;
+
+pub mod alias_reference;
+pub mod array;
+pub mod callable;
+pub mod class_like_string;
+pub mod composite;
+pub mod conditional;
+pub mod generics;
+pub mod index_access;
+pub mod int_mask;
+pub mod int_range;
+pub mod iterable;
+pub mod key_of;
+pub mod literal;
+pub mod new;
+pub mod object;
+pub mod properties_of;
+pub mod reference;
+pub mod shape;
+pub mod slice;
+pub mod template_type;
+pub mod unary;
+pub mod value_of;
+pub mod wildcard;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+#[serde(tag = "type", content = "value")]
+#[non_exhaustive]
+pub enum Type<'arena> {
+    Parenthesized(ParenthesizedType<'arena>),
+    Union(UnionType<'arena>),
+    Intersection(IntersectionType<'arena>),
+    Nullable(NullableType<'arena>),
+    Array(ArrayType<'arena>),
+    NonEmptyArray(NonEmptyArrayType<'arena>),
+    AssociativeArray(AssociativeArrayType<'arena>),
+    List(ListType<'arena>),
+    NonEmptyList(NonEmptyListType<'arena>),
+    Iterable(IterableType<'arena>),
+    ClassString(ClassStringType<'arena>),
+    InterfaceString(InterfaceStringType<'arena>),
+    EnumString(EnumStringType<'arena>),
+    TraitString(TraitStringType<'arena>),
+    Reference(ReferenceType<'arena>),
+    Mixed(Keyword<'arena>),
+    NonEmptyMixed(Keyword<'arena>),
+    Null(Keyword<'arena>),
+    Void(Keyword<'arena>),
+    Never(Keyword<'arena>),
+    Resource(Keyword<'arena>),
+    ClosedResource(Keyword<'arena>),
+    OpenResource(Keyword<'arena>),
+    True(Keyword<'arena>),
+    False(Keyword<'arena>),
+    Bool(Keyword<'arena>),
+    Float(Keyword<'arena>),
+    Int(Keyword<'arena>),
+    PositiveInt(Keyword<'arena>),
+    NegativeInt(Keyword<'arena>),
+    NonPositiveInt(Keyword<'arena>),
+    NonNegativeInt(Keyword<'arena>),
+    NonZeroInt(Keyword<'arena>),
+    String(Keyword<'arena>),
+    StringableObject(Keyword<'arena>),
+    ArrayKey(Keyword<'arena>),
+    Object(ObjectType<'arena>),
+    Numeric(Keyword<'arena>),
+    Scalar(Keyword<'arena>),
+    CallableString(Keyword<'arena>),
+    LowercaseCallableString(Keyword<'arena>),
+    UppercaseCallableString(Keyword<'arena>),
+    NumericString(Keyword<'arena>),
+    NonEmptyString(Keyword<'arena>),
+    NonEmptyLowercaseString(Keyword<'arena>),
+    LowercaseString(Keyword<'arena>),
+    NonEmptyUppercaseString(Keyword<'arena>),
+    UppercaseString(Keyword<'arena>),
+    TruthyString(Keyword<'arena>),
+    NonFalsyString(Keyword<'arena>),
+    UnspecifiedLiteralInt(Keyword<'arena>),
+    UnspecifiedLiteralString(Keyword<'arena>),
+    UnspecifiedLiteralFloat(Keyword<'arena>),
+    NonEmptyUnspecifiedLiteralString(Keyword<'arena>),
+    LiteralFloat(LiteralFloatType<'arena>),
+    LiteralInt(LiteralIntType<'arena>),
+    LiteralString(LiteralStringType<'arena>),
+    MemberReference(MemberReferenceType<'arena>),
+    AliasReference(AliasReferenceType<'arena>),
+    Shape(ShapeType<'arena>),
+    Callable(CallableType<'arena>),
+    Variable(Variable<'arena>),
+    Conditional(ConditionalType<'arena>),
+    KeyOf(KeyOfType<'arena>),
+    ValueOf(ValueOfType<'arena>),
+    IntMask(IntMaskType<'arena>),
+    IntMaskOf(IntMaskOfType<'arena>),
+    New(NewType<'arena>),
+    TemplateType(TemplateTypeType<'arena>),
+    IndexAccess(IndexAccessType<'arena>),
+    Negated(NegatedType<'arena>),
+    Posited(PositedType<'arena>),
+    IntRange(IntRangeType<'arena>),
+    PropertiesOf(PropertiesOfType<'arena>),
+    Slice(SliceType<'arena>),
+    Wildcard(WildcardType),
+    TrailingPipe(TrailingPipeType<'arena>),
+    GlobalWildcardReference(GlobalWildcardType<'arena>),
+}
+
+impl HasSpan for Type<'_> {
+    fn span(&self) -> Span {
+        match self {
+            Type::Parenthesized(ty) => ty.span(),
+            Type::Union(ty) => ty.span(),
+            Type::Intersection(ty) => ty.span(),
+            Type::Nullable(ty) => ty.span(),
+            Type::Array(ty) => ty.span(),
+            Type::NonEmptyArray(ty) => ty.span(),
+            Type::AssociativeArray(ty) => ty.span(),
+            Type::List(ty) => ty.span(),
+            Type::NonEmptyList(ty) => ty.span(),
+            Type::Iterable(ty) => ty.span(),
+            Type::ClassString(ty) => ty.span(),
+            Type::InterfaceString(ty) => ty.span(),
+            Type::EnumString(ty) => ty.span(),
+            Type::TraitString(ty) => ty.span(),
+            Type::Reference(ty) => ty.span(),
+            Type::Mixed(ty) => ty.span(),
+            Type::NonEmptyMixed(ty) => ty.span(),
+            Type::Null(ty) => ty.span(),
+            Type::Void(ty) => ty.span(),
+            Type::Never(ty) => ty.span(),
+            Type::Resource(ty) => ty.span(),
+            Type::ClosedResource(ty) => ty.span(),
+            Type::OpenResource(ty) => ty.span(),
+            Type::True(ty) => ty.span(),
+            Type::False(ty) => ty.span(),
+            Type::Bool(ty) => ty.span(),
+            Type::Float(ty) => ty.span(),
+            Type::Int(ty) => ty.span(),
+            Type::PositiveInt(ty) => ty.span(),
+            Type::NegativeInt(ty) => ty.span(),
+            Type::NonPositiveInt(ty) => ty.span(),
+            Type::NonNegativeInt(ty) => ty.span(),
+            Type::NonZeroInt(ty) => ty.span(),
+            Type::String(ty) => ty.span(),
+            Type::ArrayKey(ty) => ty.span(),
+            Type::Scalar(ty) => ty.span(),
+            Type::Object(ty) => ty.span(),
+            Type::Numeric(ty) => ty.span(),
+            Type::CallableString(ty) => ty.span(),
+            Type::LowercaseCallableString(ty) => ty.span(),
+            Type::UppercaseCallableString(ty) => ty.span(),
+            Type::NumericString(ty) => ty.span(),
+            Type::StringableObject(ty) => ty.span(),
+            Type::NonEmptyString(ty) => ty.span(),
+            Type::NonEmptyLowercaseString(ty) => ty.span(),
+            Type::LowercaseString(ty) => ty.span(),
+            Type::NonEmptyUppercaseString(ty) => ty.span(),
+            Type::UppercaseString(ty) => ty.span(),
+            Type::TruthyString(ty) => ty.span(),
+            Type::NonFalsyString(ty) => ty.span(),
+            Type::UnspecifiedLiteralInt(ty) => ty.span(),
+            Type::UnspecifiedLiteralString(ty) => ty.span(),
+            Type::UnspecifiedLiteralFloat(ty) => ty.span(),
+            Type::NonEmptyUnspecifiedLiteralString(ty) => ty.span(),
+            Type::LiteralFloat(ty) => ty.span(),
+            Type::LiteralInt(ty) => ty.span(),
+            Type::LiteralString(ty) => ty.span(),
+            Type::MemberReference(ty) => ty.span(),
+            Type::AliasReference(ty) => ty.span(),
+            Type::Shape(ty) => ty.span(),
+            Type::Callable(ty) => ty.span(),
+            Type::Conditional(ty) => ty.span(),
+            Type::Variable(ty) => ty.span(),
+            Type::KeyOf(ty) => ty.span(),
+            Type::ValueOf(ty) => ty.span(),
+            Type::IntMask(ty) => ty.span(),
+            Type::IntMaskOf(ty) => ty.span(),
+            Type::New(ty) => ty.span(),
+            Type::TemplateType(ty) => ty.span(),
+            Type::IndexAccess(ty) => ty.span(),
+            Type::Negated(ty) => ty.span(),
+            Type::Posited(ty) => ty.span(),
+            Type::IntRange(ty) => ty.span(),
+            Type::PropertiesOf(ty) => ty.span(),
+            Type::Slice(ty) => ty.span(),
+            Type::Wildcard(ty) => ty.span(),
+            Type::TrailingPipe(ty) => ty.span(),
+            Type::GlobalWildcardReference(ty) => ty.span(),
+        }
+    }
+}
+
+impl std::fmt::Display for Type<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Type::Parenthesized(ty) => write!(f, "{ty}"),
+            Type::Union(ty) => write!(f, "{ty}"),
+            Type::Intersection(ty) => write!(f, "{ty}"),
+            Type::Nullable(ty) => write!(f, "{ty}"),
+            Type::Array(ty) => write!(f, "{ty}"),
+            Type::NonEmptyArray(ty) => write!(f, "{ty}"),
+            Type::AssociativeArray(ty) => write!(f, "{ty}"),
+            Type::List(ty) => write!(f, "{ty}"),
+            Type::NonEmptyList(ty) => write!(f, "{ty}"),
+            Type::Iterable(ty) => write!(f, "{ty}"),
+            Type::ClassString(ty) => write!(f, "{ty}"),
+            Type::InterfaceString(ty) => write!(f, "{ty}"),
+            Type::EnumString(ty) => write!(f, "{ty}"),
+            Type::TraitString(ty) => write!(f, "{ty}"),
+            Type::Reference(ty) => write!(f, "{ty}"),
+            Type::Mixed(ty) => write!(f, "{ty}"),
+            Type::NonEmptyMixed(ty) => write!(f, "{ty}"),
+            Type::Null(ty) => write!(f, "{ty}"),
+            Type::Void(ty) => write!(f, "{ty}"),
+            Type::Never(ty) => write!(f, "{ty}"),
+            Type::Resource(ty) => write!(f, "{ty}"),
+            Type::ClosedResource(ty) => write!(f, "{ty}"),
+            Type::OpenResource(ty) => write!(f, "{ty}"),
+            Type::True(ty) => write!(f, "{ty}"),
+            Type::False(ty) => write!(f, "{ty}"),
+            Type::Bool(ty) => write!(f, "{ty}"),
+            Type::Float(ty) => write!(f, "{ty}"),
+            Type::Int(ty) => write!(f, "{ty}"),
+            Type::PositiveInt(ty) => write!(f, "{ty}"),
+            Type::NegativeInt(ty) => write!(f, "{ty}"),
+            Type::NonPositiveInt(ty) => write!(f, "{ty}"),
+            Type::NonNegativeInt(ty) => write!(f, "{ty}"),
+            Type::NonZeroInt(ty) => write!(f, "{ty}"),
+            Type::String(ty) => write!(f, "{ty}"),
+            Type::ArrayKey(ty) => write!(f, "{ty}"),
+            Type::Scalar(ty) => write!(f, "{ty}"),
+            Type::Object(ty) => write!(f, "{ty}"),
+            Type::Numeric(ty) => write!(f, "{ty}"),
+            Type::CallableString(ty) => write!(f, "{ty}"),
+            Type::LowercaseCallableString(ty) => write!(f, "{ty}"),
+            Type::UppercaseCallableString(ty) => write!(f, "{ty}"),
+            Type::NumericString(ty) => write!(f, "{ty}"),
+            Type::StringableObject(ty) => write!(f, "{ty}"),
+            Type::NonEmptyString(ty) => write!(f, "{ty}"),
+            Type::NonEmptyLowercaseString(ty) => write!(f, "{ty}"),
+            Type::LowercaseString(ty) => write!(f, "{ty}"),
+            Type::NonEmptyUppercaseString(ty) => write!(f, "{ty}"),
+            Type::UppercaseString(ty) => write!(f, "{ty}"),
+            Type::TruthyString(ty) => write!(f, "{ty}"),
+            Type::NonFalsyString(ty) => write!(f, "{ty}"),
+            Type::UnspecifiedLiteralInt(ty) => write!(f, "{ty}"),
+            Type::UnspecifiedLiteralString(ty) => write!(f, "{ty}"),
+            Type::UnspecifiedLiteralFloat(ty) => write!(f, "{ty}"),
+            Type::NonEmptyUnspecifiedLiteralString(ty) => write!(f, "{ty}"),
+            Type::LiteralFloat(ty) => write!(f, "{ty}"),
+            Type::LiteralInt(ty) => write!(f, "{ty}"),
+            Type::LiteralString(ty) => write!(f, "{ty}"),
+            Type::MemberReference(ty) => write!(f, "{ty}"),
+            Type::AliasReference(ty) => write!(f, "{ty}"),
+            Type::Shape(ty) => write!(f, "{ty}"),
+            Type::Callable(ty) => write!(f, "{ty}"),
+            Type::Conditional(ty) => write!(f, "{ty}"),
+            Type::Variable(ty) => write!(f, "{ty}"),
+            Type::KeyOf(ty) => write!(f, "{ty}"),
+            Type::ValueOf(ty) => write!(f, "{ty}"),
+            Type::IntMask(ty) => write!(f, "{ty}"),
+            Type::IntMaskOf(ty) => write!(f, "{ty}"),
+            Type::New(ty) => write!(f, "{ty}"),
+            Type::TemplateType(ty) => write!(f, "{ty}"),
+            Type::IndexAccess(ty) => write!(f, "{ty}"),
+            Type::Negated(ty) => write!(f, "{ty}"),
+            Type::Posited(ty) => write!(f, "{ty}"),
+            Type::IntRange(ty) => write!(f, "{ty}"),
+            Type::PropertiesOf(ty) => write!(f, "{ty}"),
+            Type::Slice(ty) => write!(f, "{ty}"),
+            Type::Wildcard(ty) => write!(f, "{ty}"),
+            Type::TrailingPipe(ty) => write!(f, "{ty}"),
+            Type::GlobalWildcardReference(ty) => write!(f, "{ty}"),
+        }
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/type/new.rs
+++ b/crates/phpdoc-syntax/src/cst/type/new.rs
@@ -1,0 +1,25 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::keyword::Keyword;
+use crate::cst::r#type::generics::SingleGenericParameter;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct NewType<'arena> {
+    pub keyword: Keyword<'arena>,
+    pub parameter: SingleGenericParameter<'arena>,
+}
+
+impl HasSpan for NewType<'_> {
+    fn span(&self) -> Span {
+        self.keyword.span().join(self.parameter.span())
+    }
+}
+
+impl std::fmt::Display for NewType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}<{}>", self.keyword, self.parameter)
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/type/object.rs
+++ b/crates/phpdoc-syntax/src/cst/type/object.rs
@@ -1,0 +1,70 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+use mago_syntax_core::ast::Sequence;
+
+use crate::cst::keyword::Keyword;
+use crate::cst::r#type::ShapeField;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct ObjectType<'arena> {
+    pub keyword: Keyword<'arena>,
+    pub properties: Option<ObjectProperties<'arena>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct ObjectProperties<'arena> {
+    pub left_brace: Span,
+    pub fields: Sequence<'arena, ShapeField<'arena>>,
+    pub ellipsis: Option<Span>,
+    pub right_brace: Span,
+}
+
+impl HasSpan for ObjectType<'_> {
+    fn span(&self) -> Span {
+        match &self.properties {
+            Some(parameters) => self.keyword.span.join(parameters.span()),
+            None => self.keyword.span,
+        }
+    }
+}
+
+impl std::fmt::Display for ObjectType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(parameters) = &self.properties {
+            write!(f, "{}{}", self.keyword, parameters)
+        } else {
+            write!(f, "{}", self.keyword)
+        }
+    }
+}
+
+impl HasSpan for ObjectProperties<'_> {
+    fn span(&self) -> Span {
+        self.left_brace.join(self.right_brace)
+    }
+}
+
+impl std::fmt::Display for ObjectProperties<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{")?;
+        for (i, field) in self.fields.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", {field}")?;
+            } else {
+                write!(f, "{field}")?;
+            }
+        }
+
+        if self.ellipsis.is_some() {
+            if !self.fields.is_empty() {
+                write!(f, ", ")?;
+            }
+
+            write!(f, "...")?;
+        }
+
+        write!(f, "}}")
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/type/properties_of.rs
+++ b/crates/phpdoc-syntax/src/cst/type/properties_of.rs
@@ -1,0 +1,36 @@
+use serde::Serialize;
+use strum::Display;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::keyword::Keyword;
+use crate::cst::r#type::generics::SingleGenericParameter;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord, Display)]
+#[serde(tag = "type", content = "value")]
+pub enum PropertiesOfFilter {
+    All,
+    Public,
+    Protected,
+    Private,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct PropertiesOfType<'arena> {
+    pub filter: PropertiesOfFilter,
+    pub keyword: Keyword<'arena>,
+    pub parameter: SingleGenericParameter<'arena>,
+}
+
+impl HasSpan for PropertiesOfType<'_> {
+    fn span(&self) -> Span {
+        self.keyword.span().join(self.parameter.span())
+    }
+}
+
+impl std::fmt::Display for PropertiesOfType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}{}", self.keyword, self.parameter)
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/type/reference.rs
+++ b/crates/phpdoc-syntax/src/cst/type/reference.rs
@@ -1,0 +1,122 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::identifier::Identifier;
+use crate::cst::r#type::generics::GenericParameters;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct ReferenceType<'arena> {
+    pub identifier: Identifier<'arena>,
+    pub parameters: Option<GenericParameters<'arena>>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub enum MemberReferenceSelector<'arena> {
+    Wildcard(Span),
+    Identifier(Identifier<'arena>),
+    StartsWith(Identifier<'arena>, Span),
+    EndsWith(Span, Identifier<'arena>),
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct MemberReferenceType<'arena> {
+    pub class: Identifier<'arena>,
+    pub double_colon: Span,
+    pub member: MemberReferenceSelector<'arena>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct GlobalWildcardType<'arena> {
+    pub selector: GlobalWildcardSelector<'arena>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub enum GlobalWildcardSelector<'arena> {
+    StartsWith(Identifier<'arena>, Span),
+    EndsWith(Span, Identifier<'arena>),
+}
+
+impl HasSpan for ReferenceType<'_> {
+    fn span(&self) -> Span {
+        match &self.parameters {
+            Some(parameters) => self.identifier.span.join(parameters.span()),
+            None => self.identifier.span,
+        }
+    }
+}
+
+impl HasSpan for MemberReferenceSelector<'_> {
+    fn span(&self) -> Span {
+        match self {
+            MemberReferenceSelector::Wildcard(span) => *span,
+            MemberReferenceSelector::Identifier(identifier) => identifier.span,
+            MemberReferenceSelector::StartsWith(identifier, span) => identifier.span.join(*span),
+            MemberReferenceSelector::EndsWith(span, identifier) => span.join(identifier.span),
+        }
+    }
+}
+
+impl HasSpan for MemberReferenceType<'_> {
+    fn span(&self) -> Span {
+        self.class.span.join(self.member.span())
+    }
+}
+
+impl HasSpan for GlobalWildcardSelector<'_> {
+    fn span(&self) -> Span {
+        match self {
+            GlobalWildcardSelector::StartsWith(identifier, span) => identifier.span.join(*span),
+            GlobalWildcardSelector::EndsWith(span, identifier) => span.join(identifier.span),
+        }
+    }
+}
+
+impl HasSpan for GlobalWildcardType<'_> {
+    fn span(&self) -> Span {
+        self.selector.span()
+    }
+}
+
+impl std::fmt::Display for ReferenceType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(parameters) = &self.parameters {
+            write!(f, "{}{}", self.identifier, parameters)
+        } else {
+            write!(f, "{}", self.identifier)
+        }
+    }
+}
+
+impl std::fmt::Display for MemberReferenceSelector<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MemberReferenceSelector::Wildcard(_) => write!(f, "*"),
+            MemberReferenceSelector::Identifier(identifier) => write!(f, "{identifier}"),
+            MemberReferenceSelector::StartsWith(identifier, _) => write!(f, "{identifier}*"),
+            MemberReferenceSelector::EndsWith(_, identifier) => write!(f, "*{identifier}"),
+        }
+    }
+}
+
+impl std::fmt::Display for MemberReferenceType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}::{}", self.class, self.member)
+    }
+}
+
+impl std::fmt::Display for GlobalWildcardSelector<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GlobalWildcardSelector::StartsWith(identifier, _) => write!(f, "{identifier}*"),
+            GlobalWildcardSelector::EndsWith(_, identifier) => write!(f, "*{identifier}"),
+        }
+    }
+}
+
+impl std::fmt::Display for GlobalWildcardType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.selector)
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/type/shape.rs
+++ b/crates/phpdoc-syntax/src/cst/type/shape.rs
@@ -1,0 +1,217 @@
+use serde::Serialize;
+use strum::Display;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+use mago_syntax_core::ast::Sequence;
+
+use crate::cst::identifier::Identifier;
+use crate::cst::keyword::Keyword;
+use crate::cst::r#type::Type;
+use crate::cst::r#type::generics::GenericParameters;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord, Display)]
+#[serde(tag = "type", content = "value")]
+pub enum ShapeTypeKind {
+    Array,
+    NonEmptyArray,
+    AssociativeArray,
+    List,
+    NonEmptyList,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct ShapeType<'arena> {
+    pub kind: ShapeTypeKind,
+    pub keyword: Keyword<'arena>,
+    pub left_brace: Span,
+    pub fields: Sequence<'arena, ShapeField<'arena>>,
+    pub additional_fields: Option<ShapeAdditionalFields<'arena>>,
+    pub right_brace: Span,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub enum ShapeKey<'arena> {
+    String {
+        value: &'arena [u8],
+        span: Span,
+    },
+    Integer {
+        value: i64,
+        span: Span,
+    },
+    ClassLikeConstant {
+        class_name: Identifier<'arena>,
+        double_colon: Span,
+        constant_name: Identifier<'arena>,
+        span: Span,
+    },
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct ShapeFieldKey<'arena> {
+    pub key: ShapeKey<'arena>,
+    pub question_mark: Option<Span>,
+    pub colon: Span,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct ShapeField<'arena> {
+    pub key: Option<ShapeFieldKey<'arena>>,
+    pub value: &'arena Type<'arena>,
+    pub comma: Option<Span>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct ShapeAdditionalFields<'arena> {
+    pub ellipsis: Span,
+    pub parameters: Option<GenericParameters<'arena>>,
+    pub comma: Option<Span>,
+}
+
+impl ShapeTypeKind {
+    #[inline]
+    #[must_use]
+    pub const fn is_array(&self) -> bool {
+        matches!(self, ShapeTypeKind::Array | ShapeTypeKind::NonEmptyArray | ShapeTypeKind::AssociativeArray)
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn is_list(&self) -> bool {
+        matches!(self, ShapeTypeKind::List | ShapeTypeKind::NonEmptyList)
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn is_non_empty(&self) -> bool {
+        matches!(self, ShapeTypeKind::NonEmptyArray | ShapeTypeKind::NonEmptyList)
+    }
+}
+
+impl ShapeField<'_> {
+    #[inline]
+    #[must_use]
+    pub fn is_optional(&self) -> bool {
+        if let Some(key) = self.key.as_ref() { key.question_mark.is_some() } else { false }
+    }
+}
+
+impl ShapeType<'_> {
+    #[inline]
+    #[must_use]
+    pub fn has_fields(&self) -> bool {
+        !self.fields.is_empty()
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn has_non_optional_fields(&self) -> bool {
+        self.fields.iter().any(|field| !field.is_optional())
+    }
+}
+
+impl HasSpan for ShapeType<'_> {
+    fn span(&self) -> Span {
+        self.keyword.span().join(self.right_brace)
+    }
+}
+
+impl HasSpan for ShapeKey<'_> {
+    fn span(&self) -> Span {
+        match self {
+            ShapeKey::String { span, .. } => *span,
+            ShapeKey::Integer { span, .. } => *span,
+            ShapeKey::ClassLikeConstant { span, .. } => *span,
+        }
+    }
+}
+
+impl HasSpan for ShapeFieldKey<'_> {
+    fn span(&self) -> Span {
+        self.key.span().join(self.colon)
+    }
+}
+
+impl HasSpan for ShapeField<'_> {
+    fn span(&self) -> Span {
+        if let Some(key) = &self.key {
+            if let Some(comma) = self.comma { key.span().join(comma) } else { key.span().join(self.value.span()) }
+        } else if let Some(comma) = self.comma {
+            self.value.span().join(comma)
+        } else {
+            self.value.span()
+        }
+    }
+}
+
+impl HasSpan for ShapeAdditionalFields<'_> {
+    fn span(&self) -> Span {
+        let span = match &self.parameters {
+            Some(generics) => self.ellipsis.join(generics.span()),
+            None => self.ellipsis,
+        };
+
+        if let Some(comma) = self.comma { span.join(comma) } else { span }
+    }
+}
+
+impl std::fmt::Display for ShapeKey<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ShapeKey::String { value, .. } => f.write_str(&String::from_utf8_lossy(value)),
+            ShapeKey::Integer { value, .. } => write!(f, "{value}"),
+            ShapeKey::ClassLikeConstant { class_name, constant_name, .. } => {
+                write!(f, "{}::{}", class_name, constant_name)
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for ShapeFieldKey<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}{}:", self.key, self.question_mark.as_ref().map_or("", |_| "?"))
+    }
+}
+
+impl std::fmt::Display for ShapeField<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(key) = self.key.as_ref() {
+            write!(f, "{} {}", key, self.value)
+        } else {
+            write!(f, "{}", self.value)
+        }
+    }
+}
+
+impl std::fmt::Display for ShapeAdditionalFields<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "...")?;
+
+        if let Some(generics) = &self.parameters { write!(f, "{generics}") } else { Ok(()) }
+    }
+}
+
+impl std::fmt::Display for ShapeType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}{{", self.keyword)?;
+
+        for (i, field) in self.fields.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+
+            write!(f, "{field}")?;
+        }
+
+        if let Some(additional_fields) = &self.additional_fields {
+            if !self.fields.is_empty() {
+                write!(f, ", ")?;
+            }
+
+            write!(f, "{additional_fields}")?;
+        }
+
+        write!(f, "}}")
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/type/slice.rs
+++ b/crates/phpdoc-syntax/src/cst/type/slice.rs
@@ -1,0 +1,25 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::r#type::Type;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct SliceType<'arena> {
+    pub inner: &'arena Type<'arena>,
+    pub left_bracket: Span,
+    pub right_bracket: Span,
+}
+
+impl HasSpan for SliceType<'_> {
+    fn span(&self) -> Span {
+        self.inner.span().join(self.right_bracket)
+    }
+}
+
+impl std::fmt::Display for SliceType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}[]", self.inner)
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/type/template_type.rs
+++ b/crates/phpdoc-syntax/src/cst/type/template_type.rs
@@ -1,0 +1,25 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::keyword::Keyword;
+use crate::cst::r#type::generics::GenericParameters;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct TemplateTypeType<'arena> {
+    pub keyword: Keyword<'arena>,
+    pub parameters: GenericParameters<'arena>,
+}
+
+impl HasSpan for TemplateTypeType<'_> {
+    fn span(&self) -> Span {
+        self.keyword.span().join(self.parameters.span())
+    }
+}
+
+impl std::fmt::Display for TemplateTypeType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}{}", self.keyword, self.parameters)
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/type/unary.rs
+++ b/crates/phpdoc-syntax/src/cst/type/unary.rs
@@ -1,0 +1,42 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::r#type::Type;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct NegatedType<'arena> {
+    pub minus: Span,
+    pub operand: &'arena Type<'arena>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct PositedType<'arena> {
+    pub plus: Span,
+    pub operand: &'arena Type<'arena>,
+}
+
+impl HasSpan for NegatedType<'_> {
+    fn span(&self) -> Span {
+        self.minus.join(self.operand.span())
+    }
+}
+
+impl HasSpan for PositedType<'_> {
+    fn span(&self) -> Span {
+        self.plus.join(self.operand.span())
+    }
+}
+
+impl std::fmt::Display for NegatedType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "-{}", self.operand)
+    }
+}
+
+impl std::fmt::Display for PositedType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "+{}", self.operand)
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/type/value_of.rs
+++ b/crates/phpdoc-syntax/src/cst/type/value_of.rs
@@ -1,0 +1,25 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::cst::keyword::Keyword;
+use crate::cst::r#type::generics::SingleGenericParameter;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct ValueOfType<'arena> {
+    pub keyword: Keyword<'arena>,
+    pub parameter: SingleGenericParameter<'arena>,
+}
+
+impl HasSpan for ValueOfType<'_> {
+    fn span(&self) -> Span {
+        self.keyword.span().join(self.parameter.span())
+    }
+}
+
+impl std::fmt::Display for ValueOfType<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}<{}>", self.keyword, self.parameter)
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/type/wildcard.rs
+++ b/crates/phpdoc-syntax/src/cst/type/wildcard.rs
@@ -1,0 +1,31 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub enum WildcardKind {
+    Asterisk,
+    Underscore,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct WildcardType {
+    pub span: Span,
+    pub kind: WildcardKind,
+}
+
+impl HasSpan for WildcardType {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl std::fmt::Display for WildcardType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.kind {
+            WildcardKind::Asterisk => write!(f, "*"),
+            WildcardKind::Underscore => write!(f, "_"),
+        }
+    }
+}

--- a/crates/phpdoc-syntax/src/cst/variable.rs
+++ b/crates/phpdoc-syntax/src/cst/variable.rs
@@ -1,0 +1,36 @@
+use serde::Serialize;
+
+use mago_database::file::FileId;
+use mago_span::HasSpan;
+use mago_span::Span;
+
+use crate::token::Token;
+use crate::token::TokenKind;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct Variable<'arena> {
+    pub span: Span,
+    pub value: &'arena [u8],
+}
+
+impl HasSpan for Variable<'_> {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl<'arena> Variable<'arena> {
+    #[inline]
+    #[must_use]
+    pub fn from_token(token: Token<'arena>, file_id: FileId) -> Self {
+        debug_assert!(matches!(token.kind, TokenKind::Variable | TokenKind::ThisVariable), "expected a Variable token");
+
+        Variable { span: token.span_for(file_id), value: token.value }
+    }
+}
+
+impl std::fmt::Display for Variable<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&String::from_utf8_lossy(self.value))
+    }
+}

--- a/crates/phpdoc-syntax/src/error.rs
+++ b/crates/phpdoc-syntax/src/error.rs
@@ -1,0 +1,53 @@
+use serde::Serialize;
+
+use mago_span::HasSpan;
+use mago_span::Span;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, PartialOrd, Ord, Serialize)]
+pub enum ParseError {
+    UnexpectedToken(Span),
+    UnexpectedEndOfInput(Span),
+}
+
+impl ParseError {
+    #[must_use]
+    pub fn note(&self) -> String {
+        match self {
+            ParseError::UnexpectedToken(_) => {
+                "The parser encountered a token that is not valid at this position.".to_string()
+            }
+            ParseError::UnexpectedEndOfInput(_) => {
+                "The PHPDoc comment ended before the construct was complete.".to_string()
+            }
+        }
+    }
+
+    #[must_use]
+    pub fn help(&self) -> String {
+        match self {
+            ParseError::UnexpectedToken(_) => "Review the PHPDoc syntax near the unexpected token.".to_string(),
+            ParseError::UnexpectedEndOfInput(_) => {
+                "Complete the construct; check for unclosed `<>`, `()`, `[]`, or `{}`.".to_string()
+            }
+        }
+    }
+}
+
+impl HasSpan for ParseError {
+    fn span(&self) -> Span {
+        match self {
+            ParseError::UnexpectedToken(span) | ParseError::UnexpectedEndOfInput(span) => *span,
+        }
+    }
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ParseError::UnexpectedToken(_) => write!(f, "Unexpected token in PHPDoc"),
+            ParseError::UnexpectedEndOfInput(_) => write!(f, "Unexpected end of PHPDoc input"),
+        }
+    }
+}
+
+impl std::error::Error for ParseError {}

--- a/crates/phpdoc-syntax/src/lexer/mod.rs
+++ b/crates/phpdoc-syntax/src/lexer/mod.rs
@@ -1,0 +1,960 @@
+use mago_database::file::FileId;
+use mago_database::file::HasFileId;
+use mago_span::Position;
+use mago_syntax_core::input::Input;
+use mago_syntax_core::utils::is_part_of_identifier;
+use mago_syntax_core::utils::is_start_of_identifier;
+use mago_syntax_core::utils::read_digits_of_base;
+
+use crate::token::Token;
+use crate::token::TokenKind;
+
+const TAG_TABLE: [bool; 256] = {
+    let mut table = [false; 256];
+    let mut i = 0;
+    while i < 256 {
+        table[i] = matches!(i as u8, b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_' | b'-' | b'\\');
+        i += 1;
+    }
+
+    table
+};
+
+#[inline]
+const fn is_identifier_start(byte: u8) -> bool {
+    is_start_of_identifier(&byte) || byte >= 0x80
+}
+
+#[derive(Debug)]
+pub struct DocblockLexer<'arena> {
+    input: Input<'arena>,
+}
+
+impl<'arena> DocblockLexer<'arena> {
+    #[inline]
+    #[must_use]
+    pub fn new(input: Input<'arena>) -> DocblockLexer<'arena> {
+        DocblockLexer { input }
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn has_reached_eof(&self) -> bool {
+        self.input.has_reached_eof()
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn current_position(&self) -> Position {
+        self.input.current_position()
+    }
+
+    #[inline]
+    pub fn advance(&mut self) -> Option<Token<'arena>> {
+        if self.input.has_reached_eof() {
+            return None;
+        }
+
+        let start = self.input.current_position();
+        let whitespaces = self.input.consume_whitespaces();
+        if !whitespaces.is_empty() {
+            return Some(Token::new(TokenKind::Whitespace, whitespaces, start));
+        }
+
+        let remaining = self.input.read_remaining();
+        let first = remaining[0];
+        let second = remaining.get(1).copied();
+
+        let (kind, length) = match first {
+            b'|' => (TokenKind::Pipe, 1),
+            b'&' => (TokenKind::Ampersand, 1),
+            b'?' => (TokenKind::Question, 1),
+            b'!' => (TokenKind::Bang, 1),
+            b'(' => (TokenKind::LeftParenthesis, 1),
+            b')' => (TokenKind::RightParenthesis, 1),
+            b'<' => (TokenKind::LeftAngleBracket, 1),
+            b'>' => (TokenKind::RightAngleBracket, 1),
+            b'[' => (TokenKind::LeftBracket, 1),
+            b']' => (TokenKind::RightBracket, 1),
+            b'{' => (TokenKind::LeftBrace, 1),
+            b'}' => (TokenKind::RightBrace, 1),
+            b',' => (TokenKind::Comma, 1),
+            b':' if second == Some(b':') => (TokenKind::ColonColon, 2),
+            b':' => (TokenKind::Colon, 1),
+            b'=' if second == Some(b'>') => (TokenKind::DoubleArrow, 2),
+            b'=' => (TokenKind::Equals, 1),
+            b'*' if second == Some(b'/') => (TokenKind::ClosingMarker, 2),
+            b'*' => (TokenKind::Asterisk, 1),
+            b'.' if remaining.get(..3) == Some(b"...") => (TokenKind::Ellipsis, 3),
+            b'.' if second.is_some_and(|b| b.is_ascii_digit()) => self.read_number(),
+            b'-' if second == Some(b'>') => (TokenKind::Arrow, 2),
+            b'-' => (TokenKind::Minus, 1),
+            b'+' => (TokenKind::Plus, 1),
+            b'/' => self.read_slash(remaining),
+            b'\'' | b'"' => self.read_string(first).unwrap_or_else(|| self.read_other()),
+            b'$' => self.read_variable().unwrap_or_else(|| self.read_other()),
+            b'@' => self.read_tag().unwrap_or_else(|| self.read_other()),
+            b'0'..=b'9' => self.read_number(),
+            b'\\' if second.is_some_and(is_identifier_start) => (TokenKind::Identifier, self.read_identifier()),
+            b if is_identifier_start(b) => (TokenKind::Identifier, self.read_identifier()),
+            _ => self.read_other(),
+        };
+
+        let value = self.input.consume(length);
+
+        Some(Token::new(kind, value, start))
+    }
+
+    #[inline]
+    fn read_slash(&self, remaining: &[u8]) -> (TokenKind, usize) {
+        if remaining.get(1) == Some(&b'/') {
+            return self.read_line_comment();
+        }
+
+        if remaining.get(..3) == Some(b"/**")
+            && let Some(after) = remaining.get(3).copied()
+            && after.is_ascii_whitespace()
+        {
+            return (TokenKind::OpeningMarker, if after == b' ' { 4 } else { 3 });
+        }
+
+        self.read_other()
+    }
+
+    #[inline]
+    fn read_line_comment(&self) -> (TokenKind, usize) {
+        let tail = &self.input.read_remaining()[2..];
+
+        let newline = memchr::memchr2(b'\n', b'\r', tail);
+        let marker = memchr::memmem::find(tail, b"*/");
+
+        let stop = match (newline, marker) {
+            (Some(newline), Some(marker)) => newline.min(marker),
+            (Some(stop), None) | (None, Some(stop)) => stop,
+            (None, None) => tail.len(),
+        };
+
+        (TokenKind::LineComment, 2 + stop)
+    }
+
+    #[inline]
+    fn read_other(&self) -> (TokenKind, usize) {
+        let run = self.input.scan_until_whitespace(0);
+        let length = match memchr::memmem::find(&self.input.read_remaining()[..run], b"*/") {
+            Some(marker) => marker,
+            None => run,
+        };
+
+        (TokenKind::Other, length.max(1))
+    }
+
+    #[inline]
+    fn read_identifier(&self) -> usize {
+        let remaining = self.input.read_remaining();
+        let total = remaining.len();
+        let mut length = 0;
+
+        loop {
+            let (segment, ends_with_namespace_separator) = self.input.scan_identifier(length);
+            length += segment;
+
+            if ends_with_namespace_separator {
+                length += 1;
+                continue;
+            }
+
+            let mut consumed_hyphen = false;
+            while length < total && remaining[length] == b'-' {
+                length += 1;
+                consumed_hyphen = true;
+            }
+
+            if !consumed_hyphen {
+                break;
+            }
+        }
+
+        length
+    }
+
+    #[inline]
+    fn read_variable(&self) -> Option<(TokenKind, usize)> {
+        let remaining = self.input.read_remaining();
+
+        if remaining.get(..5) == Some(b"$this") && remaining.get(5).is_none_or(|b| !is_part_of_identifier(b)) {
+            return Some((TokenKind::ThisVariable, 5));
+        }
+
+        if remaining.get(1).copied().is_some_and(is_identifier_start) {
+            let (name, _) = self.input.scan_identifier(1);
+
+            return Some((TokenKind::Variable, 1 + name));
+        }
+
+        None
+    }
+
+    #[inline]
+    fn read_tag(&self) -> Option<(TokenKind, usize)> {
+        let remaining = self.input.read_remaining();
+
+        if remaining.get(1).is_none_or(|byte| !byte.is_ascii_alphabetic()) {
+            return None;
+        }
+
+        let mut length = 1 + self.input.scan_while(1, &TAG_TABLE);
+
+        if remaining.get(length) == Some(&b':')
+            && remaining.get(length + 1).is_some_and(|byte| byte.is_ascii_alphabetic())
+        {
+            length += 1 + self.input.scan_while(length + 1, &TAG_TABLE);
+        }
+
+        Some((TokenKind::Tag, length))
+    }
+
+    #[inline]
+    fn read_string(&self, quote: u8) -> Option<(TokenKind, usize)> {
+        let remaining = self.input.read_remaining();
+        let mut index = 1;
+
+        loop {
+            let tail = remaining.get(index..)?;
+            let stop = memchr::memchr2(quote, b'\\', tail)?;
+
+            if memchr::memchr2(b'\r', b'\n', tail).is_some_and(|newline| newline < stop) {
+                return None;
+            }
+
+            if tail[stop] == quote {
+                let kind = if quote == b'\'' { TokenKind::SingleQuotedString } else { TokenKind::DoubleQuotedString };
+
+                return Some((kind, index + stop + 1));
+            }
+
+            if tail.get(stop + 1).is_none_or(|byte| matches!(byte, b'\r' | b'\n')) {
+                return None;
+            }
+
+            index += stop + 2;
+        }
+    }
+
+    #[inline]
+    fn read_number(&self) -> (TokenKind, usize) {
+        let remaining = self.input.read_remaining();
+        let mut length = 0;
+        let mut is_float = false;
+
+        if remaining.get(length) == Some(&b'0')
+            && let Some(base) = remaining.get(length + 1).copied().and_then(|byte| match byte {
+                b'b' | b'B' => Some(2u8),
+                b'o' | b'O' => Some(8u8),
+                b'x' | b'X' => Some(16u8),
+                _ => None,
+            })
+        {
+            let after_prefix = length + 2;
+            let end = read_digits_of_base(&self.input, after_prefix, base);
+            if end > after_prefix {
+                return (TokenKind::LiteralInteger, end);
+            }
+        }
+
+        length = read_digits_of_base(&self.input, length, 10);
+
+        if remaining.get(length) == Some(&b'.') && remaining.get(length + 1).is_some_and(u8::is_ascii_digit) {
+            is_float = true;
+            length = read_digits_of_base(&self.input, length + 1, 10);
+        }
+
+        if matches!(remaining.get(length).copied(), Some(b'e' | b'E')) {
+            let mut exponent = length + 1;
+            if matches!(remaining.get(exponent).copied(), Some(b'+' | b'-')) {
+                exponent += 1;
+            }
+
+            if remaining.get(exponent).is_some_and(u8::is_ascii_digit) {
+                is_float = true;
+                length = read_digits_of_base(&self.input, exponent, 10);
+            }
+        }
+
+        if is_float { (TokenKind::LiteralFloat, length) } else { (TokenKind::LiteralInteger, length) }
+    }
+}
+
+impl HasFileId for DocblockLexer<'_> {
+    #[inline]
+    fn file_id(&self) -> FileId {
+        self.input.file_id()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_sample<T>(source: T, expected: Vec<TokenKind>)
+    where
+        T: AsRef<[u8]>,
+    {
+        let bytes = source.as_ref();
+
+        let input = Input::new(FileId::zero(), bytes);
+        let mut lexer = DocblockLexer::new(input);
+        let mut kinds = Vec::new();
+        let mut reconstructed = Vec::new();
+        while let Some(token) = lexer.advance() {
+            kinds.push(token.kind);
+            reconstructed.extend_from_slice(token.value);
+        }
+
+        assert_eq!(kinds, expected, "Failed to assert token kinds for input: {:?}", String::from_utf8_lossy(bytes));
+        assert_eq!(
+            reconstructed,
+            bytes,
+            "Failed to assert reconstructability for input: {:?}",
+            String::from_utf8_lossy(bytes)
+        );
+    }
+
+    macro_rules! test {
+        ($name:ident, $source:expr, $expected:expr) => {
+            #[test]
+            fn $name() {
+                test_sample($source, $expected);
+            }
+        };
+    }
+
+    test!(
+        lexes_single_line_param,
+        b"/** @param int<0, 100>|null $count */",
+        vec![
+            TokenKind::OpeningMarker,
+            TokenKind::Tag,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::LeftAngleBracket,
+            TokenKind::LiteralInteger,
+            TokenKind::Comma,
+            TokenKind::Whitespace,
+            TokenKind::LiteralInteger,
+            TokenKind::RightAngleBracket,
+            TokenKind::Pipe,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Variable,
+            TokenKind::Whitespace,
+            TokenKind::ClosingMarker,
+        ]
+    );
+
+    test!(
+        lexes_multiline_var_shape_absorbing_star,
+        "/**\n* @var array{a: int}\n*/",
+        vec![
+            TokenKind::OpeningMarker,
+            TokenKind::Whitespace,
+            TokenKind::Asterisk,
+            TokenKind::Whitespace,
+            TokenKind::Tag,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::LeftBrace,
+            TokenKind::Identifier,
+            TokenKind::Colon,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::RightBrace,
+            TokenKind::Whitespace,
+            TokenKind::ClosingMarker,
+        ]
+    );
+
+    test!(
+        lexes_namespaced_and_hyphenated_identifiers_and_this,
+        b"\\Foo\\Bar non-empty-string $this",
+        vec![
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::ThisVariable,
+        ]
+    );
+
+    test!(
+        lexes_signed_numbers_and_arrow_and_other,
+        b"@var -1|0|1.5e-3 -> #x",
+        vec![
+            TokenKind::Tag,
+            TokenKind::Whitespace,
+            TokenKind::Minus,
+            TokenKind::LiteralInteger,
+            TokenKind::Pipe,
+            TokenKind::LiteralInteger,
+            TokenKind::Pipe,
+            TokenKind::LiteralFloat,
+            TokenKind::Whitespace,
+            TokenKind::Arrow,
+            TokenKind::Whitespace,
+            TokenKind::Other,
+        ]
+    );
+
+    test!(
+        lexes_bare_radix_prefix_as_zero_then_identifier,
+        b"0x",
+        vec![TokenKind::LiteralInteger, TokenKind::Identifier]
+    );
+
+    test!(reconstructs_empty, b"", vec![]);
+
+    test!(
+        reconstructs_simple,
+        b"/** @param int $x */",
+        vec![
+            TokenKind::OpeningMarker,
+            TokenKind::Tag,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Variable,
+            TokenKind::Whitespace,
+            TokenKind::ClosingMarker
+        ]
+    );
+
+    test!(
+        reconstructs_multiline,
+        b"/**\n * @return void\n */",
+        vec![
+            TokenKind::OpeningMarker,
+            TokenKind::Whitespace,
+            TokenKind::Asterisk,
+            TokenKind::Whitespace,
+            TokenKind::Tag,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::ClosingMarker
+        ]
+    );
+
+    test!(
+        reconstructs_with_asterisks,
+        indoc::indoc! {
+            r#"/**
+            * This is a docblock with various tokens.
+            *
+            * @param int<0, 100>|null $count This is a parameter description.
+            * @return array{a: int} This is a return type description.
+            * @throws \Exception This is a throws description.
+            */"#
+        },
+        vec![
+            TokenKind::OpeningMarker,
+            TokenKind::Whitespace,
+            TokenKind::Asterisk,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Other,
+            TokenKind::Whitespace,
+            TokenKind::Asterisk,
+            TokenKind::Whitespace,
+            TokenKind::Asterisk,
+            TokenKind::Whitespace,
+            TokenKind::Tag,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::LeftAngleBracket,
+            TokenKind::LiteralInteger,
+            TokenKind::Comma,
+            TokenKind::Whitespace,
+            TokenKind::LiteralInteger,
+            TokenKind::RightAngleBracket,
+            TokenKind::Pipe,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Variable,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Other,
+            TokenKind::Whitespace,
+            TokenKind::Asterisk,
+            TokenKind::Whitespace,
+            TokenKind::Tag,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::LeftBrace,
+            TokenKind::Identifier,
+            TokenKind::Colon,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::RightBrace,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Other,
+            TokenKind::Whitespace,
+            TokenKind::Asterisk,
+            TokenKind::Whitespace,
+            TokenKind::Tag,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Other,
+            TokenKind::Whitespace,
+            TokenKind::ClosingMarker
+        ]
+    );
+
+    test!(
+        multi_line_comment_crlf_with_multibyte_char,
+        indoc::indoc! {
+            r#"/**\r\n * blah blah ‰©\r\n */"#
+        },
+        vec![
+            TokenKind::Other,
+            TokenKind::Whitespace,
+            TokenKind::Asterisk,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::ClosingMarker
+        ]
+    );
+
+    test!(
+        lex_multi_line_comment_missing_whitespace_after_asterisk,
+        indoc::indoc! {
+            "/**
+            * This is a multi-line comment.
+            *It has multiple lines.
+            * Each line starts with an asterisk.
+            */"
+        },
+        vec![
+            TokenKind::OpeningMarker,
+            TokenKind::Whitespace,
+            TokenKind::Asterisk,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Other,
+            TokenKind::Whitespace,
+            TokenKind::Asterisk,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Other,
+            TokenKind::Whitespace,
+            TokenKind::Asterisk,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Other,
+            TokenKind::Whitespace,
+            TokenKind::ClosingMarker
+        ]
+    );
+
+    test!(smoke_only_horizontal_and_vertical_whitespace, "   \t\t  \x0b\x0c   ", vec![TokenKind::Whitespace]);
+
+    test!(smoke_only_newlines, "\n\n\r\n\n\r\r\n", vec![TokenKind::Whitespace]);
+
+    test!(
+        smoke_chinese,
+        "你好世界 @param 整数 $值 描述文本",
+        vec![
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Tag,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Variable,
+            TokenKind::Whitespace,
+            TokenKind::Identifier
+        ]
+    );
+
+    test!(
+        smoke_emoji,
+        "🎉 @return 🚀|🌟 $x 🍕🍔🍟",
+        vec![
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Tag,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Pipe,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Variable,
+            TokenKind::Whitespace,
+            TokenKind::Identifier
+        ]
+    );
+
+    test!(
+        smoke_invalid_utf8,
+        b"\xff\xfe\xfd\xfc foo \x80\x81\x82 bar",
+        vec![
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier
+        ]
+    );
+
+    test!(smoke_null_and_control_bytes, b"\x00\x01\x02int\x00string\x1f\x7f", vec![TokenKind::Other]);
+
+    test!(smoke_operator_soup, b"@@@|||&&&???:::==>><<<-->>->=>", vec![TokenKind::Other]);
+
+    test!(
+        smoke_bracket_soup,
+        b"{{{[[[((( )))]]]}}}<><><>",
+        vec![
+            TokenKind::LeftBrace,
+            TokenKind::LeftBrace,
+            TokenKind::LeftBrace,
+            TokenKind::LeftBracket,
+            TokenKind::LeftBracket,
+            TokenKind::LeftBracket,
+            TokenKind::LeftParenthesis,
+            TokenKind::LeftParenthesis,
+            TokenKind::LeftParenthesis,
+            TokenKind::Whitespace,
+            TokenKind::RightParenthesis,
+            TokenKind::RightParenthesis,
+            TokenKind::RightParenthesis,
+            TokenKind::RightBracket,
+            TokenKind::RightBracket,
+            TokenKind::RightBracket,
+            TokenKind::RightBrace,
+            TokenKind::RightBrace,
+            TokenKind::RightBrace,
+            TokenKind::LeftAngleBracket,
+            TokenKind::RightAngleBracket,
+            TokenKind::LeftAngleBracket,
+            TokenKind::RightAngleBracket,
+            TokenKind::LeftAngleBracket,
+            TokenKind::RightAngleBracket
+        ]
+    );
+
+    test!(
+        smoke_leading_trailing_stars,
+        b"***array<int>***",
+        vec![
+            TokenKind::Asterisk,
+            TokenKind::Asterisk,
+            TokenKind::Asterisk,
+            TokenKind::Identifier,
+            TokenKind::LeftAngleBracket,
+            TokenKind::Identifier,
+            TokenKind::RightAngleBracket,
+            TokenKind::Asterisk,
+            TokenKind::Asterisk,
+            TokenKind::Asterisk
+        ]
+    );
+
+    test!(
+        smoke_closing_marker_edges,
+        b"*/ foo */ bar */",
+        vec![
+            TokenKind::ClosingMarker,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::ClosingMarker,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::ClosingMarker
+        ]
+    );
+
+    test!(
+        smoke_open_without_close,
+        b"/** @param int $x no closing marker here",
+        vec![
+            TokenKind::OpeningMarker,
+            TokenKind::Tag,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Variable,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier
+        ]
+    );
+
+    test!(smoke_empty_docblock, b"/**/", vec![TokenKind::Other, TokenKind::ClosingMarker]);
+
+    test!(
+        smoke_nested_markers,
+        b"/** /** */ */",
+        vec![
+            TokenKind::OpeningMarker,
+            TokenKind::OpeningMarker,
+            TokenKind::ClosingMarker,
+            TokenKind::Whitespace,
+            TokenKind::ClosingMarker
+        ]
+    );
+
+    test!(
+        smoke_unterminated_single_quote,
+        b"'unterminated string spanning the rest of input",
+        vec![
+            TokenKind::Other,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier
+        ]
+    );
+
+    test!(
+        smoke_unterminated_double_quote,
+        b"\"esc \\\" still going to the end",
+        vec![
+            TokenKind::Other,
+            TokenKind::Whitespace,
+            TokenKind::Other,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier
+        ]
+    );
+
+    test!(
+        smoke_backslash_soup,
+        b"\\\\\\Foo\\\\Bar\\\\ \\ \\1 \\$",
+        vec![
+            TokenKind::Other,
+            TokenKind::Whitespace,
+            TokenKind::Other,
+            TokenKind::Whitespace,
+            TokenKind::Other,
+            TokenKind::Whitespace,
+            TokenKind::Other
+        ]
+    );
+
+    test!(
+        smoke_dollar_soup,
+        b"$$$ $123 $ $this$that $0 $_",
+        vec![
+            TokenKind::Other,
+            TokenKind::Whitespace,
+            TokenKind::Other,
+            TokenKind::Whitespace,
+            TokenKind::Other,
+            TokenKind::Whitespace,
+            TokenKind::ThisVariable,
+            TokenKind::Variable,
+            TokenKind::Whitespace,
+            TokenKind::Other,
+            TokenKind::Whitespace,
+            TokenKind::Variable
+        ]
+    );
+
+    test!(
+        smoke_number_garbage,
+        b"---+++...0x0o0b1_2_.3.4e+-e 1.2.3.4",
+        vec![
+            TokenKind::Minus,
+            TokenKind::Minus,
+            TokenKind::Minus,
+            TokenKind::Plus,
+            TokenKind::Plus,
+            TokenKind::Plus,
+            TokenKind::Ellipsis,
+            TokenKind::LiteralInteger,
+            TokenKind::Identifier,
+            TokenKind::LiteralFloat,
+            TokenKind::LiteralFloat,
+            TokenKind::Identifier,
+            TokenKind::Plus,
+            TokenKind::Minus,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::LiteralFloat,
+            TokenKind::LiteralFloat,
+            TokenKind::LiteralFloat
+        ]
+    );
+
+    test!(
+        smoke_at_garbage,
+        b"@@ @1 @- @ @param@return @a:b:c",
+        vec![
+            TokenKind::Other,
+            TokenKind::Whitespace,
+            TokenKind::Other,
+            TokenKind::Whitespace,
+            TokenKind::Other,
+            TokenKind::Whitespace,
+            TokenKind::Other,
+            TokenKind::Whitespace,
+            TokenKind::Tag,
+            TokenKind::Tag,
+            TokenKind::Whitespace,
+            TokenKind::Tag,
+            TokenKind::Colon,
+            TokenKind::Identifier
+        ]
+    );
+
+    test!(
+        smoke_mixed_everything,
+        "int|string\t你好 @var $x */ 🎉 ::* <T of object> -1.5e3 array{a:int,'b'?:\"c\"}",
+        vec![
+            TokenKind::Identifier,
+            TokenKind::Pipe,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Tag,
+            TokenKind::Whitespace,
+            TokenKind::Variable,
+            TokenKind::Whitespace,
+            TokenKind::ClosingMarker,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::ColonColon,
+            TokenKind::Asterisk,
+            TokenKind::Whitespace,
+            TokenKind::LeftAngleBracket,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::RightAngleBracket,
+            TokenKind::Whitespace,
+            TokenKind::Minus,
+            TokenKind::LiteralFloat,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
+            TokenKind::LeftBrace,
+            TokenKind::Identifier,
+            TokenKind::Colon,
+            TokenKind::Identifier,
+            TokenKind::Comma,
+            TokenKind::SingleQuotedString,
+            TokenKind::Question,
+            TokenKind::Colon,
+            TokenKind::DoubleQuotedString,
+            TokenKind::RightBrace
+        ]
+    );
+
+    test!(
+        smoke_high_byte_boundaries,
+        b"\xe4\xbd\xa0<\xf0\x9f\x8e\x89>\xc3\x28",
+        vec![
+            TokenKind::Identifier,
+            TokenKind::LeftAngleBracket,
+            TokenKind::Identifier,
+            TokenKind::RightAngleBracket,
+            TokenKind::Identifier,
+            TokenKind::LeftParenthesis
+        ]
+    );
+}

--- a/crates/phpdoc-syntax/src/lib.rs
+++ b/crates/phpdoc-syntax/src/lib.rs
@@ -1,0 +1,11 @@
+#![allow(clippy::pub_use)]
+#![allow(clippy::exhaustive_enums)]
+
+pub mod cst;
+pub mod error;
+pub mod lexer;
+pub mod parser;
+pub mod token;
+
+pub use crate::parser::PHPDocParser;
+pub use crate::parser::parse_type;

--- a/crates/phpdoc-syntax/src/parser/internal/alloc.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/alloc.rs
@@ -1,0 +1,39 @@
+use bumpalo::collections::Vec as BVec;
+
+use mago_span::Span;
+
+use crate::cst::inherit_doc::InheritDoc;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+
+impl<'arena> PHPDocParser<'arena> {
+    #[inline]
+    pub(crate) fn new_vec<T>(&self) -> BVec<'arena, T> {
+        BVec::new_in(self.arena)
+    }
+
+    #[inline]
+    pub(crate) fn alloc<T>(&self, value: T) -> &'arena T {
+        self.arena.alloc(value)
+    }
+
+    #[inline]
+    pub(crate) fn record_error(&mut self, error: ParseError) {
+        self.errors.push(error);
+    }
+
+    #[inline]
+    pub(crate) fn take_errors(&mut self) -> BVec<'arena, ParseError> {
+        std::mem::replace(&mut self.errors, BVec::new_in(self.arena))
+    }
+
+    #[inline]
+    pub(crate) fn record_inherit_doc(&mut self, span: Span) {
+        self.inherit_docs.push(InheritDoc { span });
+    }
+
+    #[inline]
+    pub(crate) fn take_inherit_docs(&mut self) -> BVec<'arena, InheritDoc> {
+        std::mem::replace(&mut self.inherit_docs, BVec::new_in(self.arena))
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/element.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/element.rs
@@ -1,0 +1,31 @@
+use mago_span::Span;
+
+use crate::cst::element::Element;
+use crate::cst::text::Text;
+use crate::parser::PHPDocParser;
+use crate::token::TokenKind;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_element(&mut self) -> Element<'arena> {
+        if self.stream.is_at(TokenKind::Tag) {
+            match self.parse_tag() {
+                Ok(tag) => return Element::Tag(self.alloc(tag)),
+                Err(error) => self.record_error(error),
+            }
+        } else {
+            match self.parse_text() {
+                Ok(Some(text)) => return Element::Text(text),
+                Ok(None) => {}
+                Err(error) => self.record_error(error),
+            }
+        }
+
+        let file_id = self.file_id();
+        let position = self.stream.current_position();
+        if let Ok(token) = self.stream.consume() {
+            return Element::Text(Text { span: token.span_for(file_id), value: token.value });
+        }
+
+        Element::Text(Text { span: Span::new(file_id, position, position), value: &[] })
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/expression/access.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/expression/access.rs
@@ -1,0 +1,54 @@
+use crate::cst::expression::ClassLikeConstantAccessExpression;
+use crate::cst::expression::ConstantAccessExpression;
+use crate::cst::expression::ConstantExpression;
+use crate::cst::identifier::Identifier;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::token::TokenKind;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_identifier_constant(&mut self) -> Result<ConstantExpression<'arena>, ParseError> {
+        let next = self.stream.peek()?;
+
+        if next.value.eq_ignore_ascii_case(b"true") {
+            return Ok(ConstantExpression::True(self.parse_keyword()?));
+        }
+
+        if next.value.eq_ignore_ascii_case(b"false") {
+            return Ok(ConstantExpression::False(self.parse_keyword()?));
+        }
+
+        if next.value.eq_ignore_ascii_case(b"null") {
+            return Ok(ConstantExpression::Null(self.parse_keyword()?));
+        }
+
+        if next.value.eq_ignore_ascii_case(b"array")
+            && self.stream.lookahead(1).is_some_and(|t| t.kind == TokenKind::LeftParenthesis)
+        {
+            let keyword = self.parse_keyword()?;
+            let left_delimiter = self.stream.eat_span(TokenKind::LeftParenthesis)?;
+
+            return self.parse_array_constant(Some(keyword), left_delimiter, TokenKind::RightParenthesis);
+        }
+
+        let file_id = self.file_id();
+        let identifier = Identifier::from_token(self.stream.consume()?, file_id);
+
+        if self.stream.is_at(TokenKind::ColonColon) {
+            let double_colon = self.stream.consume_span()?;
+            let constant = if self.stream.is_at(TokenKind::Asterisk) {
+                Identifier::from_token(self.stream.consume()?, file_id)
+            } else {
+                Identifier::from_token(self.stream.eat(TokenKind::Identifier)?, file_id)
+            };
+
+            Ok(ConstantExpression::ClassLikeConstantAccess(ClassLikeConstantAccessExpression {
+                class: identifier,
+                double_colon,
+                constant,
+            }))
+        } else {
+            Ok(ConstantExpression::ConstantAccess(ConstantAccessExpression { name: identifier }))
+        }
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/expression/array.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/expression/array.rs
@@ -1,0 +1,64 @@
+use mago_span::Span;
+use mago_syntax_core::ast::TokenSeparatedSequence;
+
+use crate::cst::expression::ArrayConstant;
+use crate::cst::expression::ArrayConstantItem;
+use crate::cst::expression::ConstantExpression;
+use crate::cst::keyword::Keyword;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::token::TokenKind;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_bracket_array_constant(&mut self) -> Result<ConstantExpression<'arena>, ParseError> {
+        let left_delimiter = self.stream.consume_span()?;
+
+        self.parse_array_constant(None, left_delimiter, TokenKind::RightBracket)
+    }
+
+    pub(crate) fn parse_array_constant(
+        &mut self,
+        keyword: Option<Keyword<'arena>>,
+        left_delimiter: Span,
+        closing: TokenKind,
+    ) -> Result<ConstantExpression<'arena>, ParseError> {
+        let mut items = self.new_vec::<ArrayConstantItem<'arena>>();
+        let mut commas = self.new_vec::<Span>();
+
+        while !self.stream.is_at(closing) {
+            items.push(self.parse_array_constant_item()?);
+
+            if self.stream.is_at(TokenKind::Comma) {
+                commas.push(self.stream.consume_span()?);
+            } else {
+                break;
+            }
+        }
+
+        let right_delimiter = self.stream.eat_span(closing)?;
+
+        Ok(ConstantExpression::Array(ArrayConstant {
+            keyword,
+            left_delimiter,
+            items: TokenSeparatedSequence::new(items, commas),
+            right_delimiter,
+        }))
+    }
+
+    fn parse_array_constant_item(&mut self) -> Result<ArrayConstantItem<'arena>, ParseError> {
+        let first = self.parse_constant_expression()?;
+
+        if self.stream.is_at(TokenKind::DoubleArrow) {
+            let key = self.alloc(first);
+            let double_arrow = self.stream.consume_span()?;
+            let value = self.parse_constant_expression()?;
+            let value = self.alloc(value);
+
+            Ok(ArrayConstantItem { key: Some(key), double_arrow: Some(double_arrow), value })
+        } else {
+            let value = self.alloc(first);
+
+            Ok(ArrayConstantItem { key: None, double_arrow: None, value })
+        }
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/expression/literal.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/expression/literal.rs
@@ -1,0 +1,43 @@
+use ordered_float::OrderedFloat;
+
+use mago_syntax_core::utils::parse_literal_float;
+use mago_syntax_core::utils::parse_literal_integer;
+
+use crate::cst::expression::ConstantExpression;
+use crate::cst::expression::FloatConstant;
+use crate::cst::expression::IntegerConstant;
+use crate::cst::expression::StringConstant;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::token::TokenKind;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_constant_literal(&mut self) -> Result<ConstantExpression<'arena>, ParseError> {
+        let file_id = self.file_id();
+        let token = self.stream.consume()?;
+
+        let expression = match token.kind {
+            TokenKind::LiteralInteger => {
+                let value = parse_literal_integer(token.value).unwrap_or(0);
+
+                ConstantExpression::Integer(IntegerConstant { span: token.span_for(file_id), value, raw: token.value })
+            }
+            TokenKind::LiteralFloat => {
+                let value = parse_literal_float(token.value).unwrap_or(0.0);
+
+                ConstantExpression::Float(FloatConstant {
+                    span: token.span_for(file_id),
+                    value: OrderedFloat(value),
+                    raw: token.value,
+                })
+            }
+            _ => {
+                let value = token.value.get(1..token.value.len().saturating_sub(1)).unwrap_or(&[]);
+
+                ConstantExpression::String(StringConstant { span: token.span_for(file_id), value, raw: token.value })
+            }
+        };
+
+        Ok(expression)
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/expression/mod.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/expression/mod.rs
@@ -1,0 +1,27 @@
+use crate::cst::expression::ConstantExpression;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::token::TokenKind;
+
+pub(crate) mod access;
+pub(crate) mod array;
+pub(crate) mod literal;
+pub(crate) mod unary;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_constant_expression(&mut self) -> Result<ConstantExpression<'arena>, ParseError> {
+        let next = self.stream.peek()?;
+
+        match next.kind {
+            TokenKind::Minus => self.parse_negated_constant(),
+            TokenKind::Plus => self.parse_posited_constant(),
+            TokenKind::LiteralInteger
+            | TokenKind::LiteralFloat
+            | TokenKind::SingleQuotedString
+            | TokenKind::DoubleQuotedString => self.parse_constant_literal(),
+            TokenKind::LeftBracket => self.parse_bracket_array_constant(),
+            TokenKind::Identifier => self.parse_identifier_constant(),
+            _ => Err(ParseError::UnexpectedToken(next.span_for(self.file_id()))),
+        }
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/expression/unary.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/expression/unary.rs
@@ -1,0 +1,27 @@
+use crate::cst::expression::ConstantExpression;
+use crate::cst::expression::UnaryPrefixConstantExpression;
+use crate::cst::expression::UnaryPrefixConstantOperator;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_negated_constant(&mut self) -> Result<ConstantExpression<'arena>, ParseError> {
+        let minus = self.stream.consume_span()?;
+        let operand = self.parse_constant_expression()?;
+
+        Ok(ConstantExpression::UnaryPrefix(UnaryPrefixConstantExpression {
+            operator: UnaryPrefixConstantOperator::Negation(minus),
+            operand: self.alloc(operand),
+        }))
+    }
+
+    pub(crate) fn parse_posited_constant(&mut self) -> Result<ConstantExpression<'arena>, ParseError> {
+        let plus = self.stream.consume_span()?;
+        let operand = self.parse_constant_expression()?;
+
+        Ok(ConstantExpression::UnaryPrefix(UnaryPrefixConstantExpression {
+            operator: UnaryPrefixConstantOperator::Plus(plus),
+            operand: self.alloc(operand),
+        }))
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/identifier.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/identifier.rs
@@ -1,0 +1,12 @@
+use crate::cst::identifier::Identifier;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::token::TokenKind;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_identifier(&mut self) -> Result<Identifier<'arena>, ParseError> {
+        let token = self.stream.eat(TokenKind::Identifier)?;
+
+        Ok(Identifier::from_token(token, self.file_id()))
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/keyword.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/keyword.rs
@@ -1,0 +1,11 @@
+use crate::cst::keyword::Keyword;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_keyword(&mut self) -> Result<Keyword<'arena>, ParseError> {
+        let token = self.stream.consume()?;
+
+        Ok(Keyword { span: token.span_for(self.file_id()), value: token.value })
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/mod.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/mod.rs
@@ -1,0 +1,38 @@
+use mago_span::Span;
+use mago_syntax_core::ast::Sequence;
+
+use crate::cst::Document;
+use crate::cst::element::Element;
+use crate::parser::PHPDocParser;
+
+pub(crate) mod alloc;
+pub(crate) mod element;
+pub(crate) mod expression;
+pub(crate) mod identifier;
+pub(crate) mod keyword;
+pub(crate) mod stream;
+pub(crate) mod tag;
+pub(crate) mod text;
+pub(crate) mod r#type;
+pub(crate) mod variable;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_document(&mut self, span: Span) -> Document<'arena> {
+        let mut elements = self.new_vec::<Element<'arena>>();
+        while !self.stream.has_reached_eof() {
+            elements.push(self.parse_element());
+        }
+
+        let trivia = self.stream.take_trivia();
+        let inherit_docs = self.take_inherit_docs();
+        let errors = self.take_errors();
+
+        Document {
+            span,
+            trivia: Sequence::new(trivia),
+            elements: Sequence::new(elements),
+            inherit_docs: Sequence::new(inherit_docs),
+            errors,
+        }
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/stream.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/stream.rs
@@ -1,0 +1,275 @@
+use bumpalo::Bump;
+use bumpalo::collections::Vec as BVec;
+
+use mago_database::file::FileId;
+use mago_database::file::HasFileId;
+use mago_span::Position;
+use mago_span::Span;
+use mago_syntax_core::parser::LookaheadBuf;
+
+use crate::cst::trivia::Trivia;
+use crate::cst::trivia::TriviaKind;
+use crate::error::ParseError;
+use crate::lexer::DocblockLexer;
+use crate::token::Token;
+use crate::token::TokenKind;
+
+#[derive(Debug, Clone, Copy)]
+struct BufferedToken<'arena> {
+    token: Token<'arena>,
+    starts_line: bool,
+}
+
+#[derive(Debug)]
+pub struct DocblockTokenStream<'arena> {
+    arena: &'arena Bump,
+    lexer: DocblockLexer<'arena>,
+    buffer: LookaheadBuf<BufferedToken<'arena>, 64>,
+    trivia: BVec<'arena, Trivia<'arena>>,
+    source: &'arena [u8],
+    base: u32,
+    position: Position,
+    file_id: FileId,
+    pending_newline: bool,
+    allow_line_prefix: bool,
+    reached_end: bool,
+}
+
+#[inline]
+fn contains_newline(bytes: &[u8]) -> bool {
+    memchr::memchr2(b'\n', b'\r', bytes).is_some()
+}
+
+impl<'arena> DocblockTokenStream<'arena> {
+    #[must_use]
+    pub fn new(arena: &'arena Bump, lexer: DocblockLexer<'arena>, source: &'arena [u8], base: Position) -> Self {
+        let file_id = lexer.file_id();
+
+        DocblockTokenStream {
+            arena,
+            lexer,
+            buffer: LookaheadBuf::new(),
+            trivia: BVec::new_in(arena),
+            source,
+            base: base.offset,
+            position: base,
+            file_id,
+            pending_newline: false,
+            allow_line_prefix: false,
+            reached_end: false,
+        }
+    }
+
+    #[inline]
+    pub fn take_trivia(&mut self) -> BVec<'arena, Trivia<'arena>> {
+        std::mem::replace(&mut self.trivia, BVec::new_in(self.arena))
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn current_position(&self) -> Position {
+        self.position
+    }
+
+    #[inline]
+    pub fn has_reached_eof(&mut self) -> bool {
+        self.fill_buffer(1).is_none()
+    }
+
+    #[inline]
+    pub fn consume(&mut self) -> Result<Token<'arena>, ParseError> {
+        match self.advance() {
+            Some(token) => Ok(token),
+            None => Err(ParseError::UnexpectedEndOfInput(self.zero_span())),
+        }
+    }
+
+    #[inline]
+    pub fn eat(&mut self, kind: TokenKind) -> Result<Token<'arena>, ParseError> {
+        match self.buffer.get(0) {
+            Some(buffered) if buffered.token.kind == kind => {
+                let _ = self.buffer.pop_front();
+                self.position = Self::end_of(&buffered.token);
+
+                Ok(buffered.token)
+            }
+            Some(buffered) => Err(ParseError::UnexpectedToken(self.span_of(&buffered.token))),
+            None => match self.fill_buffer(1) {
+                Some(()) => self.eat(kind),
+                None => Err(ParseError::UnexpectedEndOfInput(self.zero_span())),
+            },
+        }
+    }
+
+    #[inline]
+    pub fn consume_span(&mut self) -> Result<Span, ParseError> {
+        let token = self.consume()?;
+
+        Ok(self.span_of(&token))
+    }
+
+    #[inline]
+    pub fn eat_span(&mut self, kind: TokenKind) -> Result<Span, ParseError> {
+        let token = self.eat(kind)?;
+
+        Ok(self.span_of(&token))
+    }
+
+    #[inline]
+    pub fn is_at_value(&mut self, value: &[u8]) -> bool {
+        self.lookahead(0).is_some_and(|token| token.kind == TokenKind::Identifier && token.value == value)
+    }
+
+    #[inline]
+    pub fn peek(&mut self) -> Result<Token<'arena>, ParseError> {
+        match self.lookahead(0) {
+            Some(token) => Ok(token),
+            None => Err(ParseError::UnexpectedEndOfInput(self.zero_span())),
+        }
+    }
+
+    #[inline]
+    pub fn lookahead(&mut self, n: usize) -> Option<Token<'arena>> {
+        if n < self.buffer.len() {
+            return self.buffer.get(n).map(|buffered| buffered.token);
+        }
+
+        match self.fill_buffer(n + 1) {
+            Some(()) => self.buffer.get(n).map(|buffered| buffered.token),
+            None => None,
+        }
+    }
+
+    #[inline]
+    pub fn peek_kind(&mut self, n: usize) -> Option<TokenKind> {
+        self.lookahead(n).map(|token| token.kind)
+    }
+
+    #[inline]
+    pub fn is_at(&mut self, kind: TokenKind) -> bool {
+        self.peek_kind(0) == Some(kind)
+    }
+
+    #[inline]
+    pub fn starts_line(&mut self, n: usize) -> bool {
+        if n >= self.buffer.len() {
+            let _ = self.fill_buffer(n + 1);
+        }
+
+        self.buffer.get(n).is_some_and(|buffered| buffered.starts_line)
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn raw_between(&self, from: Position, to: Position) -> &'arena [u8] {
+        let start = from.offset.saturating_sub(self.base) as usize;
+        let end = to.offset.saturating_sub(self.base) as usize;
+        let length = self.source.len();
+        let start = start.min(length);
+        let end = end.min(length).max(start);
+
+        &self.source[start..end]
+    }
+
+    #[inline]
+    fn advance(&mut self) -> Option<Token<'arena>> {
+        self.fill_buffer(1)?;
+        let buffered = self.buffer.pop_front()?;
+        self.position = Self::end_of(&buffered.token);
+
+        Some(buffered.token)
+    }
+
+    #[inline]
+    fn fill_buffer(&mut self, n: usize) -> Option<()> {
+        if self.buffer.len() >= n {
+            return Some(());
+        }
+
+        self.fill_buffer_slow(n)
+    }
+
+    #[inline(never)]
+    fn fill_buffer_slow(&mut self, n: usize) -> Option<()> {
+        while self.buffer.len() < n {
+            if self.reached_end {
+                return None;
+            }
+
+            let token = self.lexer.advance()?;
+
+            match token.kind {
+                TokenKind::Whitespace => {
+                    self.push_trivia(TriviaKind::Whitespace, token);
+                    if contains_newline(token.value) {
+                        self.pending_newline = true;
+                        self.allow_line_prefix = true;
+                    }
+                }
+                TokenKind::LineComment => {
+                    self.push_trivia(TriviaKind::LineComment, token);
+                }
+                TokenKind::Asterisk if self.allow_line_prefix => {
+                    self.push_trivia(TriviaKind::Asterisk, token);
+                    self.allow_line_prefix = false;
+                }
+                TokenKind::OpeningMarker => {
+                    self.push_trivia(TriviaKind::OpeningMarker, token);
+                    self.pending_newline = false;
+                    self.allow_line_prefix = false;
+                }
+                TokenKind::ClosingMarker => {
+                    self.push_trivia(TriviaKind::ClosingMarker, token);
+
+                    let after = Position::new(token.start.offset + token.value.len() as u32);
+                    let end = Position::new(self.base + self.source.len() as u32);
+                    if after.offset < end.offset {
+                        let value = self.raw_between(after, end);
+                        self.trivia.push(Trivia {
+                            kind: TriviaKind::Trailing,
+                            span: Span::new(self.file_id, after, end),
+                            value,
+                        });
+                    }
+
+                    self.reached_end = true;
+                }
+                _ => {
+                    let starts_line = self.pending_newline;
+                    self.pending_newline = false;
+                    self.allow_line_prefix = false;
+                    self.buffer.push_back(BufferedToken { token, starts_line });
+                }
+            }
+        }
+
+        Some(())
+    }
+
+    #[inline]
+    fn push_trivia(&mut self, kind: TriviaKind, token: Token<'arena>) {
+        self.trivia.push(Trivia::from_token(kind, token, self.file_id));
+    }
+
+    #[inline]
+    fn span_of(&self, token: &Token<'arena>) -> Span {
+        token.span_for(self.file_id)
+    }
+
+    #[inline]
+    fn end_of(token: &Token<'arena>) -> Position {
+        Position::new(token.start.offset + token.value.len() as u32)
+    }
+
+    #[inline]
+    fn zero_span(&self) -> Span {
+        Span::new(self.file_id, self.position, self.position)
+    }
+}
+
+impl HasFileId for DocblockTokenStream<'_> {
+    #[inline]
+    fn file_id(&self) -> FileId {
+        self.file_id
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/tag/assert.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/tag/assert.rs
@@ -1,0 +1,56 @@
+use crate::cst::tag::AssertTagMethodValue;
+use crate::cst::tag::AssertTagPropertyValue;
+use crate::cst::tag::AssertTagValue;
+use crate::cst::tag::TagValue;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::token::TokenKind;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_assert_tag_value(&mut self) -> Result<TagValue<'arena>, ParseError> {
+        let bang = if self.stream.is_at(TokenKind::Bang) { Some(self.stream.consume_span()?) } else { None };
+        let equals = if self.stream.is_at(TokenKind::Equals) { Some(self.stream.consume_span()?) } else { None };
+        let r#type = self.parse_type()?;
+        let r#type = self.alloc(r#type);
+        let parameter = self.parse_variable()?;
+
+        if self.stream.is_at(TokenKind::Arrow) {
+            let arrow = self.stream.consume_span()?;
+            let member = self.parse_identifier()?;
+
+            if self.stream.is_at(TokenKind::LeftParenthesis) {
+                let left_parenthesis = self.stream.consume_span()?;
+                let right_parenthesis = self.stream.eat_span(TokenKind::RightParenthesis)?;
+                let description = self.parse_optional_description(false)?;
+
+                return Ok(TagValue::AssertMethod(AssertTagMethodValue {
+                    bang,
+                    equals,
+                    r#type,
+                    parameter,
+                    arrow,
+                    method: member,
+                    left_parenthesis,
+                    right_parenthesis,
+                    description,
+                }));
+            }
+
+            let description = self.parse_optional_description(false)?;
+
+            return Ok(TagValue::AssertProperty(AssertTagPropertyValue {
+                bang,
+                equals,
+                r#type,
+                parameter,
+                arrow,
+                property: member,
+                description,
+            }));
+        }
+
+        let description = self.parse_optional_description(false)?;
+
+        Ok(TagValue::Assert(AssertTagValue { bang, equals, r#type, parameter, description }))
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/tag/inheritance.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/tag/inheritance.rs
@@ -1,0 +1,94 @@
+use mago_span::Span;
+use mago_syntax_core::ast::TokenSeparatedSequence;
+
+use crate::cst::identifier::Identifier;
+use crate::cst::tag::ExtendsTagValue;
+use crate::cst::tag::ImplementsTagValue;
+use crate::cst::tag::InheritorsTagValue;
+use crate::cst::tag::RequireExtendsTagValue;
+use crate::cst::tag::RequireImplementsTagValue;
+use crate::cst::tag::SealedTagValue;
+use crate::cst::tag::TagValue;
+use crate::cst::tag::UsesTagValue;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::token::TokenKind;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_extends_tag_value(&mut self) -> Result<TagValue<'arena>, ParseError> {
+        let r#type = self.parse_type()?;
+        let r#type = self.alloc(r#type);
+        let description = self.parse_optional_description(true)?;
+
+        Ok(TagValue::Extends(ExtendsTagValue { r#type, description }))
+    }
+
+    pub(crate) fn parse_implements_tag_value(&mut self) -> Result<TagValue<'arena>, ParseError> {
+        let r#type = self.parse_type()?;
+        let r#type = self.alloc(r#type);
+        let description = self.parse_optional_description(true)?;
+
+        Ok(TagValue::Implements(ImplementsTagValue { r#type, description }))
+    }
+
+    pub(crate) fn parse_uses_tag_value(&mut self) -> Result<TagValue<'arena>, ParseError> {
+        let r#type = self.parse_type()?;
+        let r#type = self.alloc(r#type);
+        let description = self.parse_optional_description(true)?;
+
+        Ok(TagValue::Uses(UsesTagValue { r#type, description }))
+    }
+
+    pub(crate) fn parse_require_extends_tag_value(&mut self) -> Result<TagValue<'arena>, ParseError> {
+        let r#type = self.parse_type()?;
+        let r#type = self.alloc(r#type);
+        let description = self.parse_optional_description(true)?;
+
+        Ok(TagValue::RequireExtends(RequireExtendsTagValue { r#type, description }))
+    }
+
+    pub(crate) fn parse_require_implements_tag_value(&mut self) -> Result<TagValue<'arena>, ParseError> {
+        let r#type = self.parse_type()?;
+        let r#type = self.alloc(r#type);
+        let description = self.parse_optional_description(true)?;
+
+        Ok(TagValue::RequireImplements(RequireImplementsTagValue { r#type, description }))
+    }
+
+    pub(crate) fn parse_sealed_tag_value(&mut self) -> Result<TagValue<'arena>, ParseError> {
+        let r#type = self.parse_type()?;
+        let r#type = self.alloc(r#type);
+        let description = self.parse_optional_description(true)?;
+
+        Ok(TagValue::Sealed(SealedTagValue { r#type, description }))
+    }
+
+    pub(crate) fn parse_inheritors_tag_value(&mut self) -> Result<TagValue<'arena>, ParseError> {
+        let file_id = self.file_id();
+        let start = self.stream.peek()?.start;
+
+        let mut nodes = self.new_vec::<Identifier<'arena>>();
+        let mut separators = self.new_vec();
+
+        loop {
+            nodes.push(self.parse_identifier()?);
+
+            if self.stream.is_at(TokenKind::Pipe) {
+                separators.push(self.stream.consume()?);
+            } else {
+                break;
+            }
+
+            if !self.stream.is_at(TokenKind::Identifier) {
+                break;
+            }
+        }
+
+        let span = Span::new(file_id, start, self.stream.current_position());
+
+        Ok(TagValue::Inheritors(InheritorsTagValue {
+            span,
+            inheritors: TokenSeparatedSequence::new(nodes, separators),
+        }))
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/tag/meta.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/tag/meta.rs
@@ -1,0 +1,34 @@
+use crate::cst::tag::DeprecatedTagValue;
+use crate::cst::tag::GenericTagValue;
+use crate::cst::tag::InheritDocTagValue;
+use crate::cst::tag::PureUnlessCallableIsImpureTagValue;
+use crate::cst::tag::TagValue;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_deprecated_tag_value(&mut self) -> Result<TagValue<'arena>, ParseError> {
+        let description = self.parse_text_or_empty()?;
+
+        Ok(TagValue::Deprecated(DeprecatedTagValue { description }))
+    }
+
+    pub(crate) fn parse_inherit_doc_tag_value(&mut self) -> Result<TagValue<'arena>, ParseError> {
+        let description = self.parse_text_or_empty()?;
+
+        Ok(TagValue::InheritDoc(InheritDocTagValue { description }))
+    }
+
+    pub(crate) fn parse_pure_unless_callable_is_impure_tag_value(&mut self) -> Result<TagValue<'arena>, ParseError> {
+        let parameter = self.parse_variable()?;
+        let description = self.parse_optional_description(false)?;
+
+        Ok(TagValue::PureUnlessCallableIsImpure(PureUnlessCallableIsImpureTagValue { parameter, description }))
+    }
+
+    pub(crate) fn parse_generic_tag_value(&mut self) -> Result<TagValue<'arena>, ParseError> {
+        let value = self.parse_text_or_empty()?;
+
+        Ok(TagValue::Generic(GenericTagValue { value }))
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/tag/method.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/tag/method.rs
@@ -1,0 +1,136 @@
+use mago_span::HasSpan;
+use mago_syntax_core::ast::Sequence;
+
+use crate::cst::identifier::Identifier;
+use crate::cst::tag::MethodParameterList;
+use crate::cst::tag::MethodTagValue;
+use crate::cst::tag::MethodTagValueParameter;
+use crate::cst::tag::MethodTagValueParameterDefault;
+use crate::cst::tag::MethodTemplateParameter;
+use crate::cst::tag::MethodTemplateParameterList;
+use crate::cst::tag::TagValue;
+use crate::cst::r#type::Type;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::token::TokenKind;
+
+#[inline]
+fn is_static_identifier(r#type: &Type<'_>) -> bool {
+    matches!(r#type, Type::Reference(reference)
+        if reference.parameters.is_none() && reference.identifier.value.eq_ignore_ascii_case(b"static"))
+}
+
+impl<'arena> PHPDocParser<'arena> {
+    fn identifier_from_type(&self, r#type: &Type<'arena>) -> Identifier<'arena> {
+        if let Type::Reference(reference) = r#type
+            && reference.parameters.is_none()
+        {
+            return reference.identifier;
+        }
+
+        let span = r#type.span();
+
+        Identifier { span, value: self.stream.raw_between(span.start, span.end) }
+    }
+
+    pub(crate) fn parse_method_tag_value(&mut self) -> Result<TagValue<'arena>, ParseError> {
+        let first = self.parse_type()?;
+        let treat_static_as_modifier = is_static_identifier(&first)
+            && !self.stream.is_at(TokenKind::LeftParenthesis)
+            && !self.stream.is_at(TokenKind::LeftAngleBracket);
+
+        let (r#static, candidate) =
+            if treat_static_as_modifier { (Some(first.span()), self.parse_type()?) } else { (None, first) };
+
+        let (return_type, name) = if self.stream.is_at(TokenKind::Identifier) {
+            let return_type = self.alloc(candidate);
+            let name = self.parse_identifier()?;
+
+            (Some(return_type), name)
+        } else {
+            (None, self.identifier_from_type(&candidate))
+        };
+
+        let templates = self.parse_method_templates()?;
+        let parameters = self.parse_method_parameters()?;
+        let description = self.parse_optional_description(false)?;
+
+        Ok(TagValue::Method(MethodTagValue { r#static, return_type, name, templates, parameters, description }))
+    }
+
+    fn parse_method_templates(&mut self) -> Result<Option<&'arena MethodTemplateParameterList<'arena>>, ParseError> {
+        if !self.stream.is_at(TokenKind::LeftAngleBracket) {
+            return Ok(None);
+        }
+
+        let less_than = self.stream.consume_span()?;
+
+        let mut entries = self.new_vec::<MethodTemplateParameter<'arena>>();
+        loop {
+            let template = self.parse_template_tag_value(false)?;
+            let comma = if self.stream.is_at(TokenKind::Comma) { Some(self.stream.consume_span()?) } else { None };
+            let has_comma = comma.is_some();
+            entries.push(MethodTemplateParameter { template, comma });
+
+            if !has_comma || self.stream.is_at(TokenKind::RightAngleBracket) {
+                break;
+            }
+        }
+
+        let greater_than = self.stream.eat_span(TokenKind::RightAngleBracket)?;
+
+        Ok(Some(self.alloc(MethodTemplateParameterList { less_than, entries: Sequence::new(entries), greater_than })))
+    }
+
+    fn parse_method_parameters(&mut self) -> Result<&'arena MethodParameterList<'arena>, ParseError> {
+        let left_parenthesis = self.stream.eat_span(TokenKind::LeftParenthesis)?;
+
+        let mut entries = self.new_vec::<MethodTagValueParameter<'arena>>();
+        if !self.stream.is_at(TokenKind::RightParenthesis) {
+            loop {
+                let parameter = self.parse_method_parameter()?;
+                let has_comma = parameter.comma.is_some();
+                entries.push(parameter);
+
+                if !has_comma || self.stream.is_at(TokenKind::RightParenthesis) {
+                    break;
+                }
+            }
+        }
+
+        let right_parenthesis = self.stream.eat_span(TokenKind::RightParenthesis)?;
+
+        Ok(self.alloc(MethodParameterList { left_parenthesis, entries: Sequence::new(entries), right_parenthesis }))
+    }
+
+    fn parse_method_parameter(&mut self) -> Result<MethodTagValueParameter<'arena>, ParseError> {
+        let r#type = if matches!(
+            self.stream.peek_kind(0),
+            Some(TokenKind::Ampersand | TokenKind::Ellipsis | TokenKind::Variable | TokenKind::ThisVariable)
+        ) {
+            None
+        } else {
+            let r#type = self.parse_type()?;
+
+            Some(self.alloc(r#type))
+        };
+
+        let ampersand = if self.stream.is_at(TokenKind::Ampersand) { Some(self.stream.consume_span()?) } else { None };
+        let ellipsis = if self.stream.is_at(TokenKind::Ellipsis) { Some(self.stream.consume_span()?) } else { None };
+        let parameter = self.parse_variable()?;
+
+        let default = if self.stream.is_at(TokenKind::Equals) {
+            let equals = self.stream.consume_span()?;
+            let value = self.parse_constant_expression()?;
+            let value = self.alloc(value);
+
+            Some(MethodTagValueParameterDefault { equals, value })
+        } else {
+            None
+        };
+
+        let comma = if self.stream.is_at(TokenKind::Comma) { Some(self.stream.consume_span()?) } else { None };
+
+        Ok(MethodTagValueParameter { r#type, ampersand, ellipsis, parameter, default, comma })
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/tag/mod.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/tag/mod.rs
@@ -1,0 +1,94 @@
+use mago_span::HasSpan;
+
+use crate::cst::identifier::Identifier;
+use crate::cst::tag::InvalidTagValue;
+use crate::cst::tag::Tag;
+use crate::cst::tag::TagValue;
+use crate::cst::tag::TagVendor;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::parser::internal::tag::vendor::remainder_after_vendor;
+use crate::token::TokenKind;
+
+pub(crate) mod assert;
+pub(crate) mod inheritance;
+pub(crate) mod meta;
+pub(crate) mod method;
+pub(crate) mod param;
+pub(crate) mod property;
+pub(crate) mod template;
+pub(crate) mod type_alias;
+pub(crate) mod value;
+pub(crate) mod vendor;
+pub(crate) mod where_clause;
+
+#[inline]
+pub(crate) fn is_inherit_doc_name(name: &[u8]) -> bool {
+    name.eq_ignore_ascii_case(b"inheritdoc") || name.eq_ignore_ascii_case(b"inheritdocs")
+}
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_tag(&mut self) -> Result<Tag<'arena>, ParseError> {
+        let file_id = self.file_id();
+        let token = self.stream.eat(TokenKind::Tag)?;
+
+        let raw_name = token.value.strip_prefix(b"@").unwrap_or(token.value);
+        let name = Identifier { span: token.span_for(file_id), value: raw_name };
+        let vendor = TagVendor::from_name(token.value);
+        let remainder = remainder_after_vendor(raw_name, vendor);
+
+        let value = match self.dispatch_tag_value(remainder) {
+            Ok(value) => value,
+            Err(error) => {
+                self.record_error(error);
+                let text = self.parse_text_or_empty()?;
+
+                TagValue::Invalid(InvalidTagValue { value: text })
+            }
+        };
+
+        let tag = Tag { name, vendor, value };
+        if matches!(tag.value, TagValue::InheritDoc(_)) {
+            self.record_inherit_doc(tag.span());
+        }
+
+        Ok(tag)
+    }
+
+    #[inline]
+    fn dispatch_tag_value(&mut self, remainder: &[u8]) -> Result<TagValue<'arena>, ParseError> {
+        if is_inherit_doc_name(remainder) {
+            return self.parse_inherit_doc_tag_value();
+        }
+
+        match remainder {
+            b"param" => self.parse_param_tag_value(),
+            b"param-out" => self.parse_param_out_tag_value(),
+            b"param-closure-this" => self.parse_param_closure_this_tag_value(),
+            b"param-immediately-invoked-callable" => self.parse_param_immediately_invoked_callable_tag_value(),
+            b"param-later-invoked-callable" => self.parse_param_later_invoked_callable_tag_value(),
+            b"pure-unless-callable-is-impure" => self.parse_pure_unless_callable_is_impure_tag_value(),
+            b"return" | b"real-return" => self.parse_return_tag_value(),
+            b"var" => self.parse_var_tag_value(),
+            b"throws" => self.parse_throws_tag_value(),
+            b"mixin" => self.parse_mixin_tag_value(),
+            b"self-out" | b"this-out" => self.parse_self_out_tag_value(),
+            b"property" | b"property-read" | b"property-write" => self.parse_property_tag_value(),
+            b"template" | b"template-covariant" | b"template-contravariant" => self.parse_template_tag(),
+            b"extends" | b"inherits" | b"template-extends" => self.parse_extends_tag_value(),
+            b"implements" | b"template-implements" => self.parse_implements_tag_value(),
+            b"use" | b"uses" | b"template-use" => self.parse_uses_tag_value(),
+            b"require-extends" => self.parse_require_extends_tag_value(),
+            b"require-implements" => self.parse_require_implements_tag_value(),
+            b"sealed" => self.parse_sealed_tag_value(),
+            b"inheritors" => self.parse_inheritors_tag_value(),
+            b"method" => self.parse_method_tag_value(),
+            b"assert" | b"assert-if-true" | b"assert-if-false" => self.parse_assert_tag_value(),
+            b"where" => self.parse_where_tag_value(),
+            b"type" => self.parse_type_alias_tag_value(),
+            b"import-type" => self.parse_type_alias_import_tag_value(),
+            b"deprecated" => self.parse_deprecated_tag_value(),
+            _ => self.parse_generic_tag_value(),
+        }
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/tag/param.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/tag/param.rs
@@ -1,0 +1,79 @@
+use crate::cst::tag::ParamClosureThisTagValue;
+use crate::cst::tag::ParamImmediatelyInvokedCallableTagValue;
+use crate::cst::tag::ParamLaterInvokedCallableTagValue;
+use crate::cst::tag::ParamOutTagValue;
+use crate::cst::tag::ParamTagValue;
+use crate::cst::tag::TagValue;
+use crate::cst::tag::TypelessParamTagValue;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::token::TokenKind;
+
+impl<'arena> PHPDocParser<'arena> {
+    #[inline]
+    fn at_parameter_start(&mut self) -> bool {
+        self.stream.is_at(TokenKind::Ampersand)
+            || self.stream.is_at(TokenKind::Ellipsis)
+            || self.stream.is_at(TokenKind::Variable)
+            || self.stream.is_at(TokenKind::ThisVariable)
+    }
+
+    pub(crate) fn parse_param_tag_value(&mut self) -> Result<TagValue<'arena>, ParseError> {
+        if self.at_parameter_start() {
+            let ampersand =
+                if self.stream.is_at(TokenKind::Ampersand) { Some(self.stream.consume_span()?) } else { None };
+            let ellipsis =
+                if self.stream.is_at(TokenKind::Ellipsis) { Some(self.stream.consume_span()?) } else { None };
+            let parameter = self.parse_variable()?;
+            let description = self.parse_optional_description(false)?;
+
+            return Ok(TagValue::TypelessParam(TypelessParamTagValue { ampersand, ellipsis, parameter, description }));
+        }
+
+        let r#type = self.parse_type()?;
+        let r#type = self.alloc(r#type);
+        let ampersand = if self.stream.is_at(TokenKind::Ampersand) { Some(self.stream.consume_span()?) } else { None };
+        let ellipsis = if self.stream.is_at(TokenKind::Ellipsis) { Some(self.stream.consume_span()?) } else { None };
+        let parameter = self.parse_variable()?;
+        let description = self.parse_optional_description(false)?;
+
+        Ok(TagValue::Param(ParamTagValue { r#type, ampersand, ellipsis, parameter, description }))
+    }
+
+    pub(crate) fn parse_param_out_tag_value(&mut self) -> Result<TagValue<'arena>, ParseError> {
+        let r#type = self.parse_type()?;
+        let r#type = self.alloc(r#type);
+        let parameter = self.parse_variable()?;
+        let description = self.parse_optional_description(false)?;
+
+        Ok(TagValue::ParamOut(ParamOutTagValue { r#type, parameter, description }))
+    }
+
+    pub(crate) fn parse_param_closure_this_tag_value(&mut self) -> Result<TagValue<'arena>, ParseError> {
+        let r#type = self.parse_type()?;
+        let r#type = self.alloc(r#type);
+        let parameter = self.parse_variable()?;
+        let description = self.parse_optional_description(false)?;
+
+        Ok(TagValue::ParamClosureThis(ParamClosureThisTagValue { r#type, parameter, description }))
+    }
+
+    pub(crate) fn parse_param_immediately_invoked_callable_tag_value(
+        &mut self,
+    ) -> Result<TagValue<'arena>, ParseError> {
+        let parameter = self.parse_variable()?;
+        let description = self.parse_optional_description(false)?;
+
+        Ok(TagValue::ParamImmediatelyInvokedCallable(ParamImmediatelyInvokedCallableTagValue {
+            parameter,
+            description,
+        }))
+    }
+
+    pub(crate) fn parse_param_later_invoked_callable_tag_value(&mut self) -> Result<TagValue<'arena>, ParseError> {
+        let parameter = self.parse_variable()?;
+        let description = self.parse_optional_description(false)?;
+
+        Ok(TagValue::ParamLaterInvokedCallable(ParamLaterInvokedCallableTagValue { parameter, description }))
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/tag/property.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/tag/property.rs
@@ -1,0 +1,15 @@
+use crate::cst::tag::PropertyTagValue;
+use crate::cst::tag::TagValue;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_property_tag_value(&mut self) -> Result<TagValue<'arena>, ParseError> {
+        let r#type = self.parse_type()?;
+        let r#type = self.alloc(r#type);
+        let variable = self.parse_variable()?;
+        let description = self.parse_optional_description(false)?;
+
+        Ok(TagValue::Property(PropertyTagValue { r#type, variable, description }))
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/tag/template.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/tag/template.rs
@@ -1,0 +1,55 @@
+use crate::cst::tag::TagValue;
+use crate::cst::tag::TemplateTagValue;
+use crate::cst::tag::TemplateTagValueBound;
+use crate::cst::tag::TemplateTagValueDefault;
+use crate::cst::tag::TemplateTagValueLowerBound;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::token::TokenKind;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_template_tag_value(
+        &mut self,
+        parse_description: bool,
+    ) -> Result<TemplateTagValue<'arena>, ParseError> {
+        let name = self.parse_identifier()?;
+
+        let bound = if self.stream.is_at_value(b"of") || self.stream.is_at_value(b"as") {
+            let keyword = self.parse_keyword()?;
+            let r#type = self.parse_type()?;
+            let r#type = self.alloc(r#type);
+
+            Some(TemplateTagValueBound { keyword, r#type })
+        } else {
+            None
+        };
+
+        let lower_bound = if self.stream.is_at_value(b"super") {
+            let keyword = self.parse_keyword()?;
+            let r#type = self.parse_type()?;
+            let r#type = self.alloc(r#type);
+
+            Some(TemplateTagValueLowerBound { keyword, r#type })
+        } else {
+            None
+        };
+
+        let default = if self.stream.is_at(TokenKind::Equals) {
+            let equals = self.stream.consume_span()?;
+            let r#type = self.parse_type()?;
+            let r#type = self.alloc(r#type);
+
+            Some(TemplateTagValueDefault { equals, r#type })
+        } else {
+            None
+        };
+
+        let description = if parse_description { self.parse_optional_description(true)? } else { None };
+
+        Ok(TemplateTagValue { name, bound, lower_bound, default, description })
+    }
+
+    pub(crate) fn parse_template_tag(&mut self) -> Result<TagValue<'arena>, ParseError> {
+        Ok(TagValue::Template(self.parse_template_tag_value(true)?))
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/tag/type_alias.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/tag/type_alias.rs
@@ -1,0 +1,45 @@
+use crate::cst::tag::TagValue;
+use crate::cst::tag::TypeAliasImportTagValue;
+use crate::cst::tag::TypeAliasImportTagValueAs;
+use crate::cst::tag::TypeAliasTagValue;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::token::TokenKind;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_type_alias_tag_value(&mut self) -> Result<TagValue<'arena>, ParseError> {
+        let alias = self.parse_identifier()?;
+        let equals = if self.stream.is_at(TokenKind::Equals) { Some(self.stream.consume_span()?) } else { None };
+        let r#type = self.parse_type()?;
+        let r#type = self.alloc(r#type);
+
+        Ok(TagValue::TypeAlias(TypeAliasTagValue { alias, equals, r#type }))
+    }
+
+    pub(crate) fn parse_type_alias_import_tag_value(&mut self) -> Result<TagValue<'arena>, ParseError> {
+        let imported_alias = self.parse_identifier()?;
+
+        if !self.stream.is_at_value(b"from") {
+            return Err(ParseError::UnexpectedToken(self.stream.peek()?.span_for(self.file_id())));
+        }
+        let from_keyword = self.parse_keyword()?;
+
+        let imported_from = self.parse_identifier()?;
+
+        let imported_as = if self.stream.is_at_value(b"as") {
+            let keyword = self.parse_keyword()?;
+            let local = self.parse_identifier()?;
+
+            Some(TypeAliasImportTagValueAs { keyword, local })
+        } else {
+            None
+        };
+
+        Ok(TagValue::TypeAliasImport(TypeAliasImportTagValue {
+            imported_alias,
+            from_keyword,
+            imported_from,
+            imported_as,
+        }))
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/tag/value.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/tag/value.rs
@@ -1,0 +1,56 @@
+use crate::cst::tag::MixinTagValue;
+use crate::cst::tag::ReturnTagValue;
+use crate::cst::tag::SelfOutTagValue;
+use crate::cst::tag::TagValue;
+use crate::cst::tag::ThrowsTagValue;
+use crate::cst::tag::VarTagValue;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::token::TokenKind;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_return_tag_value(&mut self) -> Result<TagValue<'arena>, ParseError> {
+        let r#type = self.parse_type()?;
+        let r#type = self.alloc(r#type);
+        let description = self.parse_optional_description(true)?;
+
+        Ok(TagValue::Return(ReturnTagValue { r#type, description }))
+    }
+
+    pub(crate) fn parse_throws_tag_value(&mut self) -> Result<TagValue<'arena>, ParseError> {
+        let r#type = self.parse_type()?;
+        let r#type = self.alloc(r#type);
+        let description = self.parse_optional_description(true)?;
+
+        Ok(TagValue::Throws(ThrowsTagValue { r#type, description }))
+    }
+
+    pub(crate) fn parse_mixin_tag_value(&mut self) -> Result<TagValue<'arena>, ParseError> {
+        let r#type = self.parse_type()?;
+        let r#type = self.alloc(r#type);
+        let description = self.parse_optional_description(true)?;
+
+        Ok(TagValue::Mixin(MixinTagValue { r#type, description }))
+    }
+
+    pub(crate) fn parse_self_out_tag_value(&mut self) -> Result<TagValue<'arena>, ParseError> {
+        let r#type = self.parse_type()?;
+        let r#type = self.alloc(r#type);
+        let description = self.parse_optional_description(true)?;
+
+        Ok(TagValue::SelfOut(SelfOutTagValue { r#type, description }))
+    }
+
+    pub(crate) fn parse_var_tag_value(&mut self) -> Result<TagValue<'arena>, ParseError> {
+        let r#type = self.parse_type()?;
+        let r#type = self.alloc(r#type);
+        let variable = if self.stream.is_at(TokenKind::Variable) || self.stream.is_at(TokenKind::ThisVariable) {
+            Some(self.parse_variable()?)
+        } else {
+            None
+        };
+        let description = self.parse_optional_description(variable.is_none())?;
+
+        Ok(TagValue::Var(VarTagValue { r#type, variable, description }))
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/tag/vendor.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/tag/vendor.rs
@@ -1,0 +1,8 @@
+use crate::cst::tag::TagVendor;
+
+pub(crate) fn remainder_after_vendor(name: &[u8], vendor: Option<TagVendor>) -> &[u8] {
+    match vendor {
+        Some(vendor) => name.get(vendor.prefix().len() + 1..).unwrap_or(name),
+        None => name,
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/tag/where_clause.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/tag/where_clause.rs
@@ -1,0 +1,25 @@
+use crate::cst::tag::TagValue;
+use crate::cst::tag::WhereTagValue;
+use crate::cst::tag::WhereTagValueModifier;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::token::TokenKind;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_where_tag_value(&mut self) -> Result<TagValue<'arena>, ParseError> {
+        let name = self.parse_identifier()?;
+
+        let modifier = if self.stream.is_at_value(b"is") {
+            WhereTagValueModifier::Is(self.parse_keyword()?)
+        } else if self.stream.is_at(TokenKind::Colon) {
+            WhereTagValueModifier::Colon(self.stream.consume_span()?)
+        } else {
+            return Err(ParseError::UnexpectedToken(self.stream.peek()?.span_for(self.file_id())));
+        };
+
+        let r#type = self.parse_type()?;
+        let r#type = self.alloc(r#type);
+
+        Ok(TagValue::Where(WhereTagValue { name, modifier, r#type }))
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/text.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/text.rs
@@ -1,0 +1,79 @@
+use mago_span::Position;
+use mago_span::Span;
+
+use crate::cst::text::Text;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::parser::internal::tag::is_inherit_doc_name;
+use crate::token::TokenKind;
+
+impl<'arena> PHPDocParser<'arena> {
+    #[inline]
+    fn at_description_boundary(&mut self) -> bool {
+        match self.stream.peek_kind(0) {
+            None => true,
+            Some(TokenKind::Tag) => self.stream.starts_line(0),
+            _ => false,
+        }
+    }
+
+    pub(crate) fn parse_text(&mut self) -> Result<Option<Text<'arena>>, ParseError> {
+        if self.at_description_boundary() {
+            return Ok(None);
+        }
+
+        let file_id = self.file_id();
+        let start = self.stream.peek()?.start;
+        let mut end = start;
+        let mut inline_inherit_doc_start: Option<Position> = None;
+
+        loop {
+            match self.stream.peek_kind(0) {
+                None => break,
+                Some(TokenKind::Tag) if self.stream.starts_line(0) => break,
+                _ => {}
+            }
+
+            if self.stream.peek_kind(0) == Some(TokenKind::LeftBrace)
+                && self.stream.lookahead(1).is_some_and(|token| {
+                    token.kind == TokenKind::Tag
+                        && is_inherit_doc_name(token.value.strip_prefix(b"@").unwrap_or(token.value))
+                })
+            {
+                inline_inherit_doc_start = Some(self.stream.peek()?.start);
+            }
+
+            let token = self.stream.consume()?;
+            end = Position::new(token.start.offset + token.value.len() as u32);
+
+            if token.kind == TokenKind::RightBrace
+                && let Some(brace_start) = inline_inherit_doc_start.take()
+            {
+                self.record_inherit_doc(Span::new(file_id, brace_start, end));
+            }
+        }
+
+        let value = self.stream.raw_between(start, end);
+
+        Ok(Some(Text { span: Span::new(file_id, start, end), value }))
+    }
+
+    pub(crate) fn parse_optional_description(&mut self, limit_start: bool) -> Result<Option<Text<'arena>>, ParseError> {
+        if limit_start && (self.stream.is_at(TokenKind::Pipe) || self.stream.is_at(TokenKind::Ampersand)) {
+            return Err(ParseError::UnexpectedToken(self.stream.peek()?.span_for(self.file_id())));
+        }
+
+        self.parse_text()
+    }
+
+    pub(crate) fn parse_text_or_empty(&mut self) -> Result<Text<'arena>, ParseError> {
+        match self.parse_text()? {
+            Some(text) => Ok(text),
+            None => {
+                let position = self.stream.current_position();
+
+                Ok(Text { span: Span::new(self.file_id(), position, position), value: &[] })
+            }
+        }
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/type/alias_reference.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/type/alias_reference.rs
@@ -1,0 +1,30 @@
+use crate::cst::identifier::Identifier;
+use crate::cst::r#type::AliasName;
+use crate::cst::r#type::AliasReferenceType;
+use crate::cst::r#type::Type;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::parser::internal::r#type::keyword::lookup_keyword;
+use crate::token::TokenKind;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_alias_reference_type(&mut self) -> Result<Type<'arena>, ParseError> {
+        let file_id = self.file_id();
+        let exclamation = self.stream.consume_span()?;
+        let class = self.parse_identifier()?;
+        let double_colon = self.stream.eat_span(TokenKind::ColonColon)?;
+
+        let next = self.stream.peek()?;
+        if next.kind != TokenKind::Identifier {
+            return Err(ParseError::UnexpectedToken(next.span_for(file_id)));
+        }
+
+        let alias = if lookup_keyword(next.value).is_some() && !next.value.contains(&b'-') {
+            AliasName::Keyword(self.parse_keyword()?)
+        } else {
+            AliasName::Identifier(Identifier::from_token(self.stream.consume()?, file_id))
+        };
+
+        Ok(Type::AliasReference(AliasReferenceType { exclamation, class, double_colon, alias }))
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/type/array.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/type/array.rs
@@ -1,0 +1,111 @@
+use mago_syntax_core::ast::Sequence;
+
+use crate::cst::r#type::ArrayType;
+use crate::cst::r#type::AssociativeArrayType;
+use crate::cst::r#type::ListType;
+use crate::cst::r#type::NonEmptyArrayType;
+use crate::cst::r#type::NonEmptyListType;
+use crate::cst::r#type::ShapeAdditionalFields;
+use crate::cst::r#type::ShapeField;
+use crate::cst::r#type::ShapeFieldKey;
+use crate::cst::r#type::ShapeType;
+use crate::cst::r#type::ShapeTypeKind;
+use crate::cst::r#type::Type;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::token::TokenKind;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_array_like_type(&mut self) -> Result<Type<'arena>, ParseError> {
+        let next = self.stream.peek()?;
+        let keyword = self.parse_keyword()?;
+
+        let kind = if next.value.eq_ignore_ascii_case(b"non-empty-array") {
+            if !self.stream.is_at(TokenKind::LeftBrace) {
+                return Ok(Type::NonEmptyArray(NonEmptyArrayType {
+                    keyword,
+                    parameters: self.parse_generic_parameters_or_none()?,
+                }));
+            }
+
+            ShapeTypeKind::NonEmptyArray
+        } else if next.value.eq_ignore_ascii_case(b"associative-array") {
+            if !self.stream.is_at(TokenKind::LeftBrace) {
+                return Ok(Type::AssociativeArray(AssociativeArrayType {
+                    keyword,
+                    parameters: self.parse_generic_parameters_or_none()?,
+                }));
+            }
+
+            ShapeTypeKind::AssociativeArray
+        } else if next.value.eq_ignore_ascii_case(b"non-empty-list") {
+            if !self.stream.is_at(TokenKind::LeftBrace) {
+                return Ok(Type::NonEmptyList(NonEmptyListType {
+                    keyword,
+                    parameters: self.parse_generic_parameters_or_none()?,
+                }));
+            }
+
+            ShapeTypeKind::NonEmptyList
+        } else if next.value.eq_ignore_ascii_case(b"list") {
+            if !self.stream.is_at(TokenKind::LeftBrace) {
+                return Ok(Type::List(ListType { keyword, parameters: self.parse_generic_parameters_or_none()? }));
+            }
+
+            ShapeTypeKind::List
+        } else {
+            if !self.stream.is_at(TokenKind::LeftBrace) {
+                return Ok(Type::Array(ArrayType { keyword, parameters: self.parse_generic_parameters_or_none()? }));
+            }
+
+            ShapeTypeKind::Array
+        };
+
+        let left_brace = self.stream.eat_span(TokenKind::LeftBrace)?;
+
+        let mut fields = self.new_vec::<ShapeField<'arena>>();
+        while !self.stream.is_at(TokenKind::RightBrace) && !self.stream.is_at(TokenKind::Ellipsis) {
+            let key = if self.scan_for_shape_field_key()? {
+                let shape_key = self.parse_shape_field_key()?;
+                let question_mark =
+                    if self.stream.is_at(TokenKind::Question) { Some(self.stream.consume_span()?) } else { None };
+                let colon = self.stream.eat_span(TokenKind::Colon)?;
+
+                Some(ShapeFieldKey { key: shape_key, question_mark, colon })
+            } else {
+                None
+            };
+
+            let value = self.parse_type()?;
+            let value = self.alloc(value);
+            let comma = if self.stream.is_at(TokenKind::Comma) { Some(self.stream.consume_span()?) } else { None };
+            let has_comma = comma.is_some();
+            fields.push(ShapeField { key, value, comma });
+
+            if !has_comma {
+                break;
+            }
+        }
+
+        let additional_fields = if self.stream.is_at(TokenKind::Ellipsis) {
+            let ellipsis = self.stream.consume_span()?;
+            let parameters = self.parse_generic_parameters_or_none()?;
+            let comma = if self.stream.is_at(TokenKind::Comma) { Some(self.stream.consume_span()?) } else { None };
+
+            Some(ShapeAdditionalFields { ellipsis, parameters, comma })
+        } else {
+            None
+        };
+
+        let right_brace = self.stream.eat_span(TokenKind::RightBrace)?;
+
+        Ok(Type::Shape(ShapeType {
+            kind,
+            keyword,
+            left_brace,
+            fields: Sequence::new(fields),
+            additional_fields,
+            right_brace,
+        }))
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/type/callable.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/type/callable.rs
@@ -1,0 +1,76 @@
+use mago_syntax_core::ast::Sequence;
+
+use crate::cst::r#type::CallableType;
+use crate::cst::r#type::CallableTypeKind;
+use crate::cst::r#type::CallableTypeParameter;
+use crate::cst::r#type::CallableTypeParameters;
+use crate::cst::r#type::CallableTypeReturnType;
+use crate::cst::r#type::CallableTypeSpecification;
+use crate::cst::r#type::Type;
+use crate::cst::variable::Variable;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::parser::internal::r#type::TypePrecedence;
+use crate::token::TokenKind;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_callable_type(&mut self, kind: CallableTypeKind) -> Result<Type<'arena>, ParseError> {
+        let keyword = self.parse_keyword()?;
+        let specification = self.parse_optional_callable_type_specifications()?;
+
+        Ok(Type::Callable(CallableType { kind, keyword, specification }))
+    }
+
+    pub(crate) fn parse_callable_type_specifications(
+        &mut self,
+    ) -> Result<CallableTypeSpecification<'arena>, ParseError> {
+        let left_parenthesis = self.stream.eat_span(TokenKind::LeftParenthesis)?;
+
+        let mut entries = self.new_vec::<CallableTypeParameter<'arena>>();
+        while !self.stream.is_at(TokenKind::RightParenthesis) {
+            let parameter_type = if self.stream.is_at(TokenKind::Ellipsis) { None } else { Some(self.parse_type()?) };
+            let ampersand =
+                if self.stream.is_at(TokenKind::Ampersand) { Some(self.stream.consume_span()?) } else { None };
+            let equals = if self.stream.is_at(TokenKind::Equals) { Some(self.stream.consume_span()?) } else { None };
+            let ellipsis =
+                if self.stream.is_at(TokenKind::Ellipsis) { Some(self.stream.consume_span()?) } else { None };
+            let variable = if self.stream.is_at(TokenKind::Variable) {
+                Some(Variable::from_token(self.stream.consume()?, self.file_id()))
+            } else {
+                None
+            };
+            let comma = if self.stream.is_at(TokenKind::Comma) { Some(self.stream.consume_span()?) } else { None };
+            let has_comma = comma.is_some();
+            entries.push(CallableTypeParameter { parameter_type, ampersand, equals, ellipsis, variable, comma });
+
+            if !has_comma {
+                break;
+            }
+        }
+
+        let right_parenthesis = self.stream.eat_span(TokenKind::RightParenthesis)?;
+        let parameters =
+            CallableTypeParameters { left_parenthesis, entries: Sequence::new(entries), right_parenthesis };
+
+        let return_type = if self.stream.is_at(TokenKind::Colon) {
+            let colon = self.stream.consume_span()?;
+            let return_type = self.parse_type_with_precedence(TypePrecedence::Callable)?;
+
+            Some(CallableTypeReturnType { colon, return_type: self.alloc(return_type) })
+        } else {
+            None
+        };
+
+        Ok(CallableTypeSpecification { parameters, return_type })
+    }
+
+    pub(crate) fn parse_optional_callable_type_specifications(
+        &mut self,
+    ) -> Result<Option<CallableTypeSpecification<'arena>>, ParseError> {
+        if self.stream.is_at(TokenKind::LeftParenthesis) {
+            Ok(Some(self.parse_callable_type_specifications()?))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/type/class_like_string.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/type/class_like_string.rs
@@ -1,0 +1,36 @@
+use crate::cst::r#type::ClassStringType;
+use crate::cst::r#type::EnumStringType;
+use crate::cst::r#type::InterfaceStringType;
+use crate::cst::r#type::TraitStringType;
+use crate::cst::r#type::Type;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_class_string_type(&mut self) -> Result<Type<'arena>, ParseError> {
+        let keyword = self.parse_keyword()?;
+
+        Ok(Type::ClassString(ClassStringType { keyword, parameter: self.parse_single_generic_parameter_or_none()? }))
+    }
+
+    pub(crate) fn parse_interface_string_type(&mut self) -> Result<Type<'arena>, ParseError> {
+        let keyword = self.parse_keyword()?;
+
+        Ok(Type::InterfaceString(InterfaceStringType {
+            keyword,
+            parameter: self.parse_single_generic_parameter_or_none()?,
+        }))
+    }
+
+    pub(crate) fn parse_enum_string_type(&mut self) -> Result<Type<'arena>, ParseError> {
+        let keyword = self.parse_keyword()?;
+
+        Ok(Type::EnumString(EnumStringType { keyword, parameter: self.parse_single_generic_parameter_or_none()? }))
+    }
+
+    pub(crate) fn parse_trait_string_type(&mut self) -> Result<Type<'arena>, ParseError> {
+        let keyword = self.parse_keyword()?;
+
+        Ok(Type::TraitString(TraitStringType { keyword, parameter: self.parse_single_generic_parameter_or_none()? }))
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/type/composite.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/type/composite.rs
@@ -1,0 +1,123 @@
+use crate::cst::r#type::IntersectionType;
+use crate::cst::r#type::NullableType;
+use crate::cst::r#type::ParenthesizedType;
+use crate::cst::r#type::TrailingPipeType;
+use crate::cst::r#type::Type;
+use crate::cst::r#type::UnionType;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::parser::internal::r#type::TypePrecedence;
+use crate::parser::internal::r#type::is_keyword;
+use crate::parser::internal::r#type::keyword::TypeKeyword;
+use crate::token::TokenKind;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_type_with_precedence(
+        &mut self,
+        min_precedence: TypePrecedence,
+    ) -> Result<Type<'arena>, ParseError> {
+        let mut inner = self.parse_primary_type()?;
+
+        loop {
+            let is_inner_nullable = matches!(inner, Type::Nullable(_));
+
+            let Some(token) = self.stream.lookahead(0) else {
+                return Ok(inner);
+            };
+
+            inner = match token.kind {
+                TokenKind::Pipe if !is_inner_nullable && min_precedence <= TypePrecedence::Union => {
+                    let pipe = self.stream.consume_span()?;
+
+                    if self.is_at_union_closing_token() {
+                        return Ok(Type::TrailingPipe(TrailingPipeType { inner: self.alloc(inner), pipe }));
+                    }
+
+                    let right = self.parse_type_with_precedence(TypePrecedence::Union)?;
+                    if let Type::TrailingPipe(trailing) = right {
+                        let union =
+                            self.alloc(Type::Union(UnionType { left: self.alloc(inner), pipe, right: trailing.inner }));
+
+                        return Ok(Type::TrailingPipe(TrailingPipeType { inner: union, pipe: trailing.pipe }));
+                    }
+
+                    let left = self.alloc(inner);
+                    let right = self.alloc(right);
+
+                    Type::Union(UnionType { left, pipe, right })
+                }
+                TokenKind::Ampersand
+                    if !is_inner_nullable
+                        && min_precedence <= TypePrecedence::Intersection
+                        && !self
+                            .stream
+                            .lookahead(1)
+                            .is_some_and(|t| matches!(t.kind, TokenKind::Variable | TokenKind::Ellipsis)) =>
+                {
+                    let left = self.alloc(inner);
+                    let ampersand = self.stream.consume_span()?;
+                    let right = self.parse_type_with_precedence(TypePrecedence::Intersection)?;
+                    let right = self.alloc(right);
+
+                    Type::Intersection(IntersectionType { left, ampersand, right })
+                }
+                TokenKind::Identifier
+                    if !is_inner_nullable
+                        && min_precedence <= TypePrecedence::Conditional
+                        && is_keyword(&token, TypeKeyword::Is) =>
+                {
+                    let subject = self.alloc(inner);
+
+                    self.parse_conditional_type(subject)?
+                }
+                TokenKind::LeftBracket if min_precedence <= TypePrecedence::Postfix => {
+                    let left_bracket = self.stream.consume_span()?;
+
+                    if self.stream.is_at(TokenKind::RightBracket) {
+                        let inner_ref = self.alloc(inner);
+
+                        self.parse_slice_type(inner_ref, left_bracket)?
+                    } else {
+                        let target = self.alloc(inner);
+
+                        self.parse_index_access_type(target, left_bracket)?
+                    }
+                }
+                _ => return Ok(inner),
+            };
+        }
+    }
+
+    #[inline]
+    fn is_at_union_closing_token(&mut self) -> bool {
+        match self.stream.peek_kind(0) {
+            None => true,
+            Some(kind) => matches!(
+                kind,
+                TokenKind::Comma
+                    | TokenKind::RightParenthesis
+                    | TokenKind::RightAngleBracket
+                    | TokenKind::RightBrace
+                    | TokenKind::RightBracket
+                    | TokenKind::Colon
+                    | TokenKind::Equals
+            ),
+        }
+    }
+
+    pub(crate) fn parse_nullable_type(&mut self) -> Result<Type<'arena>, ParseError> {
+        let question_mark = self.stream.consume_span()?;
+        let inner = self.parse_type()?;
+
+        Ok(Type::Nullable(NullableType { question_mark, inner: self.alloc(inner) }))
+    }
+
+    pub(crate) fn parse_parenthesized_type(&mut self) -> Result<Type<'arena>, ParseError> {
+        let left_parenthesis = self.stream.consume_span()?;
+        let inner = self.parse_type()?;
+        let inner = self.alloc(inner);
+        let right_parenthesis = self.stream.eat_span(TokenKind::RightParenthesis)?;
+
+        Ok(Type::Parenthesized(ParenthesizedType { left_parenthesis, inner, right_parenthesis }))
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/type/conditional.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/type/conditional.rs
@@ -1,0 +1,29 @@
+use crate::cst::r#type::ConditionalType;
+use crate::cst::r#type::Type;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::parser::internal::r#type::TypePrecedence;
+use crate::parser::internal::r#type::is_keyword;
+use crate::parser::internal::r#type::keyword::TypeKeyword;
+use crate::token::TokenKind;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_conditional_type(&mut self, subject: &'arena Type<'arena>) -> Result<Type<'arena>, ParseError> {
+        let is = self.parse_keyword()?;
+        let not = if self.stream.lookahead(0).is_some_and(|t| is_keyword(&t, TypeKeyword::Not)) {
+            Some(self.parse_keyword()?)
+        } else {
+            None
+        };
+        let target = self.parse_type_with_precedence(TypePrecedence::Conditional)?;
+        let target = self.alloc(target);
+        let question_mark = self.stream.eat_span(TokenKind::Question)?;
+        let then = self.parse_type_with_precedence(TypePrecedence::Conditional)?;
+        let then = self.alloc(then);
+        let colon = self.stream.eat_span(TokenKind::Colon)?;
+        let otherwise = self.parse_type_with_precedence(TypePrecedence::Conditional)?;
+        let otherwise = self.alloc(otherwise);
+
+        Ok(Type::Conditional(ConditionalType { subject, is, not, target, question_mark, then, colon, otherwise }))
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/type/generics.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/type/generics.rs
@@ -1,0 +1,58 @@
+use mago_syntax_core::ast::Sequence;
+
+use crate::cst::r#type::GenericParameterEntry;
+use crate::cst::r#type::GenericParameters;
+use crate::cst::r#type::SingleGenericParameter;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::token::TokenKind;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_single_generic_parameter(&mut self) -> Result<SingleGenericParameter<'arena>, ParseError> {
+        let less_than = self.stream.eat_span(TokenKind::LeftAngleBracket)?;
+        let inner = self.parse_type()?;
+        let comma = if self.stream.is_at(TokenKind::Comma) { Some(self.stream.consume_span()?) } else { None };
+        let entry = self.alloc(GenericParameterEntry { inner, comma });
+        let greater_than = self.stream.eat_span(TokenKind::RightAngleBracket)?;
+
+        Ok(SingleGenericParameter { less_than, entry, greater_than })
+    }
+
+    pub(crate) fn parse_generic_parameters(&mut self) -> Result<GenericParameters<'arena>, ParseError> {
+        let less_than = self.stream.eat_span(TokenKind::LeftAngleBracket)?;
+        let mut entries = self.new_vec::<GenericParameterEntry<'arena>>();
+
+        loop {
+            let inner = self.parse_type()?;
+            let comma = if self.stream.is_at(TokenKind::Comma) { Some(self.stream.consume_span()?) } else { None };
+            let has_comma = comma.is_some();
+            entries.push(GenericParameterEntry { inner, comma });
+
+            if !has_comma || self.stream.is_at(TokenKind::RightAngleBracket) {
+                break;
+            }
+        }
+
+        let greater_than = self.stream.eat_span(TokenKind::RightAngleBracket)?;
+
+        Ok(GenericParameters { less_than, entries: Sequence::new(entries), greater_than })
+    }
+
+    pub(crate) fn parse_single_generic_parameter_or_none(
+        &mut self,
+    ) -> Result<Option<SingleGenericParameter<'arena>>, ParseError> {
+        if self.stream.is_at(TokenKind::LeftAngleBracket) {
+            Ok(Some(self.parse_single_generic_parameter()?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub(crate) fn parse_generic_parameters_or_none(&mut self) -> Result<Option<GenericParameters<'arena>>, ParseError> {
+        if self.stream.is_at(TokenKind::LeftAngleBracket) {
+            Ok(Some(self.parse_generic_parameters()?))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/type/index_access.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/type/index_access.rs
@@ -1,0 +1,21 @@
+use mago_span::Span;
+
+use crate::cst::r#type::IndexAccessType;
+use crate::cst::r#type::Type;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::token::TokenKind;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_index_access_type(
+        &mut self,
+        target: &'arena Type<'arena>,
+        left_bracket: Span,
+    ) -> Result<Type<'arena>, ParseError> {
+        let index = self.parse_type()?;
+        let index = self.alloc(index);
+        let right_bracket = self.stream.eat_span(TokenKind::RightBracket)?;
+
+        Ok(Type::IndexAccess(IndexAccessType { target, left_bracket, index, right_bracket }))
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/type/int_mask.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/type/int_mask.rs
@@ -1,0 +1,19 @@
+use crate::cst::r#type::IntMaskOfType;
+use crate::cst::r#type::IntMaskType;
+use crate::cst::r#type::Type;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_int_mask_type(&mut self) -> Result<Type<'arena>, ParseError> {
+        let keyword = self.parse_keyword()?;
+
+        Ok(Type::IntMask(IntMaskType { keyword, parameters: self.parse_generic_parameters()? }))
+    }
+
+    pub(crate) fn parse_int_mask_of_type(&mut self) -> Result<Type<'arena>, ParseError> {
+        let keyword = self.parse_keyword()?;
+
+        Ok(Type::IntMaskOf(IntMaskOfType { keyword, parameter: self.parse_single_generic_parameter()? }))
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/type/int_range.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/type/int_range.rs
@@ -1,0 +1,46 @@
+use mago_syntax_core::utils::parse_literal_integer;
+
+use crate::cst::keyword::Keyword;
+use crate::cst::r#type::IntOrKeyword;
+use crate::cst::r#type::IntRangeType;
+use crate::cst::r#type::LiteralIntType;
+use crate::cst::r#type::Type;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::token::TokenKind;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_int_range_type(&mut self, keyword: Keyword<'arena>) -> Result<Type<'arena>, ParseError> {
+        let less_than = self.stream.eat_span(TokenKind::LeftAngleBracket)?;
+        let min = self.parse_int_or_keyword()?;
+        let comma = self.stream.eat_span(TokenKind::Comma)?;
+        let max = self.parse_int_or_keyword()?;
+        let greater_than = self.stream.eat_span(TokenKind::RightAngleBracket)?;
+
+        Ok(Type::IntRange(IntRangeType { keyword, less_than, min, comma, max, greater_than }))
+    }
+
+    fn parse_int_or_keyword(&mut self) -> Result<IntOrKeyword<'arena>, ParseError> {
+        let file_id = self.file_id();
+
+        if self.stream.is_at(TokenKind::Minus) {
+            let minus = self.stream.consume_span()?;
+            let token = self.stream.eat(TokenKind::LiteralInteger)?;
+            let value = parse_literal_integer(token.value).unwrap_or(0);
+
+            Ok(IntOrKeyword::NegativeInt {
+                minus,
+                int: LiteralIntType { span: token.span_for(file_id), value, raw: token.value },
+            })
+        } else if self.stream.is_at(TokenKind::LiteralInteger) {
+            let token = self.stream.consume()?;
+            let value = parse_literal_integer(token.value).unwrap_or(0);
+
+            Ok(IntOrKeyword::Int(LiteralIntType { span: token.span_for(file_id), value, raw: token.value }))
+        } else if self.stream.is_at(TokenKind::Identifier) {
+            Ok(IntOrKeyword::Keyword(self.parse_keyword()?))
+        } else {
+            Err(ParseError::UnexpectedToken(self.stream.peek()?.span_for(file_id)))
+        }
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/type/iterable.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/type/iterable.rs
@@ -1,0 +1,12 @@
+use crate::cst::r#type::IterableType;
+use crate::cst::r#type::Type;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_iterable_type(&mut self) -> Result<Type<'arena>, ParseError> {
+        let keyword = self.parse_keyword()?;
+
+        Ok(Type::Iterable(IterableType { keyword, parameters: self.parse_generic_parameters_or_none()? }))
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/type/key_of.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/type/key_of.rs
@@ -1,0 +1,12 @@
+use crate::cst::r#type::KeyOfType;
+use crate::cst::r#type::Type;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_key_of_type(&mut self) -> Result<Type<'arena>, ParseError> {
+        let keyword = self.parse_keyword()?;
+
+        Ok(Type::KeyOf(KeyOfType { keyword, parameter: self.parse_single_generic_parameter()? }))
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/type/keyword.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/type/keyword.rs
@@ -1,0 +1,430 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TypeKeyword {
+    As,
+    Is,
+    Int,
+    Min,
+    Max,
+    Not,
+    New,
+    Bool,
+    List,
+    Null,
+    Real,
+    True,
+    Void,
+    Array,
+    False,
+    Float,
+    Mixed,
+    Never,
+    Double,
+    KeyOf,
+    Object,
+    Scalar,
+    String,
+    Boolean,
+    Integer,
+    Nothing,
+    Numeric,
+    Callable,
+    IntMask,
+    Iterable,
+    Resource,
+    ValueOf,
+    ArrayKey,
+    NoReturn,
+    EnumString,
+    IntMaskOf,
+    UnspecifiedLiteralInt,
+    ClassString,
+    NeverReturn,
+    NegativeInt,
+    NonZeroInt,
+    PositiveInt,
+    PureClosure,
+    TraitString,
+    UnspecifiedLiteralFloat,
+    NeverReturns,
+    OpenResource,
+    PropertiesOf,
+    PureCallable,
+    TruthyString,
+    TemplateType,
+    UnspecifiedLiteralString,
+    NonEmptyList,
+    NumericString,
+    ClosedResource,
+    CallableString,
+    NonEmptyArray,
+    NonEmptyMixed,
+    InterfaceString,
+    LowercaseString,
+    UppercaseString,
+    NonEmptyString,
+    NonFalsyString,
+    NonPositiveInt,
+    NonNegativeInt,
+    AssociativeArray,
+    StringableObject,
+    PublicPropertiesOf,
+    PrivatePropertiesOf,
+    ProtectedPropertiesOf,
+    NonEmptyUnspecifiedLiteralString,
+    LowercaseCallableString,
+    UppercaseCallableString,
+    NonEmptyLowercaseString,
+    NonEmptyUppercaseString,
+}
+
+#[inline]
+#[must_use]
+pub fn lookup_keyword(bytes: &[u8]) -> Option<TypeKeyword> {
+    match bytes.len() {
+        2 => lookup_len2(bytes),
+        3 => lookup_len3(bytes),
+        4 => lookup_len4(bytes),
+        5 => lookup_len5(bytes),
+        6 => lookup_len6(bytes),
+        7 => lookup_len7(bytes),
+        8 => lookup_len8(bytes),
+        9 => lookup_len9(bytes),
+        11 => lookup_len11(bytes),
+        12 => lookup_len12(bytes),
+        13 => lookup_len13(bytes),
+        14 => lookup_len14(bytes),
+        15 => lookup_len15(bytes),
+        16 => lookup_len16(bytes),
+        17 => lookup_len17(bytes),
+        20 => lookup_len20(bytes),
+        21 => lookup_len21(bytes),
+        23 => lookup_len23(bytes),
+        24 => lookup_len24(bytes),
+        25 => lookup_len25(bytes),
+        26 => lookup_len26(bytes),
+        _ => None,
+    }
+}
+
+#[inline]
+fn eq(a: &[u8], b: &[u8]) -> bool {
+    a.eq_ignore_ascii_case(b)
+}
+
+#[inline]
+fn eq_exact(a: &[u8], b: &[u8]) -> bool {
+    a == b
+}
+
+#[inline]
+fn lookup_len2(bytes: &[u8]) -> Option<TypeKeyword> {
+    match bytes[0] | 0x20 {
+        b'a' if eq(bytes, b"as") => Some(TypeKeyword::As),
+        b'i' if eq(bytes, b"is") => Some(TypeKeyword::Is),
+        _ => None,
+    }
+}
+
+#[inline]
+fn lookup_len3(bytes: &[u8]) -> Option<TypeKeyword> {
+    match bytes[0] | 0x20 {
+        b'i' if eq(bytes, b"int") => Some(TypeKeyword::Int),
+        b'm' => {
+            if eq_exact(bytes, b"min") {
+                Some(TypeKeyword::Min)
+            } else if eq_exact(bytes, b"max") {
+                Some(TypeKeyword::Max)
+            } else {
+                None
+            }
+        }
+        b'n' => {
+            if eq(bytes, b"not") {
+                Some(TypeKeyword::Not)
+            } else if eq(bytes, b"new") {
+                Some(TypeKeyword::New)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+#[inline]
+fn lookup_len4(bytes: &[u8]) -> Option<TypeKeyword> {
+    match bytes[0] | 0x20 {
+        b'b' if eq(bytes, b"bool") => Some(TypeKeyword::Bool),
+        b'l' if eq(bytes, b"list") => Some(TypeKeyword::List),
+        b'n' if eq(bytes, b"null") => Some(TypeKeyword::Null),
+        b'r' if eq_exact(bytes, b"real") => Some(TypeKeyword::Real),
+        b't' if eq(bytes, b"true") => Some(TypeKeyword::True),
+        b'v' if eq(bytes, b"void") => Some(TypeKeyword::Void),
+        _ => None,
+    }
+}
+
+#[inline]
+fn lookup_len5(bytes: &[u8]) -> Option<TypeKeyword> {
+    match bytes[0] | 0x20 {
+        b'a' if eq(bytes, b"array") => Some(TypeKeyword::Array),
+        b'f' => {
+            if eq(bytes, b"false") {
+                Some(TypeKeyword::False)
+            } else if eq(bytes, b"float") {
+                Some(TypeKeyword::Float)
+            } else {
+                None
+            }
+        }
+        b'm' if eq(bytes, b"mixed") => Some(TypeKeyword::Mixed),
+        b'n' if eq(bytes, b"never") => Some(TypeKeyword::Never),
+        _ => None,
+    }
+}
+
+#[inline]
+fn lookup_len6(bytes: &[u8]) -> Option<TypeKeyword> {
+    match bytes[0] | 0x20 {
+        b'd' if eq_exact(bytes, b"double") => Some(TypeKeyword::Double),
+        b'k' if eq(bytes, b"key-of") => Some(TypeKeyword::KeyOf),
+        b'o' if eq(bytes, b"object") => Some(TypeKeyword::Object),
+        b's' => {
+            if eq_exact(bytes, b"scalar") {
+                Some(TypeKeyword::Scalar)
+            } else if eq(bytes, b"string") {
+                Some(TypeKeyword::String)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+#[inline]
+fn lookup_len7(bytes: &[u8]) -> Option<TypeKeyword> {
+    match bytes[0] | 0x20 {
+        b'b' if eq_exact(bytes, b"boolean") => Some(TypeKeyword::Boolean),
+        b'i' if eq_exact(bytes, b"integer") => Some(TypeKeyword::Integer),
+        b'n' => {
+            if eq_exact(bytes, b"nothing") {
+                Some(TypeKeyword::Nothing)
+            } else if eq_exact(bytes, b"numeric") {
+                Some(TypeKeyword::Numeric)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+#[inline]
+fn lookup_len8(bytes: &[u8]) -> Option<TypeKeyword> {
+    match bytes[0] | 0x20 {
+        b'c' if eq(bytes, b"callable") => Some(TypeKeyword::Callable),
+        b'i' => {
+            if eq(bytes, b"int-mask") {
+                Some(TypeKeyword::IntMask)
+            } else if eq(bytes, b"iterable") {
+                Some(TypeKeyword::Iterable)
+            } else {
+                None
+            }
+        }
+        b'r' if eq_exact(bytes, b"resource") => Some(TypeKeyword::Resource),
+        b'v' if eq(bytes, b"value-of") => Some(TypeKeyword::ValueOf),
+        _ => None,
+    }
+}
+
+#[inline]
+fn lookup_len9(bytes: &[u8]) -> Option<TypeKeyword> {
+    match bytes[0] | 0x20 {
+        b'a' if eq(bytes, b"array-key") => Some(TypeKeyword::ArrayKey),
+        b'n' if eq(bytes, b"no-return") => Some(TypeKeyword::NoReturn),
+        _ => None,
+    }
+}
+
+#[inline]
+fn lookup_len11(bytes: &[u8]) -> Option<TypeKeyword> {
+    match bytes[0] | 0x20 {
+        b'e' if eq(bytes, b"enum-string") => Some(TypeKeyword::EnumString),
+        b'i' if eq(bytes, b"int-mask-of") => Some(TypeKeyword::IntMaskOf),
+        b'l' if eq(bytes, b"literal-int") => Some(TypeKeyword::UnspecifiedLiteralInt),
+        _ => None,
+    }
+}
+
+#[inline]
+fn lookup_len12(bytes: &[u8]) -> Option<TypeKeyword> {
+    match bytes[0] | 0x20 {
+        b'c' if eq(bytes, b"class-string") => Some(TypeKeyword::ClassString),
+        b'n' => {
+            if eq(bytes, b"never-return") {
+                Some(TypeKeyword::NeverReturn)
+            } else if eq(bytes, b"negative-int") {
+                Some(TypeKeyword::NegativeInt)
+            } else if eq(bytes, b"non-zero-int") {
+                Some(TypeKeyword::NonZeroInt)
+            } else {
+                None
+            }
+        }
+        b'p' => {
+            if eq(bytes, b"positive-int") {
+                Some(TypeKeyword::PositiveInt)
+            } else if eq(bytes, b"pure-closure") {
+                Some(TypeKeyword::PureClosure)
+            } else {
+                None
+            }
+        }
+        b't' if eq(bytes, b"trait-string") => Some(TypeKeyword::TraitString),
+        _ => None,
+    }
+}
+
+#[inline]
+fn lookup_len13(bytes: &[u8]) -> Option<TypeKeyword> {
+    match bytes[0] | 0x20 {
+        b'l' if eq(bytes, b"literal-float") => Some(TypeKeyword::UnspecifiedLiteralFloat),
+        b'n' if eq(bytes, b"never-returns") => Some(TypeKeyword::NeverReturns),
+        b'o' if eq(bytes, b"open-resource") => Some(TypeKeyword::OpenResource),
+        b'p' => {
+            if eq(bytes, b"properties-of") {
+                Some(TypeKeyword::PropertiesOf)
+            } else if eq(bytes, b"pure-callable") {
+                Some(TypeKeyword::PureCallable)
+            } else {
+                None
+            }
+        }
+        b't' => {
+            if eq(bytes, b"truthy-string") {
+                Some(TypeKeyword::TruthyString)
+            } else if eq(bytes, b"template-type") {
+                Some(TypeKeyword::TemplateType)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+#[inline]
+fn lookup_len14(bytes: &[u8]) -> Option<TypeKeyword> {
+    match bytes[0] | 0x20 {
+        b'l' if eq(bytes, b"literal-string") => Some(TypeKeyword::UnspecifiedLiteralString),
+        b'n' => {
+            if eq(bytes, b"non-empty-list") {
+                Some(TypeKeyword::NonEmptyList)
+            } else if eq(bytes, b"numeric-string") {
+                Some(TypeKeyword::NumericString)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+#[inline]
+fn lookup_len15(bytes: &[u8]) -> Option<TypeKeyword> {
+    match bytes[0] | 0x20 {
+        b'c' => {
+            if eq(bytes, b"closed-resource") {
+                Some(TypeKeyword::ClosedResource)
+            } else if eq(bytes, b"callable-string") {
+                Some(TypeKeyword::CallableString)
+            } else {
+                None
+            }
+        }
+        b'n' => {
+            if eq(bytes, b"non-empty-array") {
+                Some(TypeKeyword::NonEmptyArray)
+            } else if eq(bytes, b"non-empty-mixed") {
+                Some(TypeKeyword::NonEmptyMixed)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+#[inline]
+fn lookup_len16(bytes: &[u8]) -> Option<TypeKeyword> {
+    match bytes[0] | 0x20 {
+        b'i' if eq(bytes, b"interface-string") => Some(TypeKeyword::InterfaceString),
+        b'l' if eq(bytes, b"lowercase-string") => Some(TypeKeyword::LowercaseString),
+        b'u' if eq(bytes, b"uppercase-string") => Some(TypeKeyword::UppercaseString),
+        b'n' => {
+            if eq(bytes, b"non-empty-string") {
+                Some(TypeKeyword::NonEmptyString)
+            } else if eq(bytes, b"non-falsy-string") {
+                Some(TypeKeyword::NonFalsyString)
+            } else if eq(bytes, b"non-positive-int") {
+                Some(TypeKeyword::NonPositiveInt)
+            } else if eq(bytes, b"non-negative-int") {
+                Some(TypeKeyword::NonNegativeInt)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+#[inline]
+fn lookup_len17(bytes: &[u8]) -> Option<TypeKeyword> {
+    match bytes[0] | 0x20 {
+        b'a' if eq(bytes, b"associative-array") => Some(TypeKeyword::AssociativeArray),
+        b's' if eq(bytes, b"stringable-object") => Some(TypeKeyword::StringableObject),
+        _ => None,
+    }
+}
+
+#[inline]
+fn lookup_len20(bytes: &[u8]) -> Option<TypeKeyword> {
+    if eq(bytes, b"public-properties-of") { Some(TypeKeyword::PublicPropertiesOf) } else { None }
+}
+
+#[inline]
+fn lookup_len21(bytes: &[u8]) -> Option<TypeKeyword> {
+    if eq(bytes, b"private-properties-of") { Some(TypeKeyword::PrivatePropertiesOf) } else { None }
+}
+
+#[inline]
+fn lookup_len23(bytes: &[u8]) -> Option<TypeKeyword> {
+    if eq(bytes, b"protected-properties-of") { Some(TypeKeyword::ProtectedPropertiesOf) } else { None }
+}
+
+#[inline]
+fn lookup_len24(bytes: &[u8]) -> Option<TypeKeyword> {
+    if eq(bytes, b"non-empty-literal-string") { Some(TypeKeyword::NonEmptyUnspecifiedLiteralString) } else { None }
+}
+
+#[inline]
+fn lookup_len25(bytes: &[u8]) -> Option<TypeKeyword> {
+    match bytes[0] | 0x20 {
+        b'l' if eq(bytes, b"lowercase-callable-string") => Some(TypeKeyword::LowercaseCallableString),
+        b'u' if eq(bytes, b"uppercase-callable-string") => Some(TypeKeyword::UppercaseCallableString),
+        _ => None,
+    }
+}
+
+#[inline]
+fn lookup_len26(bytes: &[u8]) -> Option<TypeKeyword> {
+    if eq(bytes, b"non-empty-lowercase-string") {
+        Some(TypeKeyword::NonEmptyLowercaseString)
+    } else if eq(bytes, b"non-empty-uppercase-string") {
+        Some(TypeKeyword::NonEmptyUppercaseString)
+    } else {
+        None
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/type/literal.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/type/literal.rs
@@ -1,0 +1,43 @@
+use ordered_float::OrderedFloat;
+
+use mago_syntax_core::utils::parse_literal_float;
+use mago_syntax_core::utils::parse_literal_integer;
+
+use crate::cst::r#type::LiteralFloatType;
+use crate::cst::r#type::LiteralIntType;
+use crate::cst::r#type::LiteralStringType;
+use crate::cst::r#type::Type;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::token::TokenKind;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_literal_type(&mut self) -> Result<Type<'arena>, ParseError> {
+        let file_id = self.file_id();
+        let token = self.stream.consume()?;
+
+        let ty = match token.kind {
+            TokenKind::LiteralInteger => {
+                let value = parse_literal_integer(token.value).unwrap_or(0);
+
+                Type::LiteralInt(LiteralIntType { span: token.span_for(file_id), value, raw: token.value })
+            }
+            TokenKind::LiteralFloat => {
+                let value = parse_literal_float(token.value).unwrap_or(0.0);
+
+                Type::LiteralFloat(LiteralFloatType {
+                    span: token.span_for(file_id),
+                    value: OrderedFloat(value),
+                    raw: token.value,
+                })
+            }
+            _ => {
+                let value = token.value.get(1..token.value.len().saturating_sub(1)).unwrap_or(&[]);
+
+                Type::LiteralString(LiteralStringType { span: token.span_for(file_id), value, raw: token.value })
+            }
+        };
+
+        Ok(ty)
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/type/mod.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/type/mod.rs
@@ -1,0 +1,355 @@
+use crate::cst::r#type::Type;
+use crate::cst::variable::Variable;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::parser::internal::r#type::keyword::TypeKeyword;
+use crate::parser::internal::r#type::keyword::lookup_keyword;
+use crate::token::Token;
+use crate::token::TokenKind;
+
+pub(crate) mod alias_reference;
+pub(crate) mod array;
+pub(crate) mod callable;
+pub(crate) mod class_like_string;
+pub(crate) mod composite;
+pub(crate) mod conditional;
+pub(crate) mod generics;
+pub(crate) mod index_access;
+pub(crate) mod int_mask;
+pub(crate) mod int_range;
+pub(crate) mod iterable;
+pub(crate) mod key_of;
+pub(crate) mod keyword;
+pub(crate) mod literal;
+pub(crate) mod new;
+pub(crate) mod object;
+pub(crate) mod properties_of;
+pub(crate) mod reference;
+pub(crate) mod shape;
+pub(crate) mod slice;
+pub(crate) mod template_type;
+pub(crate) mod unary;
+pub(crate) mod value_of;
+pub(crate) mod wildcard;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum TypePrecedence {
+    Lowest,
+    Conditional,
+    Union,
+    Intersection,
+    Postfix,
+    Callable,
+}
+
+#[inline]
+pub(super) fn is_keyword(token: &Token<'_>, keyword: TypeKeyword) -> bool {
+    token.kind == TokenKind::Identifier && lookup_keyword(token.value) == Some(keyword)
+}
+
+impl<'arena> PHPDocParser<'arena> {
+    #[inline]
+    pub(crate) fn parse_type(&mut self) -> Result<Type<'arena>, ParseError> {
+        self.parse_type_with_precedence(TypePrecedence::Lowest)
+    }
+
+    #[inline]
+    pub(crate) fn is_at_member_identifier_at(&mut self, offset: usize) -> bool {
+        self.stream.lookahead(offset).is_some_and(|token| token.kind == TokenKind::Identifier)
+    }
+
+    #[inline]
+    pub(crate) fn is_at_member_identifier(&mut self) -> bool {
+        self.is_at_member_identifier_at(0)
+    }
+
+    #[inline]
+    pub(crate) fn eat_member_identifier(&mut self) -> Result<Token<'arena>, ParseError> {
+        self.stream.eat(TokenKind::Identifier)
+    }
+
+    pub(crate) fn parse_primary_type(&mut self) -> Result<Type<'arena>, ParseError> {
+        let next = self.stream.peek()?;
+        let file_id = self.file_id();
+
+        let inner = match next.kind {
+            TokenKind::Variable => Type::Variable(Variable::from_token(self.stream.consume()?, file_id)),
+            TokenKind::Question => self.parse_nullable_type()?,
+            TokenKind::LeftParenthesis => self.parse_parenthesized_type()?,
+            TokenKind::Asterisk => self.parse_wildcard_type()?,
+            TokenKind::Minus => self.parse_negated_type()?,
+            TokenKind::Plus => self.parse_posited_type()?,
+            TokenKind::Bang => self.parse_alias_reference_type()?,
+            TokenKind::LiteralInteger
+            | TokenKind::LiteralFloat
+            | TokenKind::SingleQuotedString
+            | TokenKind::DoubleQuotedString => self.parse_literal_type()?,
+            TokenKind::Identifier => match lookup_keyword(next.value) {
+                Some(keyword) => self.parse_keyword_type(keyword)?,
+                None => self.parse_reference_type()?,
+            },
+            _ => return Err(ParseError::UnexpectedToken(next.span_for(file_id))),
+        };
+
+        Ok(inner)
+    }
+
+    fn parse_keyword_type(&mut self, keyword: TypeKeyword) -> Result<Type<'arena>, ParseError> {
+        let ty = match keyword {
+            TypeKeyword::Int | TypeKeyword::Integer => {
+                let keyword = self.parse_keyword()?;
+                if self.stream.is_at(TokenKind::LeftAngleBracket) {
+                    self.parse_int_range_type(keyword)?
+                } else {
+                    Type::Int(keyword)
+                }
+            }
+            TypeKeyword::Array
+            | TypeKeyword::NonEmptyArray
+            | TypeKeyword::AssociativeArray
+            | TypeKeyword::List
+            | TypeKeyword::NonEmptyList => self.parse_array_like_type()?,
+            TypeKeyword::Object => self.parse_object_type()?,
+            TypeKeyword::Iterable => self.parse_iterable_type()?,
+            TypeKeyword::KeyOf => self.parse_key_of_type()?,
+            TypeKeyword::ValueOf => self.parse_value_of_type()?,
+            TypeKeyword::IntMaskOf => self.parse_int_mask_of_type()?,
+            TypeKeyword::IntMask => self.parse_int_mask_type()?,
+            TypeKeyword::New => self.parse_new_type()?,
+            TypeKeyword::TemplateType => self.parse_template_type()?,
+            TypeKeyword::PropertiesOf => self.parse_properties_of_type(crate::cst::r#type::PropertiesOfFilter::All)?,
+            TypeKeyword::PublicPropertiesOf => {
+                self.parse_properties_of_type(crate::cst::r#type::PropertiesOfFilter::Public)?
+            }
+            TypeKeyword::PrivatePropertiesOf => {
+                self.parse_properties_of_type(crate::cst::r#type::PropertiesOfFilter::Private)?
+            }
+            TypeKeyword::ProtectedPropertiesOf => {
+                self.parse_properties_of_type(crate::cst::r#type::PropertiesOfFilter::Protected)?
+            }
+            TypeKeyword::ClassString => self.parse_class_string_type()?,
+            TypeKeyword::InterfaceString => self.parse_interface_string_type()?,
+            TypeKeyword::EnumString => self.parse_enum_string_type()?,
+            TypeKeyword::TraitString => self.parse_trait_string_type()?,
+            TypeKeyword::Callable => self.parse_callable_type(crate::cst::r#type::CallableTypeKind::Callable)?,
+            TypeKeyword::PureCallable => {
+                self.parse_callable_type(crate::cst::r#type::CallableTypeKind::PureCallable)?
+            }
+            TypeKeyword::PureClosure => self.parse_callable_type(crate::cst::r#type::CallableTypeKind::PureClosure)?,
+            TypeKeyword::Mixed => Type::Mixed(self.parse_keyword()?),
+            TypeKeyword::NonEmptyMixed => Type::NonEmptyMixed(self.parse_keyword()?),
+            TypeKeyword::Null => Type::Null(self.parse_keyword()?),
+            TypeKeyword::Void => Type::Void(self.parse_keyword()?),
+            TypeKeyword::Never
+            | TypeKeyword::NoReturn
+            | TypeKeyword::NeverReturn
+            | TypeKeyword::NeverReturns
+            | TypeKeyword::Nothing => Type::Never(self.parse_keyword()?),
+            TypeKeyword::Resource => Type::Resource(self.parse_keyword()?),
+            TypeKeyword::OpenResource => Type::OpenResource(self.parse_keyword()?),
+            TypeKeyword::ClosedResource => Type::ClosedResource(self.parse_keyword()?),
+            TypeKeyword::True => Type::True(self.parse_keyword()?),
+            TypeKeyword::False => Type::False(self.parse_keyword()?),
+            TypeKeyword::Bool | TypeKeyword::Boolean => Type::Bool(self.parse_keyword()?),
+            TypeKeyword::Float | TypeKeyword::Real | TypeKeyword::Double => Type::Float(self.parse_keyword()?),
+            TypeKeyword::String => Type::String(self.parse_keyword()?),
+            TypeKeyword::Scalar => Type::Scalar(self.parse_keyword()?),
+            TypeKeyword::Numeric => Type::Numeric(self.parse_keyword()?),
+            TypeKeyword::ArrayKey => Type::ArrayKey(self.parse_keyword()?),
+            TypeKeyword::StringableObject => Type::StringableObject(self.parse_keyword()?),
+            TypeKeyword::CallableString => Type::CallableString(self.parse_keyword()?),
+            TypeKeyword::LowercaseCallableString => Type::LowercaseCallableString(self.parse_keyword()?),
+            TypeKeyword::UppercaseCallableString => Type::UppercaseCallableString(self.parse_keyword()?),
+            TypeKeyword::NumericString => Type::NumericString(self.parse_keyword()?),
+            TypeKeyword::NonEmptyString => Type::NonEmptyString(self.parse_keyword()?),
+            TypeKeyword::NonEmptyLowercaseString => Type::NonEmptyLowercaseString(self.parse_keyword()?),
+            TypeKeyword::LowercaseString => Type::LowercaseString(self.parse_keyword()?),
+            TypeKeyword::NonEmptyUppercaseString => Type::NonEmptyUppercaseString(self.parse_keyword()?),
+            TypeKeyword::UppercaseString => Type::UppercaseString(self.parse_keyword()?),
+            TypeKeyword::TruthyString => Type::TruthyString(self.parse_keyword()?),
+            TypeKeyword::NonFalsyString => Type::NonFalsyString(self.parse_keyword()?),
+            TypeKeyword::PositiveInt => Type::PositiveInt(self.parse_keyword()?),
+            TypeKeyword::NegativeInt => Type::NegativeInt(self.parse_keyword()?),
+            TypeKeyword::NonPositiveInt => Type::NonPositiveInt(self.parse_keyword()?),
+            TypeKeyword::NonNegativeInt => Type::NonNegativeInt(self.parse_keyword()?),
+            TypeKeyword::NonZeroInt => Type::NonZeroInt(self.parse_keyword()?),
+            TypeKeyword::UnspecifiedLiteralInt => Type::UnspecifiedLiteralInt(self.parse_keyword()?),
+            TypeKeyword::UnspecifiedLiteralString => Type::UnspecifiedLiteralString(self.parse_keyword()?),
+            TypeKeyword::UnspecifiedLiteralFloat => Type::UnspecifiedLiteralFloat(self.parse_keyword()?),
+            TypeKeyword::NonEmptyUnspecifiedLiteralString => {
+                Type::NonEmptyUnspecifiedLiteralString(self.parse_keyword()?)
+            }
+            TypeKeyword::As | TypeKeyword::Is | TypeKeyword::Not | TypeKeyword::Min | TypeKeyword::Max => {
+                self.parse_reference_type()?
+            }
+        };
+
+        Ok(ty)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bumpalo::Bump;
+
+    use mago_database::file::FileId;
+    use mago_span::Position;
+    use mago_span::Span;
+
+    use crate::cst::r#type::CallableTypeKind;
+    use crate::cst::r#type::Type;
+    use crate::parser::PHPDocParser;
+
+    fn parse<'arena>(arena: &'arena Bump, source: &'arena [u8]) -> Type<'arena> {
+        let span = Span::new(FileId::zero(), Position::new(0), Position::new(source.len() as u32));
+        let mut parser = PHPDocParser::new(arena, source, span);
+
+        match parser.parse_type() {
+            Ok(ty) => ty,
+            Err(error) => panic!("failed to parse {:?}: {error:?}", String::from_utf8_lossy(source)),
+        }
+    }
+
+    #[test]
+    fn parses_int_keyword() {
+        let arena = Bump::new();
+        assert!(matches!(parse(&arena, b"int"), Type::Int(_)));
+        assert!(matches!(parse(&arena, b"INT"), Type::Int(_)));
+        assert!(matches!(parse(&arena, b"non-empty-string"), Type::NonEmptyString(_)));
+    }
+
+    #[test]
+    fn parses_reference_fallback() {
+        let arena = Bump::new();
+        let Type::Reference(reference) = parse(&arena, b"\\Foo\\Bar") else { panic!() };
+        assert_eq!(reference.identifier.value, b"\\Foo\\Bar");
+        assert!(reference.parameters.is_none());
+    }
+
+    #[test]
+    fn parses_union_and_intersection() {
+        let arena = Bump::new();
+        let Type::Union(union) = parse(&arena, b"int|string") else { panic!() };
+        assert!(matches!(union.left, Type::Int(_)));
+        assert!(matches!(union.right, Type::String(_)));
+
+        let Type::Intersection(intersection) = parse(&arena, b"A&B") else { panic!() };
+        assert!(matches!(intersection.left, Type::Reference(_)));
+        assert!(matches!(intersection.right, Type::Reference(_)));
+    }
+
+    #[test]
+    fn parses_nullable() {
+        let arena = Bump::new();
+        let Type::Nullable(nullable) = parse(&arena, b"?Foo") else { panic!() };
+        assert!(matches!(nullable.inner, Type::Reference(_)));
+    }
+
+    #[test]
+    fn parses_generics() {
+        let arena = Bump::new();
+        let Type::Array(array) = parse(&arena, b"array<int, string>") else { panic!() };
+        let Some(parameters) = array.parameters else { panic!() };
+        assert_eq!(parameters.entries.len(), 2);
+    }
+
+    #[test]
+    fn parses_shape() {
+        let arena = Bump::new();
+        let Type::Shape(shape) = parse(&arena, b"array{a: int, b?: string}") else { panic!() };
+        assert_eq!(shape.fields.len(), 2);
+    }
+
+    #[test]
+    fn parses_negated_and_posited() {
+        let arena = Bump::new();
+        let Type::Negated(negated) = parse(&arena, b"-1") else { panic!() };
+        assert!(matches!(negated.operand, Type::LiteralInt(_)));
+
+        let Type::Posited(posited) = parse(&arena, b"+2") else { panic!() };
+        assert!(matches!(posited.operand, Type::LiteralInt(_)));
+
+        let Type::Negated(negated) = parse(&arena, b"-Foo") else { panic!() };
+        assert!(matches!(negated.operand, Type::Reference(_)));
+    }
+
+    #[test]
+    fn parses_int_range() {
+        let arena = Bump::new();
+        assert!(matches!(parse(&arena, b"int<-5, 10>"), Type::IntRange(_)));
+        assert!(matches!(parse(&arena, b"int<min, max>"), Type::IntRange(_)));
+    }
+
+    #[test]
+    fn parses_key_of_and_class_string() {
+        let arena = Bump::new();
+        assert!(matches!(parse(&arena, b"key-of<Foo>"), Type::KeyOf(_)));
+        assert!(matches!(parse(&arena, b"class-string"), Type::ClassString(_)));
+        assert!(matches!(parse(&arena, b"class-string<Foo>"), Type::ClassString(_)));
+    }
+
+    #[test]
+    fn parses_single_generic_parameter_with_trailing_comma() {
+        let arena = Bump::new();
+        let Type::ClassString(class_string) = parse(&arena, b"class-string<Foo,>") else { panic!() };
+        let Some(parameter) = &class_string.parameter else { panic!("expected a generic parameter") };
+        assert!(parameter.entry.comma.is_some());
+    }
+
+    #[test]
+    fn parses_callable_and_closure() {
+        let arena = Bump::new();
+        let Type::Callable(callable) = parse(&arena, b"callable(int, string): bool") else { panic!() };
+        assert_eq!(callable.kind, CallableTypeKind::Callable);
+
+        let Type::Callable(closure) = parse(&arena, b"Closure(): void") else { panic!() };
+        assert_eq!(closure.kind, CallableTypeKind::Closure);
+    }
+
+    #[test]
+    fn parses_conditional() {
+        let arena = Bump::new();
+        assert!(matches!(parse(&arena, b"T is int ? string : float"), Type::Conditional(_)));
+    }
+
+    #[test]
+    fn parses_member_reference() {
+        let arena = Bump::new();
+        assert!(matches!(parse(&arena, b"Foo::BAR"), Type::MemberReference(_)));
+        assert!(matches!(parse(&arena, b"Foo::*"), Type::MemberReference(_)));
+    }
+
+    #[test]
+    fn parses_literal_string() {
+        let arena = Bump::new();
+        let Type::LiteralString(literal) = parse(&arena, b"'hello'") else { panic!() };
+        assert_eq!(literal.value, b"hello");
+    }
+
+    #[test]
+    fn does_not_emit_invalid_float_for_dangling_exponent() {
+        let arena = Bump::new();
+
+        let Type::LiteralFloat(literal) = parse(&arena, b".1") else { panic!("expected .1 to be a float") };
+        assert_eq!(*literal.value, 0.1);
+        assert_eq!(literal.raw, b".1");
+
+        assert!(matches!(parse(&arena, b".1E"), Type::LiteralFloat(_)));
+        assert!(matches!(parse(&arena, b".1e+"), Type::LiteralFloat(_)));
+        assert!(matches!(parse(&arena, b"1e"), Type::LiteralInt(_)));
+        assert!(matches!(parse(&arena, b"1e+"), Type::LiteralInt(_)));
+        assert!(matches!(parse(&arena, b"3.e"), Type::LiteralInt(_)));
+
+        let _ = parse(&arena, b".1E.111.12E1ra");
+    }
+
+    #[test]
+    fn errors_on_empty() {
+        let arena = Bump::new();
+        let span = Span::new(FileId::zero(), Position::new(0), Position::new(0));
+        let mut parser = PHPDocParser::new(&arena, b"", span);
+        if parser.parse_type().is_ok() {
+            panic!("expected an error for empty input");
+        }
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/type/new.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/type/new.rs
@@ -1,0 +1,12 @@
+use crate::cst::r#type::NewType;
+use crate::cst::r#type::Type;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_new_type(&mut self) -> Result<Type<'arena>, ParseError> {
+        let keyword = self.parse_keyword()?;
+
+        Ok(Type::New(NewType { keyword, parameter: self.parse_single_generic_parameter()? }))
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/type/object.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/type/object.rs
@@ -1,0 +1,53 @@
+use mago_syntax_core::ast::Sequence;
+
+use crate::cst::r#type::ShapeField;
+use crate::cst::r#type::ShapeFieldKey;
+use crate::cst::r#type::Type;
+use crate::cst::r#type::object::ObjectProperties;
+use crate::cst::r#type::object::ObjectType;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::token::TokenKind;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_object_type(&mut self) -> Result<Type<'arena>, ParseError> {
+        let keyword = self.parse_keyword()?;
+        if !self.stream.is_at(TokenKind::LeftBrace) {
+            return Ok(Type::Object(ObjectType { keyword, properties: None }));
+        }
+
+        let left_brace = self.stream.eat_span(TokenKind::LeftBrace)?;
+
+        let mut fields = self.new_vec::<ShapeField<'arena>>();
+        while !self.stream.is_at(TokenKind::RightBrace) && !self.stream.is_at(TokenKind::Ellipsis) {
+            let key = if self.scan_for_shape_field_key()? {
+                let shape_key = self.parse_shape_field_key()?;
+                let question_mark =
+                    if self.stream.is_at(TokenKind::Question) { Some(self.stream.consume_span()?) } else { None };
+                let colon = self.stream.eat_span(TokenKind::Colon)?;
+
+                Some(ShapeFieldKey { key: shape_key, question_mark, colon })
+            } else {
+                None
+            };
+
+            let value = self.parse_type()?;
+            let value = self.alloc(value);
+            let comma = if self.stream.is_at(TokenKind::Comma) { Some(self.stream.consume_span()?) } else { None };
+            let has_comma = comma.is_some();
+            fields.push(ShapeField { key, value, comma });
+
+            if !has_comma {
+                break;
+            }
+        }
+
+        let ellipsis = if self.stream.is_at(TokenKind::Ellipsis) { Some(self.stream.consume_span()?) } else { None };
+        let right_brace = self.stream.eat_span(TokenKind::RightBrace)?;
+
+        Ok(Type::Object(ObjectType {
+            keyword,
+            properties: Some(ObjectProperties { left_brace, fields: Sequence::new(fields), ellipsis, right_brace }),
+        }))
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/type/properties_of.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/type/properties_of.rs
@@ -1,0 +1,13 @@
+use crate::cst::r#type::PropertiesOfFilter;
+use crate::cst::r#type::PropertiesOfType;
+use crate::cst::r#type::Type;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_properties_of_type(&mut self, filter: PropertiesOfFilter) -> Result<Type<'arena>, ParseError> {
+        let keyword = self.parse_keyword()?;
+
+        Ok(Type::PropertiesOf(PropertiesOfType { filter, keyword, parameter: self.parse_single_generic_parameter()? }))
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/type/reference.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/type/reference.rs
@@ -1,0 +1,79 @@
+use crate::cst::identifier::Identifier;
+use crate::cst::r#type::CallableType;
+use crate::cst::r#type::CallableTypeKind;
+use crate::cst::r#type::GlobalWildcardSelector;
+use crate::cst::r#type::GlobalWildcardType;
+use crate::cst::r#type::MemberReferenceSelector;
+use crate::cst::r#type::MemberReferenceType;
+use crate::cst::r#type::ReferenceType;
+use crate::cst::r#type::Type;
+use crate::cst::r#type::WildcardKind;
+use crate::cst::r#type::WildcardType;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::token::TokenKind;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_reference_type(&mut self) -> Result<Type<'arena>, ParseError> {
+        let next = self.stream.peek()?;
+        let file_id = self.file_id();
+
+        if next.value == b"_" {
+            let token = self.stream.consume()?;
+
+            return Ok(Type::Wildcard(WildcardType { span: token.span_for(file_id), kind: WildcardKind::Underscore }));
+        }
+
+        if (next.value.eq_ignore_ascii_case(b"Closure") || next.value.eq_ignore_ascii_case(b"\\Closure"))
+            && self.stream.lookahead(1).is_some_and(|t| t.kind == TokenKind::LeftParenthesis)
+        {
+            let keyword = self.parse_keyword()?;
+            let specification = self.parse_callable_type_specifications()?;
+
+            return Ok(Type::Callable(CallableType {
+                kind: CallableTypeKind::Closure,
+                keyword,
+                specification: Some(specification),
+            }));
+        }
+
+        let identifier = Identifier::from_token(self.stream.consume()?, file_id);
+
+        if self.stream.is_at(TokenKind::ColonColon) {
+            let double_colon = self.stream.consume_span()?;
+
+            let member = if self.stream.is_at(TokenKind::Asterisk) {
+                let asterisk = self.stream.consume_span()?;
+
+                if self.is_at_member_identifier() {
+                    MemberReferenceSelector::EndsWith(
+                        asterisk,
+                        Identifier::from_token(self.eat_member_identifier()?, file_id),
+                    )
+                } else {
+                    MemberReferenceSelector::Wildcard(asterisk)
+                }
+            } else {
+                let member_identifier = Identifier::from_token(self.eat_member_identifier()?, file_id);
+
+                if self.stream.is_at(TokenKind::Asterisk) {
+                    MemberReferenceSelector::StartsWith(member_identifier, self.stream.consume_span()?)
+                } else {
+                    MemberReferenceSelector::Identifier(member_identifier)
+                }
+            };
+
+            Ok(Type::MemberReference(MemberReferenceType { class: identifier, double_colon, member }))
+        } else if self.stream.is_at(TokenKind::Asterisk) {
+            let asterisk = self.stream.consume_span()?;
+
+            Ok(Type::GlobalWildcardReference(GlobalWildcardType {
+                selector: GlobalWildcardSelector::StartsWith(identifier, asterisk),
+            }))
+        } else {
+            let parameters = self.parse_generic_parameters_or_none()?;
+
+            Ok(Type::Reference(ReferenceType { identifier, parameters }))
+        }
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/type/shape.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/type/shape.rs
@@ -1,0 +1,97 @@
+use mago_span::Position;
+use mago_span::Span;
+use mago_syntax_core::utils::parse_literal_integer;
+
+use crate::cst::identifier::Identifier;
+use crate::cst::r#type::ShapeKey;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::token::TokenKind;
+
+const SHAPE_KEY_SCAN_LIMIT: usize = 48;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn scan_for_shape_field_key(&mut self) -> Result<bool, ParseError> {
+        let mut depth_angle: u32 = 0;
+
+        for index in 0..SHAPE_KEY_SCAN_LIMIT {
+            let Some(token) = self.stream.lookahead(index) else {
+                return Ok(false);
+            };
+
+            match token.kind {
+                TokenKind::Colon if depth_angle == 0 => return Ok(true),
+                TokenKind::Question
+                    if depth_angle == 0
+                        && self.stream.lookahead(index + 1).is_some_and(|t| t.kind == TokenKind::Colon) =>
+                {
+                    return Ok(true);
+                }
+                TokenKind::Comma
+                | TokenKind::RightBrace
+                | TokenKind::LeftBrace
+                | TokenKind::LeftParenthesis
+                | TokenKind::RightParenthesis
+                | TokenKind::LeftBracket
+                | TokenKind::RightBracket
+                | TokenKind::Ellipsis
+                    if depth_angle == 0 =>
+                {
+                    return Ok(false);
+                }
+                TokenKind::LeftAngleBracket => depth_angle += 1,
+                TokenKind::RightAngleBracket if depth_angle > 0 => depth_angle -= 1,
+                _ => {}
+            }
+        }
+
+        Ok(false)
+    }
+
+    pub(crate) fn parse_shape_field_key(&mut self) -> Result<ShapeKey<'arena>, ParseError> {
+        if self.stream.is_at(TokenKind::SingleQuotedString) || self.stream.is_at(TokenKind::DoubleQuotedString) {
+            let token = self.stream.consume()?;
+            let value = token.value.get(1..token.value.len().saturating_sub(1)).unwrap_or(&[]);
+
+            return Ok(ShapeKey::String { value, span: token.span_for(self.file_id()) });
+        }
+
+        if self.stream.is_at(TokenKind::LiteralInteger) {
+            let token = self.stream.consume()?;
+            let raw_value = parse_literal_integer(token.value).unwrap_or(0);
+            let value = i64::try_from(raw_value).unwrap_or(0);
+
+            return Ok(ShapeKey::Integer { value, span: token.span_for(self.file_id()) });
+        }
+
+        if self.stream.is_at(TokenKind::Minus)
+            && self.stream.lookahead(1).is_some_and(|t| t.kind == TokenKind::LiteralInteger)
+        {
+            let sign_token = self.stream.consume()?;
+            let token = self.stream.consume()?;
+            let raw_value = parse_literal_integer(token.value).unwrap_or(0);
+            let value = i64::try_from(raw_value).unwrap_or(0).checked_neg().unwrap_or(0);
+            let end = Position::new(token.start.offset + token.value.len() as u32);
+
+            return Ok(ShapeKey::Integer { value, span: Span::new(self.file_id(), sign_token.start, end) });
+        }
+
+        if self.stream.is_at(TokenKind::Identifier)
+            && self.stream.lookahead(1).is_some_and(|t| t.kind == TokenKind::ColonColon)
+            && self.is_at_member_identifier_at(2)
+        {
+            let class_token = self.stream.consume()?;
+            let class_name = Identifier::from_token(class_token, self.file_id());
+            let double_colon = self.stream.eat_span(TokenKind::ColonColon)?;
+            let constant_token = self.eat_member_identifier()?;
+            let constant_name = Identifier::from_token(constant_token, self.file_id());
+            let span = class_name.span.join(constant_name.span);
+
+            return Ok(ShapeKey::ClassLikeConstant { class_name, double_colon, constant_name, span });
+        }
+
+        let token = self.stream.eat(TokenKind::Identifier)?;
+
+        Ok(ShapeKey::String { value: token.value, span: token.span_for(self.file_id()) })
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/type/slice.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/type/slice.rs
@@ -1,0 +1,18 @@
+use mago_span::Span;
+
+use crate::cst::r#type::SliceType;
+use crate::cst::r#type::Type;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_slice_type(
+        &mut self,
+        inner: &'arena Type<'arena>,
+        left_bracket: Span,
+    ) -> Result<Type<'arena>, ParseError> {
+        let right_bracket = self.stream.consume_span()?;
+
+        Ok(Type::Slice(SliceType { inner, left_bracket, right_bracket }))
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/type/template_type.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/type/template_type.rs
@@ -1,0 +1,12 @@
+use crate::cst::r#type::TemplateTypeType;
+use crate::cst::r#type::Type;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_template_type(&mut self) -> Result<Type<'arena>, ParseError> {
+        let keyword = self.parse_keyword()?;
+
+        Ok(Type::TemplateType(TemplateTypeType { keyword, parameters: self.parse_generic_parameters()? }))
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/type/unary.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/type/unary.rs
@@ -1,0 +1,21 @@
+use crate::cst::r#type::NegatedType;
+use crate::cst::r#type::PositedType;
+use crate::cst::r#type::Type;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_negated_type(&mut self) -> Result<Type<'arena>, ParseError> {
+        let minus = self.stream.consume_span()?;
+        let operand = self.parse_primary_type()?;
+
+        Ok(Type::Negated(NegatedType { minus, operand: self.alloc(operand) }))
+    }
+
+    pub(crate) fn parse_posited_type(&mut self) -> Result<Type<'arena>, ParseError> {
+        let plus = self.stream.consume_span()?;
+        let operand = self.parse_primary_type()?;
+
+        Ok(Type::Posited(PositedType { plus, operand: self.alloc(operand) }))
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/type/value_of.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/type/value_of.rs
@@ -1,0 +1,12 @@
+use crate::cst::r#type::Type;
+use crate::cst::r#type::ValueOfType;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_value_of_type(&mut self) -> Result<Type<'arena>, ParseError> {
+        let keyword = self.parse_keyword()?;
+
+        Ok(Type::ValueOf(ValueOfType { keyword, parameter: self.parse_single_generic_parameter()? }))
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/type/wildcard.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/type/wildcard.rs
@@ -1,0 +1,26 @@
+use crate::cst::identifier::Identifier;
+use crate::cst::r#type::GlobalWildcardSelector;
+use crate::cst::r#type::GlobalWildcardType;
+use crate::cst::r#type::Type;
+use crate::cst::r#type::WildcardKind;
+use crate::cst::r#type::WildcardType;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_wildcard_type(&mut self) -> Result<Type<'arena>, ParseError> {
+        let token = self.stream.consume()?;
+        let file_id = self.file_id();
+        let asterisk_span = token.span_for(file_id);
+
+        if self.is_at_member_identifier() {
+            let identifier = Identifier::from_token(self.eat_member_identifier()?, file_id);
+
+            Ok(Type::GlobalWildcardReference(GlobalWildcardType {
+                selector: GlobalWildcardSelector::EndsWith(asterisk_span, identifier),
+            }))
+        } else {
+            Ok(Type::Wildcard(WildcardType { span: asterisk_span, kind: WildcardKind::Asterisk }))
+        }
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/internal/variable.rs
+++ b/crates/phpdoc-syntax/src/parser/internal/variable.rs
@@ -1,0 +1,16 @@
+use crate::cst::variable::Variable;
+use crate::error::ParseError;
+use crate::parser::PHPDocParser;
+use crate::token::TokenKind;
+
+impl<'arena> PHPDocParser<'arena> {
+    pub(crate) fn parse_variable(&mut self) -> Result<Variable<'arena>, ParseError> {
+        if self.stream.is_at(TokenKind::Variable) || self.stream.is_at(TokenKind::ThisVariable) {
+            let token = self.stream.consume()?;
+
+            Ok(Variable { span: token.span_for(self.file_id()), value: token.value })
+        } else {
+            Err(ParseError::UnexpectedToken(self.stream.peek()?.span_for(self.file_id())))
+        }
+    }
+}

--- a/crates/phpdoc-syntax/src/parser/mod.rs
+++ b/crates/phpdoc-syntax/src/parser/mod.rs
@@ -1,0 +1,70 @@
+use bumpalo::Bump;
+use bumpalo::collections::Vec as BVec;
+
+use mago_database::file::FileId;
+use mago_database::file::HasFileId;
+use mago_span::Position;
+use mago_span::Span;
+use mago_syntax_core::input::Input;
+
+use crate::cst::Document;
+use crate::cst::inherit_doc::InheritDoc;
+use crate::error::ParseError;
+use crate::lexer::DocblockLexer;
+use crate::parser::internal::stream::DocblockTokenStream;
+
+pub(crate) mod internal;
+
+#[derive(Debug)]
+#[allow(clippy::field_scoped_visibility_modifiers)]
+pub struct PHPDocParser<'arena> {
+    pub(crate) arena: &'arena Bump,
+    pub(crate) stream: DocblockTokenStream<'arena>,
+    pub(crate) errors: BVec<'arena, ParseError>,
+    pub(crate) inherit_docs: BVec<'arena, InheritDoc>,
+}
+
+impl<'arena> PHPDocParser<'arena> {
+    #[must_use]
+    pub fn new(arena: &'arena Bump, content: &'arena [u8], span: Span) -> Self {
+        let input = Input::anchored_at(span.file_id, content, span.start);
+        let lexer = DocblockLexer::new(input);
+        let stream = DocblockTokenStream::new(arena, lexer, content, span.start);
+
+        Self { arena, stream, errors: BVec::new_in(arena), inherit_docs: BVec::new_in(arena) }
+    }
+
+    #[must_use]
+    pub fn parse_with_span(arena: &'arena Bump, content: &'arena [u8], span: Span) -> Document<'arena> {
+        let mut parser = Self::new(arena, content, span);
+
+        parser.parse_document(span)
+    }
+
+    #[must_use]
+    pub fn parse(arena: &'arena Bump, file_id: FileId, content: &'arena [u8]) -> Document<'arena> {
+        let span = Span::new(file_id, Position::new(0), Position::new(content.len() as u32));
+
+        Self::parse_with_span(arena, content, span)
+    }
+
+    #[inline]
+    pub(crate) fn file_id(&self) -> FileId {
+        self.stream.file_id()
+    }
+}
+
+/// Parses a standalone type expression (the PHPStan/Psalm type mini-language) from `content`.
+///
+/// # Errors
+///
+/// Returns a [`ParseError`] if the input is not a well-formed type.
+pub fn parse_type<'arena>(
+    arena: &'arena Bump,
+    content: &'arena [u8],
+    span: Span,
+) -> Result<crate::cst::r#type::Type<'arena>, ParseError> {
+    let mut parser = PHPDocParser::new(arena, content, span);
+
+    parser.parse_type()
+}

--- a/crates/phpdoc-syntax/src/token/mod.rs
+++ b/crates/phpdoc-syntax/src/token/mod.rs
@@ -1,0 +1,101 @@
+use serde::Serialize;
+use strum::Display;
+
+use mago_database::file::FileId;
+use mago_span::HasPosition;
+use mago_span::Position;
+use mago_span::Span;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord, Display)]
+#[serde(tag = "type", content = "value")]
+pub enum TokenKind {
+    OpeningMarker,
+    ClosingMarker,
+    Tag,
+    Whitespace,
+    LineComment,
+    Pipe,
+    Ampersand,
+    Question,
+    Bang,
+    LeftParenthesis,
+    RightParenthesis,
+    LeftAngleBracket,
+    RightAngleBracket,
+    LeftBracket,
+    RightBracket,
+    LeftBrace,
+    RightBrace,
+    Comma,
+    Colon,
+    ColonColon,
+    Arrow,
+    DoubleArrow,
+    Equals,
+    Minus,
+    Plus,
+    Ellipsis,
+    Asterisk,
+    LiteralInteger,
+    LiteralFloat,
+    SingleQuotedString,
+    DoubleQuotedString,
+    Identifier,
+    Variable,
+    ThisVariable,
+    Other,
+}
+
+impl TokenKind {
+    #[inline]
+    #[must_use]
+    pub const fn is_trivia(&self) -> bool {
+        matches!(self, TokenKind::Whitespace | TokenKind::LineComment)
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn is_string_literal(&self) -> bool {
+        matches!(self, TokenKind::SingleQuotedString | TokenKind::DoubleQuotedString)
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn is_number_literal(&self) -> bool {
+        matches!(self, TokenKind::LiteralInteger | TokenKind::LiteralFloat)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, PartialOrd, Ord)]
+pub struct Token<'arena> {
+    pub kind: TokenKind,
+    pub start: Position,
+    pub value: &'arena [u8],
+}
+
+impl<'arena> Token<'arena> {
+    #[inline]
+    #[must_use]
+    pub const fn new(kind: TokenKind, value: &'arena [u8], start: Position) -> Self {
+        Self { kind, start, value }
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn span_for(&self, file_id: FileId) -> Span {
+        Span::new(file_id, self.start, Position::new(self.start.offset + self.value.len() as u32))
+    }
+}
+
+impl HasPosition for Token<'_> {
+    #[inline]
+    fn position(&self) -> Position {
+        self.start
+    }
+}
+
+impl std::fmt::Display for Token<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}({})", self.kind, String::from_utf8_lossy(self.value))
+    }
+}

--- a/crates/phpdoc-syntax/tests/corpus.rs
+++ b/crates/phpdoc-syntax/tests/corpus.rs
@@ -1,0 +1,196 @@
+use bumpalo::Bump;
+
+use mago_database::file::FileId;
+use mago_phpdoc_syntax::PHPDocParser;
+use mago_phpdoc_syntax::cst::Document;
+use mago_phpdoc_syntax::cst::Element;
+use mago_phpdoc_syntax::cst::Tag;
+use mago_phpdoc_syntax::cst::TagValue;
+use mago_phpdoc_syntax::cst::Text;
+use mago_phpdoc_syntax::cst::r#type::Type;
+
+fn parse<'arena>(arena: &'arena Bump, source: &'arena [u8]) -> Document<'arena> {
+    PHPDocParser::parse(arena, FileId::zero(), source)
+}
+
+fn tags<'arena>(document: &'arena Document<'arena>) -> Vec<&'arena Tag<'arena>> {
+    document
+        .elements
+        .iter()
+        .filter_map(|element| if let Element::Tag(tag) = element { Some(*tag) } else { None })
+        .collect()
+}
+
+fn texts<'arena>(document: &'arena Document<'arena>) -> Vec<&'arena Text<'arena>> {
+    document
+        .elements
+        .iter()
+        .filter_map(|element| if let Element::Text(text) = element { Some(text) } else { None })
+        .collect()
+}
+
+#[test]
+fn parses_description_text_and_typed_tags() {
+    let arena = Bump::new();
+    let source = b"/**\n * Summary.\n *\n * @param string $foo\n * @return void\n */";
+    let document = parse(&arena, source);
+
+    let elements: Vec<&Element> = document.elements.iter().collect();
+    assert_eq!(elements.len(), 3);
+
+    let Element::Text(summary) = elements[0] else { panic!("expected text, got {:?}", elements[0]) };
+    assert_eq!(summary.value, b"Summary.");
+
+    let Element::Tag(foo) = elements[1] else { panic!("expected tag, got {:?}", elements[1]) };
+    assert_eq!(foo.name.value, b"param");
+    let TagValue::Param(foo) = &foo.value else { panic!("expected param, got {:?}", foo.value) };
+    assert!(matches!(foo.r#type, Type::String(_)));
+    assert_eq!(foo.parameter.value, b"$foo");
+    assert!(foo.description.is_none());
+
+    let Element::Tag(ret) = elements[2] else { panic!("expected tag, got {:?}", elements[2]) };
+    assert_eq!(ret.name.value, b"return");
+    let TagValue::Return(ret) = &ret.value else { panic!("expected return, got {:?}", ret.value) };
+    assert!(matches!(ret.r#type, Type::Void(_)));
+    assert!(ret.description.is_none());
+}
+
+#[test]
+fn underscore_in_tag_name_is_preserved() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @some_tag Description */");
+    let tags = tags(&document);
+
+    assert_eq!(tags.len(), 1);
+    assert_eq!(tags[0].name.value, b"some_tag");
+
+    let TagValue::Generic(generic) = &tags[0].value else { panic!("expected generic, got {:?}", tags[0].value) };
+    assert_eq!(generic.value.value, b"Description");
+}
+
+#[test]
+fn utf8_variable_name_and_ascii_description() {
+    let arena = Bump::new();
+    let source = "/** @param string $مثال A parameter with an Arabic variable name. */".as_bytes();
+    let document = parse(&arena, source);
+    let tags = tags(&document);
+
+    assert_eq!(tags.len(), 1);
+    let TagValue::Param(param) = &tags[0].value else { panic!("expected param, got {:?}", tags[0].value) };
+    assert!(matches!(param.r#type, Type::String(_)));
+    assert_eq!(param.parameter.value, "$مثال".as_bytes());
+    let Some(description) = param.description else { panic!("expected a description") };
+    assert_eq!(description.value, b"A parameter with an Arabic variable name.");
+}
+
+#[test]
+fn utf8_return_description_is_kept_verbatim() {
+    let arena = Bump::new();
+    let source = "/** @return int 返回值是整数类型。 */".as_bytes();
+    let document = parse(&arena, source);
+    let tags = tags(&document);
+
+    assert_eq!(tags.len(), 1);
+    let TagValue::Return(ret) = &tags[0].value else { panic!("expected return, got {:?}", tags[0].value) };
+    assert!(matches!(ret.r#type, Type::Int(_)));
+    let Some(description) = ret.description else { panic!("expected a description") };
+    assert_eq!(description.value, "返回值是整数类型。".as_bytes());
+}
+
+#[test]
+fn ideographic_space_is_part_of_identifiers() {
+    let arena = Bump::new();
+    let source = "/** @param\u{3000}string $foo 中文描述 */".as_bytes();
+    let document = parse(&arena, source);
+    let tags = tags(&document);
+
+    assert_eq!(tags.len(), 1);
+    let TagValue::Param(param) = &tags[0].value else { panic!("expected param, got {:?}", tags[0].value) };
+    let Type::Reference(reference) = param.r#type else { panic!("expected reference, got {:?}", param.r#type) };
+    assert_eq!(reference.identifier.value, "\u{3000}string".as_bytes());
+    assert_eq!(param.parameter.value, b"$foo");
+    let Some(description) = param.description else { panic!("expected a description") };
+    assert_eq!(description.value, "中文描述".as_bytes());
+}
+
+#[test]
+fn ideographic_space_return_and_throws() {
+    let arena = Bump::new();
+    let source = "/**\n * @return\u{3000}int\n * @throws\u{3000}Exception\n */".as_bytes();
+    let document = parse(&arena, source);
+    let tags = tags(&document);
+    assert_eq!(tags.len(), 2);
+
+    let TagValue::Return(ret) = &tags[0].value else { panic!("expected return, got {:?}", tags[0].value) };
+    let Type::Reference(ret_type) = ret.r#type else { panic!("expected reference, got {:?}", ret.r#type) };
+    assert_eq!(ret_type.identifier.value, "\u{3000}int".as_bytes());
+
+    let TagValue::Throws(throws) = &tags[1].value else { panic!("expected throws, got {:?}", tags[1].value) };
+    let Type::Reference(throws_type) = throws.r#type else { panic!("expected reference, got {:?}", throws.r#type) };
+    assert_eq!(throws_type.identifier.value, "\u{3000}Exception".as_bytes());
+}
+
+#[test]
+fn multiline_description_is_kept_verbatim() {
+    let arena = Bump::new();
+    let source = b"/** @var string[] line one\nline two*/";
+    let document = parse(&arena, source);
+    let tags = tags(&document);
+
+    assert_eq!(tags.len(), 1);
+    let TagValue::Var(var) = &tags[0].value else { panic!("expected var, got {:?}", tags[0].value) };
+    let Type::Slice(slice) = var.r#type else { panic!("expected slice, got {:?}", var.r#type) };
+    assert!(matches!(slice.inner, Type::String(_)));
+    assert!(var.variable.is_none());
+
+    let Some(description) = var.description else { panic!("expected a description") };
+    assert_eq!(description.value, b"line one\nline two");
+}
+
+#[test]
+fn doctrine_annotations_become_generic_tags() {
+    let arena = Bump::new();
+    let source = b"/**\n * @Event(\"X\")\n * @SimpleAnnotation\n */";
+    let document = parse(&arena, source);
+    let tags = tags(&document);
+    assert_eq!(tags.len(), 2);
+
+    assert_eq!(tags[0].name.value, b"Event");
+    let TagValue::Generic(event) = &tags[0].value else { panic!("expected generic, got {:?}", tags[0].value) };
+    assert_eq!(event.value.value, b"(\"X\")");
+
+    assert_eq!(tags[1].name.value, b"SimpleAnnotation");
+    let TagValue::Generic(simple) = &tags[1].value else { panic!("expected generic, got {:?}", tags[1].value) };
+    assert_eq!(simple.value.value, b"");
+}
+
+#[test]
+fn inline_tags_are_kept_as_raw_text() {
+    let arena = Bump::new();
+    let document = parse(&arena, br#"/** See {@see \Some\Class} for details. */"#);
+    let texts = texts(&document);
+
+    assert_eq!(texts.len(), 1);
+    assert_eq!(texts[0].value, br#"See {@see \Some\Class} for details."#);
+}
+
+#[test]
+fn code_blocks_are_kept_as_raw_text() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/**\n * ```php\n * echo 1;\n * ```\n */");
+    let texts = texts(&document);
+
+    assert_eq!(texts.len(), 1);
+    assert_eq!(texts[0].value, b"```php\n * echo 1;\n * ```");
+}
+
+#[test]
+fn utf8_paragraph_text_is_kept_verbatim() {
+    let arena = Bump::new();
+    let source = "/**\n * 中文段落\n */".as_bytes();
+    let document = parse(&arena, source);
+    let texts = texts(&document);
+
+    assert_eq!(texts.len(), 1);
+    assert_eq!(texts[0].value, "中文段落".as_bytes());
+}

--- a/crates/phpdoc-syntax/tests/errors.rs
+++ b/crates/phpdoc-syntax/tests/errors.rs
@@ -1,0 +1,77 @@
+use bumpalo::Bump;
+
+use mago_database::file::FileId;
+use mago_phpdoc_syntax::PHPDocParser;
+use mago_phpdoc_syntax::cst::Document;
+use mago_phpdoc_syntax::cst::Element;
+use mago_phpdoc_syntax::cst::TagValue;
+use mago_phpdoc_syntax::error::ParseError;
+use mago_span::Position;
+use mago_span::Span;
+
+fn parse<'arena>(arena: &'arena Bump, source: &'arena [u8]) -> Document<'arena> {
+    PHPDocParser::parse(arena, FileId::zero(), source)
+}
+
+fn span(start: u32, end: u32) -> Span {
+    Span::new(FileId::zero(), Position::new(start), Position::new(end))
+}
+
+fn invalid_tag_count(document: &Document<'_>) -> usize {
+    document
+        .elements
+        .iter()
+        .filter(|element| matches!(element, Element::Tag(tag) if matches!(tag.value, TagValue::Invalid(_))))
+        .count()
+}
+
+#[test]
+fn valid_docblock_has_no_errors() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @return int */");
+
+    assert!(!document.has_errors());
+    assert_eq!(document.errors.as_slice(), [].as_slice());
+}
+
+#[test]
+fn malformed_tag_value_records_an_error_and_recovers() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @param | */");
+
+    assert!(document.has_errors());
+    assert_eq!(document.errors.as_slice(), [ParseError::UnexpectedToken(span(11, 12))].as_slice());
+
+    assert_eq!(invalid_tag_count(&document), 1);
+}
+
+#[test]
+fn every_malformed_tag_is_recorded_in_order() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/**\n * @param |\n * @return |\n */");
+
+    assert_eq!(
+        document.errors.as_slice(),
+        [ParseError::UnexpectedToken(span(14, 15)), ParseError::UnexpectedToken(span(27, 28))].as_slice()
+    );
+
+    assert_eq!(invalid_tag_count(&document), 2);
+}
+
+#[test]
+fn unexpected_end_of_input_is_recorded() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @template */");
+
+    assert_eq!(document.errors.as_slice(), [ParseError::UnexpectedEndOfInput(span(13, 13))].as_slice());
+    assert_eq!(invalid_tag_count(&document), 1);
+}
+
+#[test]
+fn import_type_without_from_is_recorded() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @import-type Foo */");
+
+    assert_eq!(document.errors.as_slice(), [ParseError::UnexpectedEndOfInput(span(20, 20))].as_slice());
+    assert_eq!(invalid_tag_count(&document), 1);
+}

--- a/crates/phpdoc-syntax/tests/inherit_doc.rs
+++ b/crates/phpdoc-syntax/tests/inherit_doc.rs
@@ -1,0 +1,92 @@
+use bumpalo::Bump;
+
+use mago_database::file::FileId;
+use mago_phpdoc_syntax::PHPDocParser;
+use mago_phpdoc_syntax::cst::Document;
+use mago_phpdoc_syntax::cst::Element;
+use mago_phpdoc_syntax::cst::TagValue;
+use mago_phpdoc_syntax::cst::TagVendor;
+
+fn parse<'arena>(arena: &'arena Bump, source: &'arena [u8]) -> Document<'arena> {
+    PHPDocParser::parse(arena, FileId::zero(), source)
+}
+
+fn inherit_spans(document: &Document<'_>) -> Vec<(u32, u32)> {
+    document.inherit_docs.iter().map(|inherit| (inherit.span.start.offset, inherit.span.end.offset)).collect()
+}
+
+#[test]
+fn standalone_inheritdoc_tag_is_recognized_and_recorded() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @inheritdoc */");
+
+    assert!(document.has_inherit_doc());
+    assert_eq!(inherit_spans(&document), vec![(4, 15)]);
+
+    let elements: Vec<&Element> = document.elements.iter().collect();
+    assert_eq!(elements.len(), 1);
+    let Element::Tag(tag) = elements[0] else { panic!("expected tag, got {:?}", elements[0]) };
+    assert!(matches!(tag.value, TagValue::InheritDoc(_)));
+}
+
+#[test]
+fn inheritdoc_tag_name_is_case_insensitive() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @inheritDoc */");
+
+    assert!(document.has_inherit_doc());
+    assert_eq!(inherit_spans(&document), vec![(4, 15)]);
+
+    let tag = match document.elements.iter().next() {
+        Some(Element::Tag(tag)) => tag,
+        other => panic!("expected tag, got {other:?}"),
+    };
+    assert!(matches!(tag.value, TagValue::InheritDoc(_)));
+}
+
+#[test]
+fn vendor_prefixed_inheritdoc_is_recognized() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @psalm-inheritdoc */");
+
+    assert_eq!(inherit_spans(&document), vec![(4, 21)]);
+
+    let tag = match document.elements.iter().next() {
+        Some(Element::Tag(tag)) => tag,
+        other => panic!("expected tag, got {other:?}"),
+    };
+    assert_eq!(tag.vendor, Some(TagVendor::Psalm));
+    assert!(matches!(tag.value, TagValue::InheritDoc(_)));
+}
+
+#[test]
+fn inline_inheritdoc_is_recorded_and_text_kept_raw() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** Well, {@inheritDoc} i guess */");
+
+    assert!(document.has_inherit_doc());
+    assert_eq!(inherit_spans(&document), vec![(10, 23)]);
+
+    let elements: Vec<&Element> = document.elements.iter().collect();
+    assert_eq!(elements.len(), 1);
+    let Element::Text(text) = elements[0] else { panic!("expected text, got {:?}", elements[0]) };
+    assert_eq!(text.value, b"Well, {@inheritDoc} i guess");
+}
+
+#[test]
+fn both_inline_and_standalone_are_recorded_in_order() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/**\n * {@inheritDoc} text\n * @inheritdoc\n */");
+
+    assert!(document.has_inherit_doc());
+    assert_eq!(inherit_spans(&document), vec![(7, 20), (29, 40)]);
+}
+
+#[test]
+fn no_inheritdoc_means_empty() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @return int */");
+
+    assert!(!document.has_inherit_doc());
+    assert_eq!(inherit_spans(&document), Vec::new());
+}

--- a/crates/phpdoc-syntax/tests/structural.rs
+++ b/crates/phpdoc-syntax/tests/structural.rs
@@ -1,0 +1,324 @@
+use bumpalo::Bump;
+
+use mago_database::file::FileId;
+use mago_phpdoc_syntax::PHPDocParser;
+use mago_phpdoc_syntax::cst::ConstantExpression;
+use mago_phpdoc_syntax::cst::Document;
+use mago_phpdoc_syntax::cst::Element;
+use mago_phpdoc_syntax::cst::Tag;
+use mago_phpdoc_syntax::cst::TagValue;
+use mago_phpdoc_syntax::cst::TagVendor;
+use mago_phpdoc_syntax::cst::WhereTagValueModifier;
+use mago_phpdoc_syntax::cst::r#type::Type;
+
+fn parse<'arena>(arena: &'arena Bump, source: &'arena [u8]) -> Document<'arena> {
+    PHPDocParser::parse(arena, FileId::zero(), source)
+}
+
+fn first_tag<'arena>(document: &'arena Document<'arena>) -> &'arena Tag<'arena> {
+    for element in document.elements.iter() {
+        if let Element::Tag(tag) = element {
+            return tag;
+        }
+    }
+
+    panic!("expected a tag element");
+}
+
+#[test]
+fn parses_param_with_type_and_variable() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @param string $bar */");
+    let tag = first_tag(&document);
+
+    assert_eq!(tag.name.value, b"param");
+    assert_eq!(tag.vendor, None);
+
+    let TagValue::Param(param) = &tag.value else { panic!("expected param, got {:?}", tag.value) };
+    assert!(matches!(param.r#type, Type::String(_)));
+    assert!(param.ampersand.is_none());
+    assert!(param.ellipsis.is_none());
+    assert_eq!(param.parameter.value, b"$bar");
+    assert!(param.description.is_none());
+}
+
+#[test]
+fn parses_param_by_reference_variadic_with_description() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @param int &...$values the values */");
+    let tag = first_tag(&document);
+
+    let TagValue::Param(param) = &tag.value else { panic!() };
+    assert!(param.ampersand.is_some());
+    assert!(param.ellipsis.is_some());
+    assert_eq!(param.parameter.value, b"$values");
+    let Some(description) = &param.description else { panic!() };
+    assert_eq!(description.value, b"the values");
+}
+
+#[test]
+fn parses_typeless_param() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @param $foo description */");
+    let tag = first_tag(&document);
+
+    assert!(matches!(tag.value, TagValue::TypelessParam(_)));
+}
+
+#[test]
+fn parses_return_with_union() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @return int|string the result */");
+    let tag = first_tag(&document);
+
+    let TagValue::Return(value) = &tag.value else { panic!() };
+    assert!(matches!(value.r#type, Type::Union(_)));
+    let Some(description) = &value.description else { panic!() };
+    assert_eq!(description.value, b"the result");
+}
+
+#[test]
+fn parses_var_with_name() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @var array<int, string> $map */");
+    let tag = first_tag(&document);
+
+    let TagValue::Var(value) = &tag.value else { panic!() };
+    assert!(matches!(value.r#type, Type::Array(_)));
+    let Some(variable) = &value.variable else { panic!() };
+    assert_eq!(variable.value, b"$map");
+}
+
+#[test]
+fn parses_template_with_bound_and_default() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @template T of object = stdClass */");
+    let tag = first_tag(&document);
+
+    let TagValue::Template(template) = &tag.value else { panic!() };
+    assert_eq!(template.name.value, b"T");
+    let Some(bound) = &template.bound else { panic!("expected a bound") };
+    assert_eq!(bound.keyword.value, b"of");
+    assert!(matches!(bound.r#type, Type::Object(_)));
+    assert!(template.lower_bound.is_none());
+    let Some(default) = &template.default else { panic!("expected a default") };
+    assert!(matches!(default.r#type, Type::Reference(_)));
+}
+
+#[test]
+fn parses_method_with_static_return_templates_and_parameters() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @method static T find<T>(int $id, ?string $name = null) by id */");
+    let tag = first_tag(&document);
+
+    let TagValue::Method(method) = &tag.value else { panic!() };
+    assert!(method.r#static.is_some());
+    assert!(method.return_type.is_some());
+    assert_eq!(method.name.value, b"find");
+    assert!(method.templates.is_some());
+    assert_eq!(method.parameters.entries.len(), 2);
+}
+
+#[test]
+fn parses_method_without_return_type() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @method getName() */");
+    let tag = first_tag(&document);
+
+    let TagValue::Method(method) = &tag.value else { panic!() };
+    assert!(method.return_type.is_none());
+    assert_eq!(method.name.value, b"getName");
+    assert_eq!(method.parameters.entries.len(), 0);
+}
+
+#[test]
+fn parses_method_with_literal_parameter_type_and_grouped_default() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @method foo(int $a = 1, 'x'|'y' $b) */");
+    let tag = first_tag(&document);
+
+    let TagValue::Method(method) = &tag.value else { panic!("got {:?}", tag.value) };
+    assert_eq!(method.name.value, b"foo");
+
+    let entries: Vec<_> = method.parameters.entries.iter().collect();
+    assert_eq!(entries.len(), 2);
+
+    let Some(a_type) = entries[0].r#type else { panic!("expected a type") };
+    assert!(matches!(a_type, Type::Int(_)));
+    assert_eq!(entries[0].parameter.value, b"$a");
+    let Some(a_default) = &entries[0].default else { panic!("expected a default") };
+    assert!(matches!(a_default.value, ConstantExpression::Integer(_)));
+
+    let Some(b_type) = entries[1].r#type else { panic!("expected a type") };
+    assert!(matches!(b_type, Type::Union(_)));
+    assert_eq!(entries[1].parameter.value, b"$b");
+    assert!(entries[1].default.is_none());
+}
+
+#[test]
+fn parses_assert_property() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @phpstan-assert !null $this->value */");
+    let tag = first_tag(&document);
+
+    assert_eq!(tag.vendor, Some(TagVendor::PhpStan));
+    let TagValue::AssertProperty(assert) = &tag.value else { panic!("got {:?}", tag.value) };
+    assert!(assert.bang.is_some());
+    assert_eq!(assert.parameter.value, b"$this");
+    assert_eq!(assert.property.value, b"value");
+}
+
+#[test]
+fn parses_assert_method() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @psalm-assert Foo $this->bar() */");
+    let tag = first_tag(&document);
+
+    assert_eq!(tag.vendor, Some(TagVendor::Psalm));
+    let TagValue::AssertMethod(assert) = &tag.value else { panic!() };
+    assert_eq!(assert.method.value, b"bar");
+}
+
+#[test]
+fn parses_extends_with_generics() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @extends Collection<int, User> */");
+    let tag = first_tag(&document);
+
+    let TagValue::Extends(extends) = &tag.value else { panic!() };
+    assert!(matches!(extends.r#type, Type::Reference(_)));
+}
+
+#[test]
+fn parses_type_alias() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @phpstan-type UserId = int */");
+    let tag = first_tag(&document);
+
+    assert_eq!(tag.vendor, Some(TagVendor::PhpStan));
+    let TagValue::TypeAlias(alias) = &tag.value else { panic!() };
+    assert_eq!(alias.alias.value, b"UserId");
+    assert!(alias.equals.is_some());
+    assert!(matches!(alias.r#type, Type::Int(_)));
+}
+
+#[test]
+fn parses_type_alias_import() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @phpstan-import-type UserId from User as Id */");
+    let tag = first_tag(&document);
+
+    let TagValue::TypeAliasImport(import) = &tag.value else { panic!() };
+    assert_eq!(import.imported_alias.value, b"UserId");
+    assert_eq!(import.from_keyword.value, b"from");
+    assert_eq!(import.imported_from.value, b"User");
+    let Some(imported_as) = &import.imported_as else { panic!() };
+    assert_eq!(imported_as.keyword.value, b"as");
+    assert_eq!(imported_as.local.value, b"Id");
+}
+
+#[test]
+fn parses_inheritors_pipe_separated() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @inheritors A|B|C */");
+    let tag = first_tag(&document);
+
+    let TagValue::Inheritors(inheritors) = &tag.value else { panic!() };
+    assert_eq!(inheritors.inheritors.len(), 3);
+}
+
+#[test]
+fn parses_phan_vendor() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @phan-param int $x */");
+    let tag = first_tag(&document);
+
+    assert_eq!(tag.vendor, Some(TagVendor::Phan));
+    assert!(matches!(tag.value, TagValue::Param(_)));
+}
+
+#[test]
+fn parses_unknown_tag_as_generic() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @author Jane Doe <jane@example.com> */");
+    let tag = first_tag(&document);
+
+    assert_eq!(tag.name.value, b"author");
+    assert!(matches!(tag.value, TagValue::Generic(_)));
+}
+
+#[test]
+fn parses_deprecated_description_only() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @deprecated use bar() instead */");
+    let tag = first_tag(&document);
+
+    let TagValue::Deprecated(deprecated) = &tag.value else { panic!() };
+    assert_eq!(deprecated.description.value, b"use bar() instead");
+}
+
+#[test]
+fn parses_multiline_docblock_with_multiple_tags() {
+    let arena = Bump::new();
+    let source = b"/**\n * Summary line.\n *\n * @param int $a first\n * @param string $b second\n * @return bool\n */";
+    let document = parse(&arena, source);
+
+    let elements: Vec<&Element> = document.elements.iter().collect();
+    assert_eq!(elements.len(), 4);
+
+    let Element::Text(summary) = elements[0] else { panic!("expected text, got {:?}", elements[0]) };
+    assert_eq!(summary.value, b"Summary line.");
+
+    let Element::Tag(a) = elements[1] else { panic!("expected tag, got {:?}", elements[1]) };
+    let TagValue::Param(a) = &a.value else { panic!("expected param, got {:?}", a.value) };
+    assert!(matches!(a.r#type, Type::Int(_)));
+    assert_eq!(a.parameter.value, b"$a");
+    let Some(a_description) = a.description else { panic!("expected description") };
+    assert_eq!(a_description.value, b"first");
+
+    let Element::Tag(b) = elements[2] else { panic!("expected tag, got {:?}", elements[2]) };
+    let TagValue::Param(b) = &b.value else { panic!("expected param, got {:?}", b.value) };
+    assert!(matches!(b.r#type, Type::String(_)));
+    assert_eq!(b.parameter.value, b"$b");
+    let Some(b_description) = b.description else { panic!("expected description") };
+    assert_eq!(b_description.value, b"second");
+
+    let Element::Tag(ret) = elements[3] else { panic!("expected tag, got {:?}", elements[3]) };
+    let TagValue::Return(ret) = &ret.value else { panic!("expected return, got {:?}", ret.value) };
+    assert!(matches!(ret.r#type, Type::Bool(_)));
+    assert!(ret.description.is_none());
+}
+
+#[test]
+fn parses_where_tag_with_is_modifier() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @where T is int */");
+    let tag = first_tag(&document);
+
+    let TagValue::Where(where_clause) = &tag.value else { panic!("got {:?}", tag.value) };
+    assert_eq!(where_clause.name.value, b"T");
+    let WhereTagValueModifier::Is(keyword) = &where_clause.modifier else { panic!("expected is modifier") };
+    assert_eq!(keyword.value, b"is");
+    assert!(matches!(where_clause.r#type, Type::Int(_)));
+}
+
+#[test]
+fn parses_where_tag_with_colon_modifier() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @where T: string */");
+    let tag = first_tag(&document);
+
+    let TagValue::Where(where_clause) = &tag.value else { panic!("got {:?}", tag.value) };
+    assert_eq!(where_clause.name.value, b"T");
+    assert!(matches!(where_clause.modifier, WhereTagValueModifier::Colon(_)));
+    assert!(matches!(where_clause.r#type, Type::String(_)));
+}
+
+#[test]
+fn recovers_invalid_tag_value() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @param | */");
+    let tag = first_tag(&document);
+
+    assert!(matches!(tag.value, TagValue::Invalid(_)));
+}

--- a/crates/phpdoc-syntax/tests/trivia.rs
+++ b/crates/phpdoc-syntax/tests/trivia.rs
@@ -1,0 +1,136 @@
+use bumpalo::Bump;
+
+use mago_database::file::FileId;
+use mago_phpdoc_syntax::PHPDocParser;
+use mago_phpdoc_syntax::cst::Document;
+use mago_phpdoc_syntax::cst::Element;
+use mago_phpdoc_syntax::cst::TriviaKind;
+use mago_phpdoc_syntax::lexer::DocblockLexer;
+use mago_span::HasSpan;
+use mago_span::Position;
+use mago_syntax_core::input::Input;
+
+fn parse<'arena>(arena: &'arena Bump, source: &'arena [u8]) -> Document<'arena> {
+    PHPDocParser::parse(arena, FileId::zero(), source)
+}
+
+fn assert_every_token_is_accounted_for(source: &[u8]) {
+    let file_id = FileId::zero();
+
+    let input = Input::anchored_at(file_id, source, Position::new(0));
+    let mut lexer = DocblockLexer::new(input);
+    let mut token_spans = Vec::new();
+    while let Some(token) = lexer.advance() {
+        token_spans.push(token.span_for(file_id));
+    }
+
+    let arena = Bump::new();
+    let document = parse(&arena, source);
+
+    for span in token_spans {
+        let in_trivia = document
+            .trivia
+            .iter()
+            .any(|trivia| trivia.span.start.offset <= span.start.offset && span.end.offset <= trivia.span.end.offset);
+        let in_element = document.elements.iter().any(|element| {
+            let element = element.span();
+            element.start.offset <= span.start.offset && span.end.offset <= element.end.offset
+        });
+
+        assert!(
+            in_trivia || in_element,
+            "token at {}..{} is not part of the document (source: {:?})",
+            span.start.offset,
+            span.end.offset,
+            String::from_utf8_lossy(source),
+        );
+    }
+}
+
+#[test]
+fn every_source_token_is_accounted_for() {
+    assert_every_token_is_accounted_for(b"/** @param int $x */");
+    assert_every_token_is_accounted_for(b"/**\n * @return void\n */");
+    assert_every_token_is_accounted_for(b"/**\n * Summary.\n *\n * @param string $a first\n * @return bool\n */");
+    assert_every_token_is_accounted_for(b"/** @var array{a: int, b: string} $map the map */");
+    assert_every_token_is_accounted_for(b"/** @method static T find<T>(int $id, ?string $name = null) by id */");
+    assert_every_token_is_accounted_for(b"/** plain description with no tags */");
+    assert_every_token_is_accounted_for(b"/** @var int // trailing line comment */");
+    assert_every_token_is_accounted_for("/** @param string $مثال 中文描述 */".as_bytes());
+    assert_every_token_is_accounted_for(b"/** */");
+    assert_every_token_is_accounted_for(b"/** @var int */ trailing words after the marker");
+    assert_every_token_is_accounted_for(b"/** x */\n");
+}
+
+#[test]
+fn content_after_closing_marker_is_captured_as_trailing_trivia() {
+    let arena = Bump::new();
+    let source = b"/** @var int */ tail";
+    let document = parse(&arena, source);
+
+    assert_eq!(document.span.end.offset, source.len() as u32);
+
+    let elements: Vec<&Element> = document.elements.iter().collect();
+    assert_eq!(elements.len(), 1);
+    assert!(matches!(elements[0], Element::Tag(_)));
+
+    let Some(trailing) = document.trivia.iter().find(|trivia| trivia.kind == TriviaKind::Trailing) else {
+        panic!("expected trailing trivia after the closing marker")
+    };
+    assert_eq!(trailing.value, b" tail");
+}
+
+fn trivia_pairs<'arena>(document: &'arena Document<'arena>) -> Vec<(TriviaKind, &'arena [u8])> {
+    document.trivia.iter().map(|trivia| (trivia.kind, trivia.value)).collect()
+}
+
+#[test]
+fn captures_opening_closing_markers_asterisks_and_whitespace() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/**\n * @return void\n */");
+
+    assert_eq!(
+        trivia_pairs(&document),
+        vec![
+            (TriviaKind::OpeningMarker, b"/**".as_slice()),
+            (TriviaKind::Whitespace, b"\n ".as_slice()),
+            (TriviaKind::Asterisk, b"*".as_slice()),
+            (TriviaKind::Whitespace, b" ".as_slice()),
+            (TriviaKind::Whitespace, b" ".as_slice()),
+            (TriviaKind::Whitespace, b"\n ".as_slice()),
+            (TriviaKind::ClosingMarker, b"*/".as_slice()),
+        ]
+    );
+}
+
+#[test]
+fn captures_line_comments_as_trivia() {
+    let arena = Bump::new();
+    let document = parse(&arena, b"/** @var int // note */");
+
+    assert_eq!(
+        trivia_pairs(&document),
+        vec![
+            (TriviaKind::OpeningMarker, b"/** ".as_slice()),
+            (TriviaKind::Whitespace, b" ".as_slice()),
+            (TriviaKind::Whitespace, b" ".as_slice()),
+            (TriviaKind::LineComment, b"// note ".as_slice()),
+            (TriviaKind::ClosingMarker, b"*/".as_slice()),
+        ]
+    );
+}
+
+#[test]
+fn missing_markers_are_not_faked() {
+    let arena = Bump::new();
+    let source = b"@var int $x";
+    let document = parse(&arena, source);
+
+    assert_eq!(document.span.start.offset, 0);
+    assert_eq!(document.span.end.offset, source.len() as u32);
+
+    assert_eq!(
+        trivia_pairs(&document),
+        vec![(TriviaKind::Whitespace, b" ".as_slice()), (TriviaKind::Whitespace, b" ".as_slice())]
+    );
+}

--- a/crates/syntax-core/src/input.rs
+++ b/crates/syntax-core/src/input.rs
@@ -410,6 +410,52 @@ impl<'src> Input<'src> {
         (pos - start, false)
     }
 
+    /// Scans bytes starting at `offset_from_current` while they are members of `table`, without consuming.
+    /// Returns the length of the matching run.
+    #[inline(always)]
+    #[must_use]
+    pub fn scan_while(&self, offset_from_current: usize, table: &[bool; 256]) -> usize {
+        let bytes = self.bytes;
+        let len = self.length;
+        let start = self.offset + offset_from_current;
+        let mut pos = start;
+
+        while pos < len {
+            // SAFETY: `pos < len` was just checked.
+            let b = unsafe { *bytes.get_unchecked(pos) };
+            if !table[b as usize] {
+                break;
+            }
+
+            pos += 1;
+        }
+
+        pos.saturating_sub(start)
+    }
+
+    /// Scans bytes starting at `offset_from_current` until a whitespace byte is found, without consuming.
+    /// Returns the length of the non-whitespace run.
+    #[inline(always)]
+    #[must_use]
+    pub fn scan_until_whitespace(&self, offset_from_current: usize) -> usize {
+        let bytes = self.bytes;
+        let len = self.length;
+        let start = self.offset + offset_from_current;
+        let mut pos = start;
+
+        while pos < len {
+            // SAFETY: `pos < len` was just checked.
+            let b = unsafe { *bytes.get_unchecked(pos) };
+            if WHITESPACE_TABLE[b as usize] {
+                break;
+            }
+
+            pos += 1;
+        }
+
+        pos.saturating_sub(start)
+    }
+
     /// Reads the next `n` characters without advancing the position.
     ///
     /// # Arguments


### PR DESCRIPTION
A new docblock parser that is meant to replace both `mago-docblock` and `mago-type-syntax`. The parser does both jobs in one run. The CST from this parser, alongside PHP CST, will feed into the new `IR`.