### PR TITLE
fix(analyzer): subtract enum cases from named enum subjects

### DIFF
--- a/crates/analyzer/src/reconciler/negated_assertion_reconciler.rs
+++ b/crates/analyzer/src/reconciler/negated_assertion_reconciler.rs
@@ -220,32 +220,33 @@ fn subtract_complex_type<A>(
                 acceptable_types.push(existing_atomic);
             }
             (
+                TAtomic::Object(TObject::Named(existing_named_object)),
+                TAtomic::Object(TObject::Enum(TEnum { name: assertion_enum_name, case: Some(assertion_case) })),
+            ) if context
+                .codebase
+                .is_instance_of(assertion_enum_name.as_bytes(), existing_named_object.get_name().as_bytes()) =>
+            {
+                subtract_enum_case(
+                    context,
+                    existing_named_object.get_name(),
+                    assertion_case,
+                    &existing_atomic,
+                    &mut acceptable_types,
+                    can_be_disjunct,
+                );
+            }
+            (
                 TAtomic::Object(TObject::Enum(TEnum { name: existing_enum_name, case: None })),
                 TAtomic::Object(TObject::Enum(TEnum { name: assertion_enum_name, case: Some(assertion_case) })),
             ) if context.codebase.is_instance_of(assertion_enum_name.as_bytes(), existing_enum_name.as_bytes()) => {
-                *can_be_disjunct = true;
-
-                let Some(enum_metadata) = context.codebase.get_enum(existing_enum_name.as_bytes()) else {
-                    acceptable_types.push(existing_atomic);
-                    continue;
-                };
-
-                // Enum is too large, do not subtract anything
-                if enum_metadata.enum_cases.len() > MAX_ENUM_CASES_FOR_ANALYSIS {
-                    acceptable_types.push(existing_atomic);
-                    continue;
-                }
-
-                for enum_case in enum_metadata.enum_cases.keys() {
-                    if enum_case == assertion_case {
-                        continue;
-                    }
-
-                    acceptable_types.push(TAtomic::Object(TObject::Enum(TEnum {
-                        name: *existing_enum_name,
-                        case: Some(*enum_case),
-                    })));
-                }
+                subtract_enum_case(
+                    context,
+                    *existing_enum_name,
+                    assertion_case,
+                    &existing_atomic,
+                    &mut acceptable_types,
+                    can_be_disjunct,
+                );
             }
             (TAtomic::Object(TObject::Enum(_)), TAtomic::Object(TObject::Enum(_))) => {
                 *can_be_disjunct = true;
@@ -282,6 +283,38 @@ fn subtract_complex_type<A>(
     }
 
     existing_var_type.types = Cow::Owned(acceptable_types);
+}
+
+fn subtract_enum_case<A>(
+    context: &mut Context<'_, '_, A>,
+    existing_enum_name: Word,
+    assertion_case: &Word,
+    existing_atomic: &TAtomic,
+    acceptable_types: &mut Vec<TAtomic>,
+    can_be_disjunct: &mut bool,
+) where
+    A: Arena,
+{
+    *can_be_disjunct = true;
+
+    let Some(enum_metadata) = context.codebase.get_enum(existing_enum_name.as_bytes()) else {
+        acceptable_types.push(existing_atomic.clone());
+        return;
+    };
+
+    if enum_metadata.enum_cases.len() > MAX_ENUM_CASES_FOR_ANALYSIS {
+        acceptable_types.push(existing_atomic.clone());
+        return;
+    }
+
+    for enum_case in enum_metadata.enum_cases.keys() {
+        if enum_case == assertion_case {
+            continue;
+        }
+
+        acceptable_types
+            .push(TAtomic::Object(TObject::Enum(TEnum { name: existing_enum_name, case: Some(*enum_case) })));
+    }
 }
 
 fn handle_negated_class<A>(

--- a/crates/analyzer/tests/cases/issue_2019.php
+++ b/crates/analyzer/tests/cases/issue_2019.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+enum Issue2019SomeEnum: string
+{
+    case Negative = 'negative';
+    case Positive = 'positive';
+
+    public static function fromNumber(int $number): self
+    {
+        return match (true) {
+            $number < 0 => self::Negative,
+            $number > 0 => self::Positive,
+            default => throw new InvalidArgumentException('Number is zero.'),
+        };
+    }
+}
+
+$is1 = match (Issue2019SomeEnum::fromNumber(-1)) {
+    Issue2019SomeEnum::Negative => 'negative',
+    Issue2019SomeEnum::Positive => 'positive',
+};
+
+$is2 = match (Issue2019SomeEnum::Positive) {
+    Issue2019SomeEnum::Negative => 'negative',
+    Issue2019SomeEnum::Positive => 'positive',
+};

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -2510,6 +2510,7 @@ test_case!(issue_2008, {
     s.strict_array_index_existence = true;
     s
 });
+test_case!(issue_2019);
 test_case!(issue_1772);
 test_case!(issue_1775);
 test_case!(issue_1786);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes a false positive `match-not-exhaustive` analyzer issue when matching over enum values returned from a method call.

## 🔍 Context & Motivation

`match` exhaustiveness narrowing correctly handled enum subject types represented as enum objects, but missed cases where the subject was represented as a named enum object. This caused exhaustive matches like match `(SomeEnum::fromNumber(...))` to be incorrectly reported as non-exhaustive.

## 🛠️ Summary of Changes

- **Bug Fix:** Subtract enum cases from named enum subject types during negated assertion reconciliation.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Analyzer

## 🔗 Related Issues or PRs

Fixes #2019
