### PR TITLE
fix(type-syntax): import Arena trait in parser fuzz target

### DIFF
--- a/crates/type-syntax/fuzz/fuzz_targets/parser.rs
+++ b/crates/type-syntax/fuzz/fuzz_targets/parser.rs
@@ -3,6 +3,7 @@
 #![no_main]
 #![allow(deprecated)]
 
+use mago_allocator::Arena;
 use mago_allocator::LocalArena;
 use libfuzzer_sys::fuzz_target;
 


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes the `type-syntax` parser fuzz target, which currently fails to compile. This breaks the "Fuzz / type-syntax / parser" CI check on every PR.

## 🔍 Context & Motivation

`crates/type-syntax/fuzz/fuzz_targets/parser.rs` calls `arena.alloc_slice_copy(data)`, but `alloc_slice_copy` is a method of the `mago_allocator::Arena` trait, which was not imported. In Rust, trait methods are only callable via dot-syntax when the trait is in scope, so the build failed with `error[E0599]: no method named alloc_slice_copy found for struct LocalArena` ("trait `Arena` is implemented but not in scope; perhaps you want to import it"). The regression came from 898f1dcf ("chore(type-syntax): deprecate parsing entry points in favor of mago-phpdoc-syntax"), which moved `alloc_slice_copy` onto the `Arena` trait without updating the fuzz target.

## 🛠️ Summary of Changes

- **Bug Fix:** Added `use mago_allocator::Arena;` to `crates/type-syntax/fuzz/fuzz_targets/parser.rs` so the `alloc_slice_copy` trait method resolves again.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Fuzz targets / CI

## 🔗 Related Issues or PRs

N/A

## 📝 Notes for Reviewers

One-line import fix. The sibling target `lexer.rs` does not need it (it doesn't use `alloc_slice_copy`). Verified locally with `cargo check --manifest-path crates/type-syntax/fuzz/Cargo.toml --bin parser`, which now finishes cleanly (the E0599 error is gone).