### PR TITLE
chore(docs): improve github actions setup and update versions

### DIFF
--- a/docs/content/en/recipes/github-actions.md
+++ b/docs/content/en/recipes/github-actions.md
@@ -25,22 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: "8.4"
-          coverage: none
-          tools: composer
-        env:
-          COMPOSER_ALLOW_SUPERUSER: 1
-
-      - name: Install Composer dependencies
-        run: composer install --prefer-dist --no-progress
+        uses: actions/checkout@v6
 
       - name: Set up Mago
-        uses: nhedger/setup-mago@v1
+        uses: nhedger/setup-mago@v2
 
       - name: Check formatting
         run: mago format --check
@@ -80,7 +68,7 @@ jobs:
       image: ghcr.io/carthage-software/mago:1
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check formatting
         run: mago fmt --check

--- a/docs/content/fr/recipes/github-actions.md
+++ b/docs/content/fr/recipes/github-actions.md
@@ -25,22 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: "8.4"
-          coverage: none
-          tools: composer
-        env:
-          COMPOSER_ALLOW_SUPERUSER: 1
-
-      - name: Install Composer dependencies
-        run: composer install --prefer-dist --no-progress
+        uses: actions/checkout@v6
 
       - name: Set up Mago
-        uses: nhedger/setup-mago@v1
+        uses: nhedger/setup-mago@v2
 
       - name: Check formatting
         run: mago format --check
@@ -80,7 +68,7 @@ jobs:
       image: ghcr.io/carthage-software/mago:1
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check formatting
         run: mago fmt --check

--- a/docs/content/zh/recipes/github-actions.md
+++ b/docs/content/zh/recipes/github-actions.md
@@ -25,22 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: "8.4"
-          coverage: none
-          tools: composer
-        env:
-          COMPOSER_ALLOW_SUPERUSER: 1
-
-      - name: Install Composer dependencies
-        run: composer install --prefer-dist --no-progress
+        uses: actions/checkout@v6
 
       - name: Set up Mago
-        uses: nhedger/setup-mago@v1
+        uses: nhedger/setup-mago@v2
 
       - name: Check formatting
         run: mago format --check
@@ -80,7 +68,7 @@ jobs:
       image: ghcr.io/carthage-software/mago:1
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check formatting
         run: mago fmt --check


### PR DESCRIPTION
## 📌 What Does This PR Do?

This PR updates the GitHub Actions quick setup recipe:

- Updates the version of the `nhedger/setup-mago` action to v2
- Updates the version of the `actions/checkout` action
- Removes the `shivammathur/setup-php` step
- Remove the Composer dependencies installation

## 🔍 Context & Motivation

- I released a new version of `setup-mago` that addresses GitHub Actions Node runtime deprecations.
- Assuming that linting and format checks run in their own job, it's unnecessary to install PHP or the Composer dependencies to run Mago. Remove these steps saves CI time.

<!-- Why is this change needed? Is it fixing a bug, adding a feature, or refactoring? -->

## 🛠️ Summary of Changes

- **Docs:** Updated GitHub Actions recipe.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [x] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

- https://github.com/nhedger/setup-mago/releases/tag/v2.0.0

<!-- Any extra context, concerns, or breaking changes? -->
