### PR TITLE
fix(analyzer): don't report trait property conflicts against @property tags

### DIFF
--- a/crates/analyzer/src/statement/class_like/mod.rs
+++ b/crates/analyzer/src/statement/class_like/mod.rs
@@ -2369,6 +2369,12 @@ fn check_trait_property_conflicts<'ctx, 'ast, 'arena, A>(
 
     let mut class_properties: IndexMap<Word, &PropertyMetadata> = IndexMap::new();
     for (property_name, property_metadata) in class_like_metadata.properties.iter().sorted_by_key(|(k, _)| *k) {
+        // Magic properties (from `@property` docblock tags) are not real declarations and
+        // never participate in PHP's trait composition, so they cannot conflict with a trait property.
+        if property_metadata.flags.is_magic_property() {
+            continue;
+        }
+
         if let Some(declaring_class) = class_like_metadata.declaring_property_ids.get(property_name)
             && declaring_class == &class_like_metadata.name
         {

--- a/crates/analyzer/tests/cases/trait_class_property_conflicts.php
+++ b/crates/analyzer/tests/cases/trait_class_property_conflicts.php
@@ -116,3 +116,24 @@ class C8
     public readonly string $prop = '';
     use T9;
 }
+
+// Test 9: Magic @property tag vs trait property (OK)
+// PHP: No error - magic properties are not real declarations and do not
+// participate in trait composition.
+trait T10
+{
+    protected int $prop;
+}
+
+/**
+ * @property int $prop
+ */
+class C9
+{
+    use T10;
+
+    public function __get(string $name): int
+    {
+        return $this->prop;
+    }
+}


### PR DESCRIPTION
## 📌 What Does This PR Do?

Disable bogus reports about visibility mismatch conflicts

## 🔍 Context & Motivation

A class can declare a magic property via a `@property` docblock tag while also using a trait that declares a real property of the same name. Magic properties default to public read/write visibility, so the trait property conflict check compares them against the trait's declaration and reports a spurious `incompatible-property-visibility` error, claiming PHP will raise a fatal error.

Magic properties are not real declarations and never participate in PHP's trait composition, so they cannot conflict with a trait property. Skip them when collecting the class's own properties for the conflict check.

## 🛠️ Summary of Changes

- **Bug Fix:** don't report trait property conflicts against @property tags

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): analyzer

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
