### PR TITLE
Introduced `packages.<system>.default`, which contains `bin/mago`

### DIFF
--- a/docs/content/en/guide/installation.md
+++ b/docs/content/en/guide/installation.md
@@ -122,6 +122,27 @@ winget install CarthageSoftware.Mago
 mago self-update
 ```
 
+### Nixpkgs / NixOS
+
+[Nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ma/mago/package.nix) distributes pre-built
+Mago derivations:
+
+```sh
+nix-shell -p mago
+mago --version
+```
+
+### Nix Flake
+
+You can run and build Mago yourself via [Nix flakes](https://nixos.wiki/wiki/flakes):
+
+```sh
+nix run git+https://github.com/carthage-software/mago -- --version
+```
+
+Note: the Mago main repository relies on `.gitattributes` for distribution, so you have to use `git+https`
+in order to get all the files necessary for Mago to compile.
+
 ### Cargo
 
 Crates.io publishing can lag a few hours behind a release. Same pattern as Homebrew, and WinGet.

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,48 @@
 {
   "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1781086641,
+        "narHash": "sha256-2oBncBeL671Tf6TnYqk36ebkfPHNYPKwz5at8NcrpvI=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "640606300f74b4891bfa1a51f5756450f9fdc7f1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "fenix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "naersk",
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src_2"
+      },
+      "locked": {
+        "lastModified": 1752475459,
+        "narHash": "sha256-z6QEu4ZFuHiqdOPbYss4/Q8B0BFhacR8ts6jO/F/aOU=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "bf0d6f70f4c9a9cf8845f992105652173f4b617f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -15,6 +58,27 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "fenix": "fenix_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780932914,
+        "narHash": "sha256-3TJ7skmzAeBRkOihfHSWye7Fkuc1gP01dwa/EX1EA/E=",
+        "owner": "nmattia",
+        "repo": "naersk",
+        "rev": "10d02d63fa3f296786d27f3a35a9926ee3fa6df0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nmattia",
+        "repo": "naersk",
         "type": "github"
       }
     },
@@ -36,8 +100,44 @@
     },
     "root": {
       "inputs": {
+        "fenix": "fenix",
         "flake-utils": "flake-utils",
+        "naersk": "naersk",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781005730,
+        "narHash": "sha256-3Bn47a+Vs2/ltQfTU2ApWqy5kYNmF+RaTEJs0A/H2pA=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "587ce15e272b94d4f0a69d695e3718a02c24667e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "rust-analyzer-src_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1752428706,
+        "narHash": "sha256-EJcdxw3aXfP8Ex1Nm3s0awyH9egQvB2Gu+QEnJn2Sfg=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "591e3b7624be97e4443ea7b5542c191311aa141d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,17 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    naersk = {
+      url = "github:nmattia/naersk";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, flake-utils, fenix, naersk }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };
@@ -14,8 +22,29 @@
         toolchain = "1.96.0";
         php = pkgs.php84;
         composer = pkgs.php84Packages.composer;
+        toolchain' = with fenix.packages.${system};
+          combine [
+            minimal.rustc
+            minimal.cargo
+            stable.rust-src
+            stable.rustfmt
+            stable.clippy
+            stable.rust-analyzer
+          ];
+
+        naersk' = naersk.lib.${system}.override {
+          cargo = toolchain';
+          rustc = toolchain';
+        };
+        
+        built = naersk'.buildPackage {
+          src = ./.;
+          doCheck = true;
+          copyLibs = true;
+        };
       in
       {
+        packages.default = built;
         devShells.default = pkgs.mkShell {
           buildInputs = [
             pkgs.rustup


### PR DESCRIPTION
## 📌 What Does This PR Do?

Introduced `packages.<system>.default` in flake outputs, which contains `bin/mago`

Note: this introduces two flake dependencies

* `fenix`, which is used to get the latest stable rust toolchain (can probably be simplified)
* `naersk`, which, given a toolchain, runs actual `rustc` compilation

Documentation on how to grab Mago from Nixpkgs or via Flake has also been added.

Usage:

```console
nix flake show
git+file:///home/ocramius/Documents/carthage-software/mago
├───devShells
│   ├───aarch64-darwin
│   │   └───default omitted (use '--all-systems' to show)
│   ├───aarch64-linux
│   │   └───default omitted (use '--all-systems' to show)
│   ├───x86_64-darwin
│   │   └───default omitted (use '--all-systems' to show)
│   └───x86_64-linux
│       └───default: development environment 'nix-shell'
└───packages
    ├───aarch64-darwin
    │   └───default omitted (use '--all-systems' to show)
    ├───aarch64-linux
    │   └───default omitted (use '--all-systems' to show)
    ├───x86_64-darwin
    │   └───default omitted (use '--all-systems' to show)
    └───x86_64-linux
        └───default: package 'mago-1.30.0'
```

```console
nix build .#
ls -lah result/
dr-xr-xr-x     2 root root     3 Jan  1  1970 bin
dr-xr-xr-x     2 root root     2 Jan  1  1970 lib
```

```console
./result/bin/mago --version
mago 1.30.0
```


## 🔍 Context & Motivation

Couldn't use the Mago composer distribution due to dynamic linking: this introduces flake builds, which ensures that all dependencies are referenced statically.

A full static build is also possible (subsequent step?)

## 🛠️ Summary of Changes

- **Feature:** added `packages.<system>.default` to flake outputs
- **Docs:** Added references for getting Mago as a Nix flake, or from Nixpkgs

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [x] Dependencies
- [x] Documentation
- [x] Other (please specify): build process
