### PR TITLE
fix(analyzer): correct foreach always-entered inference for unions

### DIFF
--- a/crates/analyzer/src/statement/loop/mod.rs
+++ b/crates/analyzer/src/statement/loop/mod.rs
@@ -1368,7 +1368,7 @@ where
         );
     }
 
-    let mut has_at_least_one_entry = false;
+    let mut always_enters_loop = true;
     let mut key_type = None;
     let mut value_type = None;
     let mut has_valid_iterable_type = false;
@@ -1382,11 +1382,13 @@ where
         };
 
         match iterator_atomic {
-            TAtomic::Null | TAtomic::Scalar(TScalar::Bool(TBool { value: Some(false) })) => {}
+            TAtomic::Null | TAtomic::Scalar(TScalar::Bool(TBool { value: Some(false) })) => {
+                always_enters_loop = false;
+            }
             TAtomic::Array(array) => {
                 has_valid_iterable_type = true;
-                if array.is_non_empty() {
-                    has_at_least_one_entry = true;
+                if !array.is_non_empty() {
+                    always_enters_loop = false;
                 }
 
                 let (k, v) = get_array_parameters(array, context.codebase);
@@ -1396,7 +1398,7 @@ where
             }
             TAtomic::Iterable(iterable) => {
                 has_valid_iterable_type = true;
-                has_at_least_one_entry = false;
+                always_enters_loop = false;
 
                 key_type = Some(add_optional_union_type(
                     iterable.key_type.as_ref().clone(),
@@ -1413,6 +1415,8 @@ where
             TAtomic::Object(object) => {
                 let (obj_key_type, obj_value_type) = match object {
                     TObject::Any | TObject::WithProperties(_) | TObject::HasMethod(_) | TObject::HasProperty(_) => {
+                        always_enters_loop = false;
+
                         context.collector.report_with_code(
                             IssueCode::GenericObjectIteration,
                             Issue::warning("Iterating over a generic `object`. This will iterate its public properties.")
@@ -1424,6 +1428,8 @@ where
                         (get_string(), get_mixed())
                     }
                     TObject::Named(atomic_object) => {
+                        always_enters_loop = false;
+
                         if let Some((k, v)) = get_iterable_parameters(iterator_atomic, context.codebase) {
                             (k, v)
                         } else {
@@ -1448,8 +1454,6 @@ where
                         }
                     }
                     TObject::Enum(enum_instance) => {
-                        has_at_least_one_entry = true;
-
                         let enum_name = enum_instance.get_name();
                         let enum_backing_type = context
                             .codebase
@@ -1562,7 +1566,7 @@ where
     }
     // every atomic in the iterator type is iterable; no diagnostic needed
 
-    Ok((has_at_least_one_entry, key_type.unwrap_or_else(get_mixed), value_type.unwrap_or_else(get_mixed)))
+    Ok((always_enters_loop, key_type.unwrap_or_else(get_mixed), value_type.unwrap_or_else(get_mixed)))
 }
 
 /// Removes generic keyed arrays from a union when their value parameter shape is a

--- a/crates/analyzer/tests/cases/loops_foreach_union_cast_not_always_entered.php
+++ b/crates/analyzer/tests/cases/loops_foreach_union_cast_not_always_entered.php
@@ -42,3 +42,24 @@ function foreach_iterable_may_be_empty(iterable $items): string
 
     return (string) count($seen);
 }
+
+/**
+ * Regression guard for the opposite direction: casting a *pure* `string` to array
+ * always yields a one-element array, so the loop genuinely always runs and `$cols`
+ * is truly non-empty afterwards. The `impossible-condition` warning must still fire
+ * here — the fix must not over-suppress legitimate cases.
+ */
+function foreach_pure_string_cast_always_enters(string $fn): string
+{
+    $cols = [];
+    foreach ((array) $fn as $f) {
+        $cols[] = $f;
+    }
+
+    /** @mago-expect analysis:impossible-condition */
+    if (!$cols) {
+        return '';
+    }
+
+    return implode(',', $cols);
+}

--- a/crates/analyzer/tests/cases/loops_foreach_union_cast_not_always_entered.php
+++ b/crates/analyzer/tests/cases/loops_foreach_union_cast_not_always_entered.php
@@ -3,10 +3,8 @@
 declare(strict_types=1);
 
 /**
- * Iterating `(array) $fn` where `$fn` is `string|array<string>` is NOT guaranteed
- * to enter the loop: if `$fn` is an empty array the body never runs, so `$cols`
- * can still be empty afterwards. The `if (!$cols)` check must not be flagged as an
- * impossible condition.
+ * `(array) $fn` with `$fn: string|array<string>` is not guaranteed to enter the
+ * loop (an empty array skips the body), so `if (!$cols)` is reachable.
  *
  * @param string|array<string> $fn
  */
@@ -25,7 +23,7 @@ function foreach_union_cast(array|string $fn): string
 }
 
 /**
- * A generic `iterable` may be empty too, so the loop is not guaranteed to enter.
+ * A generic `iterable` may be empty, so the loop is not guaranteed to enter.
  *
  * @param iterable<int> $items
  */
@@ -44,10 +42,8 @@ function foreach_iterable_may_be_empty(iterable $items): string
 }
 
 /**
- * Regression guard for the opposite direction: casting a *pure* `string` to array
- * always yields a one-element array, so the loop genuinely always runs and `$cols`
- * is truly non-empty afterwards. The `impossible-condition` warning must still fire
- * here — the fix must not over-suppress legitimate cases.
+ * Opposite direction: a *pure* string cast always yields a one-element array, so
+ * the loop always runs — `impossible-condition` must still fire (no over-suppression).
  */
 function foreach_pure_string_cast_always_enters(string $fn): string
 {

--- a/crates/analyzer/tests/cases/loops_foreach_union_cast_not_always_entered.php
+++ b/crates/analyzer/tests/cases/loops_foreach_union_cast_not_always_entered.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Iterating `(array) $fn` where `$fn` is `string|array<string>` is NOT guaranteed
+ * to enter the loop: if `$fn` is an empty array the body never runs, so `$cols`
+ * can still be empty afterwards. The `if (!$cols)` check must not be flagged as an
+ * impossible condition.
+ *
+ * @param string|array<string> $fn
+ */
+function foreach_union_cast(array|string $fn): string
+{
+    $cols = [];
+    foreach ((array) $fn as $f) {
+        $cols[] = $f;
+    }
+
+    if (!$cols) {
+        return '';
+    }
+
+    return implode(',', $cols);
+}
+
+/**
+ * A generic `iterable` may be empty too, so the loop is not guaranteed to enter.
+ *
+ * @param iterable<int> $items
+ */
+function foreach_iterable_may_be_empty(iterable $items): string
+{
+    $seen = [];
+    foreach ($items as $item) {
+        $seen[] = $item;
+    }
+
+    if (!$seen) {
+        return 'empty';
+    }
+
+    return (string) count($seen);
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -69,6 +69,7 @@ test_case!(list_destructure_string_key_in_known_items);
 test_case!(list_destructure_string_key_in_union);
 test_case!(list_destructure_string_key_simple);
 test_case!(list_destructure_with_holes_no_warn);
+test_case!(loops_foreach_union_cast_not_always_entered);
 test_case!(array_map_non_empty_array);
 test_case!(array_map_non_empty_list);
 test_case!(array_shape_fields);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes a false-positive `impossible-condition` reported after a `foreach` loop whose iterator is a union type with a possibly-empty member.

## 🔍 Context & Motivation

Reported in #1986. This minimal reproduction is flagged incorrectly:

```php
/**
 * @param string|array<string> $fn
 */
function test(array|string $fn): string
{
    $cols = [];
    foreach ((array) $fn as $f) {
        $cols[] = $f;
    }

    // false positive: "This condition (type `false`) will always evaluate to false."
    if (!$cols) {
        return '';
    }

    return implode(',', $cols);
}
```

For `test([])` the array is empty, the loop body never runs, and `$cols` stays `[]`, so `!$cols` is genuinely reachable. The root cause is in `analyze_iterator` (`crates/analyzer/src/statement/loop/mod.rs`). It decided whether a `foreach` is guaranteed to execute at least once by OR-ing over the iterator union's atomics: a single non-empty member set the flag and possibly-empty members never cleared it. `(array) (string|array<string>)` is `non-empty-list<string> | array<string>`, so the non-empty-list arm (from casting the `string`) set the flag, the loop was treated as always-entered, and `$cols` was inferred non-empty afterwards.

## 🛠️ Summary of Changes

- **Bug Fix:** Invert the always-entered computation to AND-semantics: the loop is only guaranteed to enter when every atomic is a known-non-empty iterable. Possibly-empty members (empty/possibly-empty array, generic `iterable`, `null`/`false`, generic object/`Traversable`) clear the guarantee; non-empty arrays and enum-case instances leave it intact. Renamed the local from `has_at_least_one_entry` to `always_enters_loop` to match the name already used at the call site and throughout the loop module.
- **Tests:** Added `loops_foreach_union_cast_not_always_entered.php` (registered in `crates/analyzer/tests/mod.rs`) covering both directions: the union-cast and generic-`iterable` cases must stay clean, and a pure-`string` cast must *still* report `impossible-condition` (asserted via `@mago-expect`), guarding against over-suppression.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Analyzer (control-flow / type inference)

## 🔗 Related Issues or PRs

Closes #1986

## 📝 Notes for Reviewers

The fix is surgical: the genuine `impossible-condition` for a pure-string cast is still reported, while the union false positive is gone. Full analyzer suite passes (2365/2365).