### PR TITLE
Add `-y` shorthand for `--no-confirm` flag in `self-update` command

### DIFF
--- a/src/commands/self_update.rs
+++ b/src/commands/self_update.rs
@@ -42,7 +42,7 @@ pub struct SelfUpdateCommand {
     ///
     /// When this flag is set, the update process will proceed without asking for user confirmation.
     /// Use this option for automated scripts or CI environments where no user interaction is possible.
-    #[arg(long)]
+    #[arg(long, short = 'y')]
     pub no_confirm: bool,
 
     /// Update to a specific version by providing the version tag.


### PR DESCRIPTION
## 📌 What Does This PR Do?
Add `-y` shorthand for `--no-confirm` flag in `self-update` command.

## 🔍 Context & Motivation
To make it more convenient to use and more compatible with the other POSIX utilities.

## 🛠️ Summary of Changes
- **Feature:** Added `-y` shorthand for `--no-confirm` flag in `self-update` command.

## 📂 Affected Areas
- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): `self-update` command

## 🔗 Related Issues or PRs

Related to #2009.
