### PR TITLE
fix(prelude): Add non-empty-string handler for `base64_encode`

### DIFF
--- a/crates/prelude/assets/extensions/standard.php
+++ b/crates/prelude/assets/extensions/standard.php
@@ -1968,6 +1968,8 @@ function base64_decode(string $string, bool $strict = false): string|false {}
 
 /**
  * @pure
+ *
+ * @return ($string is non-empty-string ? non-empty-string : '')
  */
 function base64_encode(string $string): string {}
 


### PR DESCRIPTION
## 📌 What Does This PR Do?

Update the typings of the `base64_encode` function to return `non-empty-string` if the input is known statically to be a `non-empty-string`

## 🔍 Context & Motivation

PHPStan supports this case https://phpstan.org/r/6480683e-e927-4f39-ac87-77e2d2375f59

## 🛠️ Summary of Changes



## 📂 Affected Areas

- [x] Analyzer 
- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs



## 📝 Notes for Reviewers


