### PR TITLE
fix(prelude): add default values to `ZipArchive->addEmptyDir()`,`xml_parser_create()` and `ini_get_all()`

### DIFF
--- a/crates/prelude/assets/extensions/standard.php
+++ b/crates/prelude/assets/extensions/standard.php
@@ -2806,7 +2806,7 @@ function ini_get(string $option): string|false {}
 /**
  * @return array{'global_value': string, 'local_value': string, 'access': int}|false
  */
-function ini_get_all(?string $extension, bool $details = true): array|false {}
+function ini_get_all(?string $extension = null, bool $details = true): array|false {}
 
 function ini_set(string $option, string|int|float|bool|null $value): string|false {}
 

--- a/crates/prelude/assets/extensions/xml.php
+++ b/crates/prelude/assets/extensions/xml.php
@@ -5,7 +5,7 @@ final class XMLParser {}
 /**
  * @pure
  */
-function xml_parser_create(?string $encoding): XMLParser {}
+function xml_parser_create(?string $encoding = null): XMLParser {}
 
 /**
  * @pure

--- a/crates/prelude/assets/extensions/zip.php
+++ b/crates/prelude/assets/extensions/zip.php
@@ -240,7 +240,7 @@ class ZipArchive implements Countable
 
     public function getStatusString(): string {}
 
-    public function addEmptyDir(string $dirname, int $flags): bool {}
+    public function addEmptyDir(string $dirname, int $flags = 0): bool {}
 
     public function addFromString(string $name, string $content, int $flags = 8192): bool {}
 


### PR DESCRIPTION
## 📌 What Does This PR Do?
This pull request updates several function signatures in the PHP extension stubs to provide default values for optional parameters.

## 🔍 Context & Motivation

- https://mago.carthage.software/1.30.0/en/playground/#019eb229-ec27-9e45-6e66-cd26ad7d3e75

- https://www.php.net/manual/en/function.xml-parser-create.php
- https://www.php.net/manual/en/function.ini-get-all.php
- https://www.php.net/manual/de/ziparchive.addemptydir.php

## 🛠️ Summary of Changes

- **Bug Fix:** Make $extension parameter optional in ini_get_all()
- **Bug Fix:** Make $encoding parameter optional in xml_parser_create()
- **Bug Fix:** Make $flags parameter optional in ZipArchive->addEmptyDir()
- 
## 📂 Affected Areas

- [x] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
