### PR TITLE
fix(formatter): make member-access chain formatting idempotent with both preserve options

### DIFF
--- a/crates/formatter/src/internal/format/member_access.rs
+++ b/crates/formatter/src/internal/format/member_access.rs
@@ -744,6 +744,9 @@ fn get_flat_expression_width_with_binary_arguments(expression: &Expression<'_>) 
                 .zip(get_selector_width(&access.property))
                 .map(|(object, property)| object + string_width(b"?->") + property)
         }
+        Expression::Call(Call::Function(call)) => get_flat_expression_width_with_binary_arguments(call.function)
+            .zip(get_argument_list_width_with_binary_arguments(&call.argument_list))
+            .map(|(function, arguments)| function + arguments),
         Expression::Call(Call::Method(call)) => get_flat_expression_width_with_binary_arguments(call.object)
             .zip(get_selector_width(&call.method))
             .zip(get_argument_list_width_with_binary_arguments(&call.argument_list))

--- a/crates/formatter/src/internal/format/member_access.rs
+++ b/crates/formatter/src/internal/format/member_access.rs
@@ -309,6 +309,22 @@ where
         width > f.settings.print_width
     }
 
+    fn exceeds_print_width_from_line_start(&self, f: &FormatterState<'_, '_, A>) -> bool {
+        let Some(width) = self.get_flat_width_with_binary_arguments() else {
+            return false;
+        };
+
+        let base_start = self.base.span().start.offset;
+        let line = f.file.line_number(base_start);
+        let Some(line_start) = f.file.get_line_start_offset(line) else {
+            return false;
+        };
+
+        let prefix_width = string_width(&f.source_text[line_start as usize..base_start as usize]);
+
+        prefix_width + width > f.settings.print_width
+    }
+
     #[inline]
     fn has_break_after_first_access(&self, f: &FormatterState<'_, '_, A>) -> bool {
         for (i, access) in self.accesses.iter().enumerate() {
@@ -365,6 +381,15 @@ where
         let mut width = get_flat_expression_width(self.base)?;
         for access in &self.accesses {
             width += access.get_flat_width()?;
+        }
+
+        Some(width)
+    }
+
+    fn get_flat_width_with_binary_arguments(&self) -> Option<usize> {
+        let mut width = get_flat_expression_width_with_binary_arguments(self.base)?;
+        for access in &self.accesses {
+            width += get_access_flat_width_with_binary_arguments(access)?;
         }
 
         Some(width)
@@ -614,6 +639,18 @@ fn get_argument_width(argument: &Argument<'_>) -> Option<usize> {
     }
 }
 
+fn get_argument_width_with_binary_arguments(argument: &Argument<'_>) -> Option<usize> {
+    match argument {
+        Argument::Positional(argument) => {
+            let unpack_width = usize::from(argument.ellipsis.is_some()) * 3;
+
+            get_flat_expression_width_with_binary_arguments(argument.value).map(|width| width + unpack_width)
+        }
+        Argument::Named(argument) => get_flat_expression_width_with_binary_arguments(argument.value)
+            .map(|width| width + string_width(argument.name.value) + 2),
+    }
+}
+
 fn get_argument_list_width(argument_list: &ArgumentList<'_>) -> Option<usize> {
     let mut width = 2;
     for (i, argument) in argument_list.arguments.iter().enumerate() {
@@ -622,6 +659,19 @@ fn get_argument_list_width(argument_list: &ArgumentList<'_>) -> Option<usize> {
         }
 
         width += get_argument_width(argument)?;
+    }
+
+    Some(width)
+}
+
+fn get_argument_list_width_with_binary_arguments(argument_list: &ArgumentList<'_>) -> Option<usize> {
+    let mut width = 2;
+    for (i, argument) in argument_list.arguments.iter().enumerate() {
+        if i > 0 {
+            width += 2;
+        }
+
+        width += get_argument_width_with_binary_arguments(argument)?;
     }
 
     Some(width)
@@ -675,6 +725,52 @@ fn get_flat_expression_width(expression: &Expression<'_>) -> Option<usize> {
             .map(|((class, method), arguments)| class + string_width(b"::") + method + arguments),
         _ => None,
     }
+}
+
+fn get_flat_expression_width_with_binary_arguments(expression: &Expression<'_>) -> Option<usize> {
+    if let Some(width) = get_expression_width(expression) {
+        return Some(width);
+    }
+
+    match expression {
+        Expression::Parenthesized(parenthesized) => {
+            get_flat_expression_width_with_binary_arguments(parenthesized.expression).map(|width| width + 2)
+        }
+        Expression::Access(Access::Property(access)) => get_flat_expression_width_with_binary_arguments(access.object)
+            .zip(get_selector_width(&access.property))
+            .map(|(object, property)| object + string_width(b"->") + property),
+        Expression::Access(Access::NullSafeProperty(access)) => {
+            get_flat_expression_width_with_binary_arguments(access.object)
+                .zip(get_selector_width(&access.property))
+                .map(|(object, property)| object + string_width(b"?->") + property)
+        }
+        Expression::Call(Call::Method(call)) => get_flat_expression_width_with_binary_arguments(call.object)
+            .zip(get_selector_width(&call.method))
+            .zip(get_argument_list_width_with_binary_arguments(&call.argument_list))
+            .map(|((object, method), arguments)| object + string_width(b"->") + method + arguments),
+        Expression::Call(Call::NullSafeMethod(call)) => get_flat_expression_width_with_binary_arguments(call.object)
+            .zip(get_selector_width(&call.method))
+            .zip(get_argument_list_width_with_binary_arguments(&call.argument_list))
+            .map(|((object, method), arguments)| object + string_width(b"?->") + method + arguments),
+        Expression::Call(Call::StaticMethod(call)) => get_flat_expression_width_with_binary_arguments(call.class)
+            .zip(get_selector_width(&call.method))
+            .zip(get_argument_list_width_with_binary_arguments(&call.argument_list))
+            .map(|((class, method), arguments)| class + string_width(b"::") + method + arguments),
+        Expression::Binary(binary) => get_flat_expression_width_with_binary_arguments(binary.lhs)
+            .zip(get_flat_expression_width_with_binary_arguments(binary.rhs))
+            .map(|(lhs, rhs)| lhs + string_width(binary.operator.as_bytes()) + rhs + 2),
+        _ => None,
+    }
+}
+
+fn get_access_flat_width_with_binary_arguments(access: &MemberAccess<'_>) -> Option<usize> {
+    let selector_width = get_selector_width(access.get_selector())?;
+    let arguments_width = match access.get_arguments_list() {
+        Some(argument_list) => get_argument_list_width_with_binary_arguments(argument_list)?,
+        None => 0,
+    };
+
+    Some(string_width(access.get_operator_as_bytes()) + selector_width + arguments_width)
 }
 
 pub(super) fn collect_member_access_chain<'arena, A>(
@@ -939,7 +1035,7 @@ where
         && member_access_chain.is_first_link_object_method_call()
         && (member_access_chain.is_first_link_already_broken(f)
             || member_access_chain.has_break_after_first_access(f)
-            || member_access_chain.exceeds_print_width(f));
+            || member_access_chain.exceeds_print_width_from_line_start(f));
 
     if preserve_same_line_first_method {
         return true;

--- a/crates/formatter/tests/cases/issue_2032/after.php
+++ b/crates/formatter/tests/cases/issue_2032/after.php
@@ -1,0 +1,7 @@
+<?php
+
+$result = bagOf(array_values($theInputCollection))->containsAll(
+    $firstNeedle,
+    $secondNeedle,
+    $thirdNeedleValue ?? $thirdNeedle,
+);

--- a/crates/formatter/tests/cases/issue_2032/before.php
+++ b/crates/formatter/tests/cases/issue_2032/before.php
@@ -1,0 +1,3 @@
+<?php
+
+$result = bagOf(array_values($theInputCollection))->containsAll($firstNeedle, $secondNeedle, $thirdNeedleValue ?? $thirdNeedle);

--- a/crates/formatter/tests/cases/issue_2032/settings.inc
+++ b/crates/formatter/tests/cases/issue_2032/settings.inc
@@ -1,0 +1,5 @@
+FormatSettings {
+    preserve_breaking_member_access_chain: true,
+    preserve_breaking_member_access_chain_first_method_on_same_line: true,
+    ..FormatSettings::default()
+}

--- a/crates/formatter/tests/cases/issue_2032_nested_function_argument/after.php
+++ b/crates/formatter/tests/cases/issue_2032_nested_function_argument/after.php
@@ -1,0 +1,7 @@
+<?php
+
+$result = bagOf(array_values($theInputCollection))->containsAll(
+    $firstNeedle,
+    $secondNeedle,
+    normalize($thirdNeedleValue ?? $thirdNeedle),
+);

--- a/crates/formatter/tests/cases/issue_2032_nested_function_argument/before.php
+++ b/crates/formatter/tests/cases/issue_2032_nested_function_argument/before.php
@@ -1,0 +1,3 @@
+<?php
+
+$result = bagOf(array_values($theInputCollection))->containsAll($firstNeedle, $secondNeedle, normalize($thirdNeedleValue ?? $thirdNeedle));

--- a/crates/formatter/tests/cases/issue_2032_nested_function_argument/settings.inc
+++ b/crates/formatter/tests/cases/issue_2032_nested_function_argument/settings.inc
@@ -1,0 +1,5 @@
+FormatSettings {
+    preserve_breaking_member_access_chain: true,
+    preserve_breaking_member_access_chain_first_method_on_same_line: true,
+    ..FormatSettings::default()
+}

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -461,6 +461,7 @@ test_case!(issue_1808);
 test_case!(issue_1874);
 test_case!(issue_1875);
 test_case!(issue_2032);
+test_case!(issue_2032_nested_function_argument);
 test_case!(member_access_chain_keeps_breaks_with_comments);
 test_case!(issue_1562);
 test_case!(bare_cr_line_endings);

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -460,6 +460,7 @@ test_case!(issue_1806);
 test_case!(issue_1808);
 test_case!(issue_1874);
 test_case!(issue_1875);
+test_case!(issue_2032);
 test_case!(member_access_chain_keeps_breaks_with_comments);
 test_case!(issue_1562);
 test_case!(bare_cr_line_endings);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Makes `mago format` idempotent when both `preserve-breaking-member-access-chain` and `preserve-breaking-member-access-chain-first-method-on-same-line` are enabled. Before this change the formatter oscillated between two layouts on alternating runs instead of converging, so a second run was never a no-op.

## 🔍 Context & Motivation

Reported in #2032. With both options on, this line never reaches a fixed point:

```php
$result = bagOf(array_values($theInputCollection))->containsAll($firstNeedle, $secondNeedle, $thirdNeedleValue ?? $thirdNeedle);
```

Odd runs break the chain onto its own line; even runs keep the chain attached and break the argument list. Each layout reformats into the other.

The decision lives in `should_inline_first_access` in `crates/formatter/src/internal/format/member_access.rs`. Its `preserve_same_line_first_method` branch inlines the first method when the chain is already broken, broke after the first access, or exceeds the print width. The first two of those are source-shape signals that differ between the two layouts, so they were meant to be backstopped by the print-width signal. But `exceeds_print_width` relies on `get_flat_width`, and the underlying `get_flat_expression_width` returns `None` for a binary expression such as `$x ?? $y`. With a `??` argument in the chain the width was never computed, the print-width signal dropped out, and the verdict flipped from pass to pass.

## 🛠️ Summary of Changes

- **Bug Fix:** Added `exceeds_print_width_from_line_start` and a binary-argument-aware width path (`get_flat_width_with_binary_arguments` and its `get_*_with_binary_arguments` helpers) in `member_access.rs`. The new width computation handles `Binary` expressions and function/method/static-method call arguments, and measures from the line start (including indentation), so the print-width signal is available even when an argument is a binary expression. `should_inline_first_access` now uses this stable signal in the `preserve_same_line_first_method` branch, so the verdict is the same whether the input is the broken or the attached layout. Both options converge on: chain attached to the receiver, argument list broken.
- **Tests:** Added `issue_2032` (the reported `??` case) and `issue_2032_nested_function_argument` (a `??` wrapped in a function call, e.g. `normalize($c ?? $d)`, which the first pass of the width helper still missed until a `Call::Function` arm was added). The `test_case!` harness asserts both `format(before) == after` and `format(after) == after`, so each case proves idempotency.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Fixes #2032

## 📝 Notes for Reviewers

The behavioral change is scoped to the `preserve_same_line_first_method` branch (both preserve options on); the single-option and default paths are untouched, and the existing member-access, idempotency, same-line-chain, and method-chain test cases still pass. Verified with `cargo test -p mago-formatter` (440 case tests + 48 precedence tests) and `cargo +nightly fmt --all -- --check --unstable-features`.
