### PR TITLE
fix(prelude): correct pcre stubs for preg_match_all and preg_replace_callback_array

### DIFF
--- a/crates/prelude/assets/extensions/pcre.php
+++ b/crates/prelude/assets/extensions/pcre.php
@@ -48,15 +48,13 @@ function preg_match(string $pattern, string $subject, &$matches = [], int $flags
 
 /**
  * @param-out list<array<string>> $matches
- *
- * @pure
  */
-function preg_match_all(string $pattern, string $subject, &$matches, int $flags = 0, int $offset = 0): int|false {}
+function preg_match_all(string $pattern, string $subject, &$matches = null, int $flags = 0, int $offset = 0): int|false {}
 
 /**
  * @param string|array<string> $pattern
- * @param string|array<string> $replacement <p>
- * @param string|array<string> $subject <p>
+ * @param string|array<string> $replacement
+ * @param string|array<string> $subject
  *
  * @param-out int $count
  *
@@ -91,12 +89,12 @@ function preg_replace_callback(
 ): array|string|null {}
 
 /**
- * @param array<(callable(array<string>): string)> $pattern
+ * @param array<string, (callable(array<string>): string)> $pattern
  * @param string|array<string> $subject
  *
  * @param-out int $count
  *
- * @return ($subject is string ? string|false : array<string>|false)
+ * @return ($subject is string ? string|null : array<string>|null)
  */
 function preg_replace_callback_array(
     array $pattern,


### PR DESCRIPTION
## 📌 What Does This PR Do?

Aligns the PCRE stubs in `crates/prelude/assets/extensions/pcre.php` with the official PHP documentation, fixing an incorrect purity annotation and a wrong error-return type.

## 🔍 Context & Motivation

While reviewing the PCRE prelude stubs against the PHP manual, a few inaccuracies surfaced that can lead to wrong analysis results: `preg_match_all` was marked `@pure` despite writing to a by-reference parameter, and `preg_replace_callback_array` declared `false` as its error return although it actually returns `null`.

## 🛠️ Summary of Changes

- **Bug Fix:** `preg_replace_callback_array` now returns `null` instead of `false` on error, matching its declared return type (`array|string|null`) and the behavior of `preg_replace`/`preg_filter`.
- **Bug Fix:** Removed the incorrect `@pure` annotation from `preg_match_all` (it mutates `$matches` by reference; its sibling `preg_match` is correctly not pure) and added the missing `$matches = null` default.
- **Refactor:** Keyed the `$pattern` array of `preg_replace_callback_array` by `string` (`array<string, callable(...)>`), since the array keys are the pattern strings.
- **Docs:** Removed leftover `<p>` fragments from the `preg_replace` docblock.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Prelude / built-in PHP stubs (`crates/prelude`)

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

Stub-only change — no runtime behavior is affected. Signatures and return types were verified against the official PHP manual.