### PR TITLE
fix(analyzer): narrow array_key_exists() with non-literal key like isset()

### DIFF
--- a/crates/analyzer/src/assertion.rs
+++ b/crates/analyzer/src/assertion.rs
@@ -33,12 +33,14 @@ use mago_syntax::cst::UnaryPrefixOperator;
 use mago_word::Word;
 use mago_word::WordMap;
 use mago_word::ascii_lowercase_word;
+use mago_word::concat_word;
 use mago_word::word;
 
 use crate::artifacts::AnalysisArtifacts;
 use crate::context::assertion::AssertionContext;
 use crate::resolver::class_name::get_class_name_from_atomic;
 use crate::utils::expression::get_expression_id;
+use crate::utils::expression::get_index_id;
 use crate::utils::misc::unwrap_expression;
 
 #[derive(Debug, Clone, Copy)]
@@ -292,6 +294,35 @@ where
     let function_name = ascii_lowercase_word(function_identifier.value());
     let resolved_function_name = ascii_lowercase_word(assertion_context.resolved_names.get(function_identifier));
     let should_check_against_unresolved = { function_identifier.is_local() };
+
+    let is_array_key_exists = |name: &[u8]| matches!(name, b"array_key_exists" | b"key_exists");
+    if (should_check_against_unresolved && is_array_key_exists(function_name.as_bytes()))
+        || is_array_key_exists(resolved_function_name.as_bytes())
+    {
+        let key_argument = function_call.argument_list.arguments.first().map(mago_syntax::cst::Argument::value);
+        let array_argument = function_call.argument_list.arguments.get(1).map(mago_syntax::cst::Argument::value);
+
+        if let (Some(key_argument), Some(array_argument)) = (key_argument, array_argument)
+            && get_expression_array_key(artifacts, key_argument).is_none()
+            && let Some(array_id) = get_expression_id(
+                array_argument,
+                assertion_context.this_class_name,
+                assertion_context.resolved_names,
+                Some(assertion_context.codebase),
+            )
+            && let Some(index_id) = get_index_id(
+                key_argument,
+                assertion_context.this_class_name,
+                assertion_context.resolved_names,
+                Some(assertion_context.codebase),
+            )
+        {
+            let access_id = concat_word!(array_id.as_bytes(), b"[", index_id.as_bytes(), b"]");
+            if_types.insert(access_id, vec![vec![Assertion::ArrayKeyExists]]);
+
+            return if_types;
+        }
+    }
 
     let (argument_variable_id_position, function_assertions) = if resolved_function_name
         .as_bytes()

--- a/crates/analyzer/src/reconciler/simple_assertion_reconciler.rs
+++ b/crates/analyzer/src/reconciler/simple_assertion_reconciler.rs
@@ -289,6 +289,8 @@ where
             if existing_var_type.is_never() {
                 existing_var_type = get_mixed_maybe_from_loop(inside_loop);
             }
+            existing_var_type.set_possibly_undefined(false, None);
+            existing_var_type.set_possibly_undefined_from_try(false);
             Some(existing_var_type)
         }
         Assertion::InArray(typed_value) => {

--- a/crates/analyzer/src/reconciler/simple_negated_assertion_reconciler.rs
+++ b/crates/analyzer/src/reconciler/simple_negated_assertion_reconciler.rs
@@ -239,7 +239,7 @@ where
             Some(reconcile_falsy_or_empty(context, assertion, existing_var_type, key, negated, span))
         }
         Assertion::IsNotIsset => Some(reconcile_not_isset(context, existing_var_type, key, span)),
-        Assertion::ArrayKeyDoesNotExist => Some(get_never()),
+        Assertion::ArrayKeyDoesNotExist => Some(reconcile_not_isset(context, existing_var_type, key, span)),
         Assertion::DoesNotHaveArrayKey(key_name) => {
             Some(reconcile_no_array_key(context, assertion, existing_var_type, key, span, key_name, negated))
         }

--- a/crates/analyzer/tests/cases/issue_2008.php
+++ b/crates/analyzer/tests/cases/issue_2008.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+function test(array $data, string $key): mixed
+{
+    if (array_key_exists($key, $data)) {
+        return $data[$key];
+    }
+
+    return null;
+}
+
+function test_isset(array $data, string $key): mixed
+{
+    if (isset($data[$key])) {
+        return $data[$key];
+    }
+
+    return null;
+}
+
+function test_alias(array $data, string $key): mixed
+{
+    if (key_exists($key, $data)) {
+        return $data[$key];
+    }
+
+    return null;
+}
+
+/**
+ * Unlike `isset()`, `array_key_exists()` keeps `null` values: the access stays `?int`.
+ *
+ * @param array<string, ?int> $arr
+ */
+function keeps_null(array $arr, string $key): ?int
+{
+    if (array_key_exists($key, $arr)) {
+        return $arr[$key];
+    }
+
+    return null;
+}
+
+// The narrowing only applies to the exact key on the exact array that was checked.
+
+function no_check(array $data, string $key): mixed
+{
+    /** @mago-expect analysis:possibly-undefined-string-array-index */
+    return $data[$key];
+}
+
+function different_key(array $data, string $key, string $other): mixed
+{
+    if (array_key_exists($other, $data)) {
+        /** @mago-expect analysis:possibly-undefined-string-array-index */
+        return $data[$key];
+    }
+
+    return null;
+}
+
+function different_array(array $data, array $other, string $key): mixed
+{
+    if (array_key_exists($key, $other)) {
+        /** @mago-expect analysis:possibly-undefined-string-array-index */
+        return $data[$key];
+    }
+
+    return null;
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -2501,6 +2501,11 @@ test_case!(issue_1770, {
     s.check_property_initialization = false;
     s
 });
+test_case!(issue_2008, {
+    let mut s = crate::framework::default_test_settings();
+    s.strict_array_index_existence = true;
+    s
+});
 test_case!(issue_1772);
 test_case!(issue_1775);
 test_case!(issue_1786);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes a false positive where `array_key_exists()` (and its alias `key_exists()`) with a non-literal key did not narrow the subsequent array access the same way `isset()` does, causing a spurious `possibly-undefined-string-array-index` warning under `strict-array-index-existence = true`.

## 🔍 Context & Motivation

When the key passed to `array_key_exists($key, $data)` is not a literal (e.g. a `string` variable), it cannot be turned into a concrete `HasArrayKey` assertion, so no narrowing was produced at all. As a result a guarded access like `if (array_key_exists($key, $data)) { return $data[$key]; }` was still flagged as possibly undefined, while the equivalent `isset($data[$key])` was not. This mirrors the behavior reported in #2008.

## 🛠️ Summary of Changes

- **Bug Fix:** For a non-literal key, assert `ArrayKeyExists` on the synthesized `$array[$key]` access id, mirroring how `isset($array[$key])` narrows the access.
- **Bug Fix:** The `ArrayKeyExists` reconciler now clears the possibly-undefined flag (the element is defined), while keeping `null` values — unlike `isset`, `array_key_exists` does not strip `null`.
- **Bug Fix:** The negated `ArrayKeyDoesNotExist` now narrows like `!isset` (the element becomes undefined) instead of an unrecoverable `never` that would poison a later re-check on the same expression.
- **Tests:** Added `issue_2008` covering `array_key_exists`/`key_exists`, the `isset` equivalent, preserved `null` values, and the negative cases (no check, different key, different array) that must still report.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Analyzer

## 🔗 Related Issues or PRs

Fixes #2008

## 📝 Notes for Reviewers

The narrowing is precise: it only applies to the exact key on the exact array that was checked — accessing a different key or a different array still reports correctly. Accessing the element *after* the `if` block reports nothing, but this is pre-existing block-context behavior that `isset` already exhibits identically; this PR only brings `array_key_exists` in line with it. 

```php
<?php
declare(strict_types=1);

// strict-array-index-existence = true

function isset_after(array $data, string $key): mixed {
    if (isset($data[$key])) {
        echo "hit";
    }
    return $data[$key]; // ❌ NO warning — but one is expected here
}

function ake_after(array $data, string $key): mixed {
    if (array_key_exists($key, $data)) {
        echo "hit";
    }
    return $data[$key]; // ❌ NO warning — but one is expected here
}

function no_check(array $data, string $key): mixed {
    return $data[$key]; // ✅ warning is reported correctly
}
```