### PR TITLE
Fix: Make $extension parameter optional in phpversion()

### DIFF
--- a/crates/prelude/assets/extensions/standard.php
+++ b/crates/prelude/assets/extensions/standard.php
@@ -1148,7 +1148,7 @@ function phpinfo(int $flags = INFO_ALL): bool {}
  *
  * @return ($extension is null ? non-empty-string : non-empty-string|false)
  */
-function phpversion(?string $extension): string|false {}
+function phpversion(?string $extension = null): string|false {}
 
 function phpcredits(int $flags = CREDITS_ALL): bool {}
 


### PR DESCRIPTION
## 📌 What Does This PR Do?

As per the official PHP documentation, calling `phpversion()` without any arguments returns the current PHP version. The current codebase defines the parameter as nullable, but required.

This PR adds the missing `= null` default value to align the signature with native PHP behavior.


## 🔍 Context & Motivation

https://www.php.net/manual/en/function.phpversion.php

https://mago.carthage.software/1.30.0/en/playground/#019e984d-a6bd-9889-5ca9-8d1a496c9bf2

## 🛠️ Summary of Changes

* **Fix phpversion() Signature:** Added the missing `= null` default value to the `$extension` parameter.

## 📂 Affected Areas

- [X] Linter

## 🔗 Related Issues or PRs

Fixes #1950
