### PR TITLE
fix(codex): stop flagging abstract mismatches in method patches

### DIFF
--- a/cases/patch_member_checks/analyzer.baseline.toml
+++ b/cases/patch_member_checks/analyzer.baseline.toml
@@ -12,11 +12,6 @@ end_line = 5
 
 [[entries."patch.php".issues]]
 code = "patch-method-structural-mismatch"
-start_line = 9
-end_line = 9
-
-[[entries."patch.php".issues]]
-code = "patch-method-structural-mismatch"
 start_line = 10
 end_line = 10
 

--- a/cases/patch_member_checks/patch.php
+++ b/cases/patch_member_checks/patch.php
@@ -7,7 +7,7 @@ abstract class VendorClass
     final const int ALLOW_ADDING_FINAL = 3;
     const int ALLOW_ADDING_TYPE = 4;
 
-    abstract public function disallowMakingAbstract(): void;
+    abstract public function allowMarkingAbstract(): void;
     public function disallowRemovingFinal(): void {}
     public static function disallowAddingStatic(): void {}
     public function disallowRemovingStatic(): void {}

--- a/cases/patch_member_checks/vendor.php
+++ b/cases/patch_member_checks/vendor.php
@@ -7,7 +7,7 @@ abstract class VendorClass
     const ALLOW_ADDING_FINAL = 3;
     const ALLOW_ADDING_TYPE = 4;
 
-    public function disallowMakingAbstract(): void {}
+    public function allowMarkingAbstract(): void {}
     final public function disallowRemovingFinal(): void {}
     public function disallowAddingStatic(): void {}
     public static function disallowRemovingStatic(): void {}

--- a/crates/codex/src/metadata/function_like.rs
+++ b/crates/codex/src/metadata/function_like.rs
@@ -421,31 +421,36 @@ impl FunctionLikeMetadata {
 
     /// Reports structural method-attribute mismatches.
     ///
-    /// For methods, visibility, abstract, static, and removing final are all structural
-    /// changes a patch may not make. Adding final is allowed. This is reported as an error
-    /// but does not abort the patch — type annotations are still applied.
+    /// For methods, visibility, static, and removing final are all structural changes a patch
+    /// may not make. Adding final is allowed. This is reported as an error but does not abort
+    /// the patch — type annotations are still applied.
+    ///
+    /// `abstract` is deliberately excluded: it is implied by writing the method with a trailing
+    /// `;` instead of a `{}` body — the idiomatic form for a signature-only type patch — rather
+    /// than being an explicit modifier the author chose. The patch never changes the original's
+    /// abstractness either way, so a difference is harmless and would only produce a spurious
+    /// error for the natural patch syntax.
     fn report_method_structural_mismatch(&self, patch: &mut FunctionLikeMetadata) {
         let (Some(patch_m), Some(base_m)) = (&patch.method_metadata, &self.method_metadata) else {
             return;
         };
 
         let visibility_mismatch = patch_m.visibility != base_m.visibility;
-        let abstract_mismatch = patch_m.is_abstract != base_m.is_abstract;
         let static_mismatch = patch_m.is_static != base_m.is_static;
         let final_removed = base_m.is_final && !patch_m.is_final;
 
-        if visibility_mismatch || abstract_mismatch || static_mismatch || final_removed {
+        if visibility_mismatch || static_mismatch || final_removed {
             patch.issues.push(
                 Issue::error(format!(
-                    "Patch for `{}` declares structural attributes (visibility, abstract, static, or \
+                    "Patch for `{}` declares structural attributes (visibility, static, or \
                      removing final) that differ from the original; only type annotations are applied.",
                     patch.original_name,
                 ))
                 .with_code(ScanningIssueKind::PatchMethodStructuralMismatch)
                 .with_annotation(Annotation::primary(patch.span))
                 .with_help(
-                    "Declare the method with the same visibility and the same `abstract`, \
-                     `static`, and `final` modifiers as the original (adding `final` is allowed); \
+                    "Declare the method with the same visibility and the same `static` and \
+                     `final` modifiers as the original (adding `final` is allowed); \
                      a patch may only refine the method's types.",
                 ),
             );

--- a/docs/content/en/guide/configuration.md
+++ b/docs/content/en/guide/configuration.md
@@ -235,7 +235,7 @@ Each of these is reported as a diagnostic on the patch file:
 - **Hierarchy.** `extends`, `implements`, `@require-extends`, and `@require-implements` need not be restated, but if restated must match the original exactly; a mismatch rejects the whole patch.
 - **Trait usage.** `use` trait statements are never valid in a patch.
 - **`readonly class` modifier** and **enum cases** are structural and cannot be changed.
-- **Member modifiers.** Visibility, `static`, `abstract`, property hooks, and removing `final` must match the original (adding `final` is allowed). On a mismatch the modifier change is ignored, but the refined types are still applied.
+- **Member modifiers.** Visibility, `static`, property hooks, and removing `final` must match the original (adding `final` is allowed). On a mismatch the modifier change is ignored, but the refined types are still applied. `abstract` is not enforced: a method patch may end in `;` (the natural signature-only form) or in a `{}` body regardless of the original, and the difference is silently ignored.
 - **Parameter count and names.** A method or function patch must declare the same parameters, in the same order, with the same names — types are mapped by position, so any divergence rejects the whole patch.
 
 ### Glob settings


### PR DESCRIPTION
## 📌 What Does This PR Do?

Drop abstract from the structural check; visibility, static, and removing final are still enforced.

## 🔍 Context & Motivation

`abstract` is implied by terminating a method with `;` instead of a `{}` body, which is the idiomatic way to write a signature-only type patch. Treating it like an explicit modifier means the natural patch form trips a structural-mismatch error against any concrete vendor method, even though a patch never changes the original's abstractness.

## 🛠️ Summary of Changes

- **Bug Fix:** Allow method patches to be `;` terminated.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): codex

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
