### PR TITLE
fix(prelude): preserve element type in array_splice return type

### DIFF
--- a/crates/analyzer/tests/cases/arrays_array_splice_list.php
+++ b/crates/analyzer/tests/cases/arrays_array_splice_list.php
@@ -2,6 +2,27 @@
 
 declare(strict_types=1);
 
+final class ArraySpliceItem {}
+
+/**
+ * @param ArraySpliceItem ...$items
+ */
+function array_splice_consume(ArraySpliceItem ...$items): void {}
+
+/**
+ * The canonical reproduction: array_splice() returns the removed elements, and
+ * spreading them into a typed variadic must not report a false-positive
+ * `mixed-argument`.
+ *
+ * @param list<ArraySpliceItem> $items
+ */
+function array_splice_spread(array $items): void
+{
+    $removed = array_splice($items, 0, 1);
+
+    array_splice_consume(...$removed);
+}
+
 /**
  * @param list<int> $xs
  * @return list<int>

--- a/crates/analyzer/tests/cases/arrays_array_splice_list.php
+++ b/crates/analyzer/tests/cases/arrays_array_splice_list.php
@@ -10,10 +10,6 @@ final class ArraySpliceItem {}
 function array_splice_consume(ArraySpliceItem ...$items): void {}
 
 /**
- * The canonical reproduction: array_splice() returns the removed elements, and
- * spreading them into a typed variadic must not report a false-positive
- * `mixed-argument`.
- *
  * @param list<ArraySpliceItem> $items
  */
 function array_splice_spread(array $items): void

--- a/crates/analyzer/tests/cases/arrays_array_splice_list.php
+++ b/crates/analyzer/tests/cases/arrays_array_splice_list.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @param list<int> $xs
+ * @return list<int>
+ */
+function cut_first_two(array $xs): array
+{
+    return array_splice($xs, 0, 2);
+}
+
+/**
+ * @param array<string, int> $map
+ * @return int
+ */
+function cut_and_sum(array $map): int
+{
+    $removed = array_splice($map, 0, 2);
+
+    $total = 0;
+    foreach ($removed as $value) {
+        $total += $value;
+    }
+
+    return $total;
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -104,6 +104,7 @@ test_case!(arrays_array_reverse_list);
 test_case!(arrays_array_search);
 test_case!(arrays_array_shift);
 test_case!(arrays_array_slice_list);
+test_case!(arrays_array_splice_list);
 test_case!(arrays_array_sum);
 test_case!(arrays_array_unique);
 test_case!(arrays_array_unshift);

--- a/crates/prelude/assets/extensions/standard.php
+++ b/crates/prelude/assets/extensions/standard.php
@@ -4661,6 +4661,8 @@ function array_unshift(array &$array, mixed ...$values): int {}
  *   )
  * ) $array
  *
+ * @return ($array is list<InputValue> ? list<InputValue> : array<InputKey, InputValue>)
+ *
  * @pure
  */
 function array_splice(array &$array, int $offset, ?int $length = null, mixed $replacement = []): array {}


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes a false positive in the analyzer: `array_splice()` no longer loses the element type of its input array. The return value now preserves the element type the same way `array_slice()` already does.

## 🔍 Context & Motivation

`array_splice()` returns the *removed* elements, but its stub had no `@return` tag, only a `@param-out` describing the by-ref *modified* `$array`. The return type therefore fell back to the bare `: array` declaration, which the analyzer widens to `array<array-key, mixed>`, discarding the element type.

As a result, code that captures and reuses the removed elements (the common "cut here, paste there" pattern) got false-positive `mixed-*` errors downstream, while `array_slice()`, which has a conditional `@return`, did not. The two functions disagreed even though both return a sub-array of the same element type.

## 🛠️ Summary of Changes

- **Bug Fix:** Added a `@return` to the `array_splice()` stub that preserves the element type, mirroring `array_slice()`. PHP reindexes integer keys but preserves string keys in the removed-elements result (the default `preserve_keys = false` behaviour), so the return type is: `($array is list<InputValue> ? list<InputValue> : array<InputKey, InputValue>)`.
- **Tests:** Added `arrays_array_splice_list.php` (registered in `crates/analyzer/tests/mod.rs`) covering the canonical issue reproduction (spreading the removed elements into a typed variadic, `consume(...$removed)`), plus a list "cut here, paste there" pattern and an associative-array capture-and-reuse pattern.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Prelude stubs / Analyzer type inference

## 🔗 Related Issues or PRs

Fixes #1982

## 📝 Notes for Reviewers