### PR TITLE
fix(analyzer): avoid duplicate diagnostics in compound conditions

### DIFF
--- a/crates/analyzer/src/utils/conditional.rs
+++ b/crates/analyzer/src/utils/conditional.rs
@@ -85,9 +85,21 @@ where
 
     let was_inside_conditional = externally_applied_context.flags.inside_conditional();
 
+    // When the second pass below runs it re-covers everything this pass touches, so record and
+    // discard this pass's diagnostics to avoid reporting them twice; its type/data-flow effects
+    // are kept regardless.
+    let must_reanalyze_full_condition =
+        internally_applied_if_cond_expr != condition || externally_applied_if_cond_expr != condition;
+
     externally_applied_context.flags.set_inside_conditional(true);
     let tmp_if_body_context = std::mem::take(&mut externally_applied_context.if_body_context);
+    if must_reanalyze_full_condition {
+        context.collector.start_recording();
+    }
     externally_applied_if_cond_expr.analyze(context, &mut externally_applied_context, artifacts)?;
+    if must_reanalyze_full_condition {
+        context.collector.finish_recording();
+    }
     externally_applied_context.if_body_context = tmp_if_body_context;
 
     let first_cond_assigned_var_ids = externally_applied_context.assigned_variable_ids.clone();
@@ -108,7 +120,7 @@ where
     let post_if_context = externally_applied_context.clone();
     let mut conditionally_referenced_variable_ids;
     let assigned_in_conditional_variable_ids;
-    if internally_applied_if_cond_expr != condition || externally_applied_if_cond_expr != condition {
+    if must_reanalyze_full_condition {
         if_conditional_context.assigned_variable_ids = WordMap::default();
         if_conditional_context.conditionally_referenced_variable_ids.clear();
 

--- a/crates/analyzer/tests/cases/issue_1569_strict.php
+++ b/crates/analyzer/tests/cases/issue_1569_strict.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  */
 function test_consistent_warn_expected(array $o): void
 {
-    /** @mago-expect analysis:possibly-undefined-string-array-index,possibly-undefined-string-array-index */
+    /** @mago-expect analysis:possibly-undefined-string-array-index */
     if ($o['x_1'] || $o['x_2']) {
         /** @mago-expect analysis:possibly-undefined-string-array-index */
         if ($o['x_1']) {

--- a/crates/analyzer/tests/cases/issue_1815.php
+++ b/crates/analyzer/tests/cases/issue_1815.php
@@ -3,7 +3,7 @@
 /**
  * @param array<int|string, array{float, string}> $cache
  *
- * @mago-expect analysis:possibly-invalid-operand(2)
+ * @mago-expect analysis:possibly-invalid-operand
  */
 function cache_put(array &$cache, int $max, int|string $key, string $val): void
 {


### PR DESCRIPTION
## 📌 What Does This PR Do?

avoid duplicate diagnostics in compound conditions

## 🔍 Context & Motivation

issues in the first half of short-circuit compound expressions are reported twice.

## 🛠️ Summary of Changes

- **Bug Fix:** avoid duplicate diagnostics in compound conditions

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): analyzer

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
