### PR TITLE
support patches arg in language server

### DIFF
--- a/src/language_server/state.rs
+++ b/src/language_server/state.rs
@@ -293,5 +293,13 @@ fn build_database_configuration(root: &Path, configuration: &Configuration) -> D
         })
         .collect();
 
-    DatabaseConfiguration { workspace, paths, includes, excludes, extensions, glob: source.glob.to_database_settings() }
+    DatabaseConfiguration {
+        workspace,
+        paths,
+        includes,
+        excludes,
+        extensions,
+        patches: Vec::new(),
+        glob: source.glob.to_database_settings(),
+    }
 }


### PR DESCRIPTION
## 📌 What Does This PR Do?

Supports new patches field on DatabaseConfiguration for the language_server allowing it to build in its respective working branch

## 🔍 Context & Motivation

Fails to build otherwise

```
error[E0063]: missing field `patches` in initializer of `DatabaseConfiguration<'_>`
   --> src/language_server/state.rs:296:5
    |
296 |     DatabaseConfiguration { workspace, paths, includes, excludes, extensions, glob: source.glob.to_database_settings() }
    |     ^^^^^^^^^^^^^^^^^^^^^ missing `patches`

For more information about this error, try `rustc --explain E0063`.
```

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed missing field patches


## 📂 Affected Areas

- [X] CLI

## 📝 Notes for Reviewers

Note: the parent for this is feat/language-server
