### PR TITLE
ci: add automated WinGet publishing to CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -536,3 +536,17 @@ jobs:
             --tag ghcr.io/carthage-software/mago:latest \
             ghcr.io/carthage-software/mago:${VERSION}-amd64 \
             ghcr.io/carthage-software/mago:${VERSION}-arm64
+
+  winget:
+    name: Publish to WinGet
+    runs-on: ubuntu-slim
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Submit package to WinGet Community Repository
+        uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: CarthageSoftware.Mago
+          installers-regex: '-windows-msvc\.zip$'
+          token: ${{ secrets.WINGET_TOKEN }}
+          fork-user: ${{ vars.WINGET_USER }}


### PR DESCRIPTION
> [!IMPORTANT]
> This PR requires repository setup before it can work.
> See **Notes for Reviewers**.

## 📌 What Does This PR Do?

Adds a WinGet publishing job to the CD workflow.

On tagged releases, the workflow will submit a WinGet manifest PR to [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) using [vedantmgoyal9/winget-releaser](https://github.com/vedantmgoyal9/winget-releaser).

## 🔍 Context & Motivation

Keeps the WinGet package updated automatically after releases, without relying on the community to submit updates manually.

## 🛠️ Summary of Changes

- **Feature:** Added `winget` CD job for tagged releases.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other: CD workflow

## 🔗 Related Issues or PRs

https://github.com/carthage-software/mago/pull/1844#issuecomment-4454428619

## 📝 Notes for Reviewers

Before this can work, the repository needs:

- Repository [secret](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets#creating-secrets-for-a-repository) `WINGET_TOKEN`: classic GitHub PAT with `public_repo`.
- Repository [variable](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-variables#creating-configuration-variables-for-a-repository) `WINGET_USER`: GitHub username owning a fork of `microsoft/winget-pkgs`.

Recommended setup: use a dedicated bot account (eg. `azjezz-bot` / `carthage-software-bot`), fork [winget-pkgs](https://github.com/microsoft/winget-pkgs) there, and [generate the PAT from](https://github.com/vedantmgoyal9/winget-releaser/blob/7bd472be23763def6e16bd06cc8b1cdfab0e2fd5/README.md#getting-started-) that account instead of a maintainer’s primary account for better security.