### PR TITLE
feat(prelude): add stubs for the sqlsrv extension

### DIFF
--- a/crates/linter/src/rule/utils/consts.rs
+++ b/crates/linter/src/rule/utils/consts.rs
@@ -154,7 +154,7 @@ pub const ALIAS_TO_FUNCTION: [(&str, &str); 68] = [
 /// List of all PHP extensions and their functions.
 ///
 /// This list is not exhaustive and may not be up-to-date.
-pub const EXTENSION_FUNCTIONS: [(&str, &[&str]); 48] = [
+pub const EXTENSION_FUNCTIONS: [(&str, &[&str]); 49] = [
     (
         "Core",
         &[
@@ -983,6 +983,47 @@ pub const EXTENSION_FUNCTIONS: [(&str, &[&str]); 48] = [
             "pg_delete",
             "pg_select",
             "pg_set_error_context_visibility",
+        ],
+    ),
+    (
+        "sqlsrv",
+        &[
+            "sqlsrv_connect",
+            "sqlsrv_close",
+            "sqlsrv_begin_transaction",
+            "sqlsrv_commit",
+            "sqlsrv_rollback",
+            "sqlsrv_errors",
+            "sqlsrv_configure",
+            "sqlsrv_get_config",
+            "sqlsrv_prepare",
+            "sqlsrv_execute",
+            "sqlsrv_query",
+            "sqlsrv_fetch",
+            "sqlsrv_fetch_array",
+            "sqlsrv_fetch_object",
+            "sqlsrv_next_result",
+            "sqlsrv_get_field",
+            "sqlsrv_field_metadata",
+            "sqlsrv_has_rows",
+            "sqlsrv_num_fields",
+            "sqlsrv_num_rows",
+            "sqlsrv_rows_affected",
+            "sqlsrv_client_info",
+            "sqlsrv_server_info",
+            "sqlsrv_cancel",
+            "sqlsrv_free_stmt",
+            "sqlsrv_send_stream_data",
+            "SQLSRV_PHPTYPE_STREAM",
+            "SQLSRV_PHPTYPE_STRING",
+            "SQLSRV_SQLTYPE_BINARY",
+            "SQLSRV_SQLTYPE_CHAR",
+            "SQLSRV_SQLTYPE_DECIMAL",
+            "SQLSRV_SQLTYPE_NCHAR",
+            "SQLSRV_SQLTYPE_NUMERIC",
+            "SQLSRV_SQLTYPE_NVARCHAR",
+            "SQLSRV_SQLTYPE_VARBINARY",
+            "SQLSRV_SQLTYPE_VARCHAR",
         ],
     ),
     (

--- a/crates/prelude/assets/extensions/sqlsrv.php
+++ b/crates/prelude/assets/extensions/sqlsrv.php
@@ -1,0 +1,362 @@
+<?php
+
+// Error / warning selectors
+
+const SQLSRV_ERR_ERRORS = 0;
+
+const SQLSRV_ERR_WARNINGS = 1;
+
+const SQLSRV_ERR_ALL = 2;
+
+// Logging subsystems
+
+const SQLSRV_LOG_SYSTEM_ALL = -1;
+
+const SQLSRV_LOG_SYSTEM_OFF = 0;
+
+const SQLSRV_LOG_SYSTEM_INIT = 1;
+
+const SQLSRV_LOG_SYSTEM_CONN = 2;
+
+const SQLSRV_LOG_SYSTEM_STMT = 4;
+
+const SQLSRV_LOG_SYSTEM_UTIL = 8;
+
+// Logging severities
+
+const SQLSRV_LOG_SEVERITY_ALL = -1;
+
+const SQLSRV_LOG_SEVERITY_ERROR = 1;
+
+const SQLSRV_LOG_SEVERITY_WARNING = 2;
+
+const SQLSRV_LOG_SEVERITY_NOTICE = 4;
+
+// Fetch types
+
+const SQLSRV_FETCH_NUMERIC = 1;
+
+const SQLSRV_FETCH_ASSOC = 2;
+
+const SQLSRV_FETCH_BOTH = 3;
+
+// PHP types (values 4 and 6 belong to SQLSRV_PHPTYPE_STRING() and SQLSRV_PHPTYPE_STREAM())
+
+const SQLSRV_PHPTYPE_NULL = 1;
+
+const SQLSRV_PHPTYPE_INT = 2;
+
+const SQLSRV_PHPTYPE_FLOAT = 3;
+
+const SQLSRV_PHPTYPE_DATETIME = 5;
+
+const SQLSRV_PHPTYPE_TABLE = 7;
+
+// Encodings
+
+const SQLSRV_ENC_BINARY = 'binary';
+
+const SQLSRV_ENC_CHAR = 'char';
+
+// Nullability
+
+const SQLSRV_NULLABLE_NO = 0;
+
+const SQLSRV_NULLABLE_YES = 1;
+
+const SQLSRV_NULLABLE_UNKNOWN = 2;
+
+// SQL types
+
+const SQLSRV_SQLTYPE_BIGINT = -5;
+
+const SQLSRV_SQLTYPE_BIT = -7;
+
+const SQLSRV_SQLTYPE_CHAR = 1;
+
+const SQLSRV_SQLTYPE_DATE = 5211;
+
+const SQLSRV_SQLTYPE_DATETIME = 25177693;
+
+const SQLSRV_SQLTYPE_DATETIME2 = 58734173;
+
+const SQLSRV_SQLTYPE_DATETIMEOFFSET = 58738021;
+
+const SQLSRV_SQLTYPE_DECIMAL = 3;
+
+const SQLSRV_SQLTYPE_FLOAT = 6;
+
+const SQLSRV_SQLTYPE_IMAGE = -4;
+
+const SQLSRV_SQLTYPE_INT = 4;
+
+const SQLSRV_SQLTYPE_MONEY = 33564163;
+
+const SQLSRV_SQLTYPE_NCHAR = -8;
+
+const SQLSRV_SQLTYPE_NTEXT = -10;
+
+const SQLSRV_SQLTYPE_NUMERIC = 2;
+
+const SQLSRV_SQLTYPE_NVARCHAR = -9;
+
+const SQLSRV_SQLTYPE_REAL = 7;
+
+const SQLSRV_SQLTYPE_SMALLDATETIME = 8285;
+
+const SQLSRV_SQLTYPE_SMALLINT = 5;
+
+const SQLSRV_SQLTYPE_SMALLMONEY = 33559555;
+
+const SQLSRV_SQLTYPE_TABLE = -153;
+
+const SQLSRV_SQLTYPE_TEXT = -1;
+
+const SQLSRV_SQLTYPE_TIME = 58728806;
+
+const SQLSRV_SQLTYPE_TIMESTAMP = 4606;
+
+const SQLSRV_SQLTYPE_TINYINT = -6;
+
+const SQLSRV_SQLTYPE_UDT = -151;
+
+const SQLSRV_SQLTYPE_UNIQUEIDENTIFIER = -11;
+
+const SQLSRV_SQLTYPE_VARBINARY = -3;
+
+const SQLSRV_SQLTYPE_VARCHAR = 12;
+
+const SQLSRV_SQLTYPE_XML = -152;
+
+// Parameter directions
+
+const SQLSRV_PARAM_IN = 1;
+
+const SQLSRV_PARAM_INOUT = 2;
+
+const SQLSRV_PARAM_OUT = 4;
+
+// Transaction isolation levels
+
+const SQLSRV_TXN_READ_UNCOMMITTED = 1;
+
+const SQLSRV_TXN_READ_COMMITTED = 2;
+
+const SQLSRV_TXN_REPEATABLE_READ = 4;
+
+const SQLSRV_TXN_SERIALIZABLE = 8;
+
+const SQLSRV_TXN_SNAPSHOT = 32;
+
+// Cursor scroll options
+
+const SQLSRV_SCROLL_NEXT = 1;
+
+const SQLSRV_SCROLL_FIRST = 2;
+
+const SQLSRV_SCROLL_LAST = 3;
+
+const SQLSRV_SCROLL_PRIOR = 4;
+
+const SQLSRV_SCROLL_ABSOLUTE = 5;
+
+const SQLSRV_SCROLL_RELATIVE = 6;
+
+// Cursor types
+
+const SQLSRV_CURSOR_FORWARD = 'forward';
+
+const SQLSRV_CURSOR_STATIC = 'static';
+
+const SQLSRV_CURSOR_DYNAMIC = 'dynamic';
+
+const SQLSRV_CURSOR_KEYSET = 'keyset';
+
+const SQLSRV_CURSOR_CLIENT_BUFFERED = 'buffered';
+
+/**
+ * @param array<string, mixed> $connectionInfo
+ *
+ * @return resource|false
+ */
+function sqlsrv_connect(string $serverName, array $connectionInfo = []): mixed {}
+
+/**
+ * @param resource $conn
+ */
+function sqlsrv_close($conn): bool {}
+
+/**
+ * @param resource $conn
+ */
+function sqlsrv_begin_transaction($conn): bool {}
+
+/**
+ * @param resource $conn
+ */
+function sqlsrv_commit($conn): bool {}
+
+/**
+ * @param resource $conn
+ */
+function sqlsrv_rollback($conn): bool {}
+
+/**
+ * @return array<int, array<string, mixed>>|null
+ */
+function sqlsrv_errors(int $errorsOrWarnings = SQLSRV_ERR_ALL): ?array {}
+
+function sqlsrv_configure(string $setting, mixed $value): bool {}
+
+function sqlsrv_get_config(string $setting): mixed {}
+
+/**
+ * @param resource             $conn
+ * @param array<int, mixed>    $params
+ * @param array<string, mixed> $options
+ *
+ * @return resource|false
+ */
+function sqlsrv_prepare($conn, string $sql, array $params = [], array $options = []): mixed {}
+
+/**
+ * @param resource $stmt
+ */
+function sqlsrv_execute($stmt): bool {}
+
+/**
+ * @param resource             $conn
+ * @param array<int, mixed>    $params
+ * @param array<string, mixed> $options
+ *
+ * @return resource|false
+ */
+function sqlsrv_query($conn, string $sql, array $params = [], array $options = []): mixed {}
+
+/**
+ * @param resource $stmt
+ */
+function sqlsrv_fetch($stmt, ?int $row = null, ?int $offset = null): ?bool {}
+
+/**
+ * @param resource $stmt
+ *
+ * @return array<array-key, mixed>|null|false
+ */
+function sqlsrv_fetch_array($stmt, ?int $fetchType = null, ?int $row = null, ?int $offset = null): array|false|null {}
+
+/**
+ * @param resource          $stmt
+ * @param class-string|null      $className
+ * @param array<int, mixed>|null $ctorParams
+ *
+ * @return object|null|false
+ */
+function sqlsrv_fetch_object(
+    $stmt,
+    ?string $className = null,
+    ?array $ctorParams = null,
+    ?int $row = null,
+    ?int $offset = null,
+): object|false|null {}
+
+/**
+ * @param resource $stmt
+ */
+function sqlsrv_next_result($stmt): ?bool {}
+
+/**
+ * @param resource $stmt
+ */
+function sqlsrv_get_field($stmt, int $fieldIndex, ?int $getAsType = null): mixed {}
+
+/**
+ * @param resource $stmt
+ *
+ * @return array<int, array<string, mixed>>|false
+ */
+function sqlsrv_field_metadata($stmt): array|false {}
+
+/**
+ * @param resource $stmt
+ */
+function sqlsrv_has_rows($stmt): bool {}
+
+/**
+ * @param resource $stmt
+ *
+ * @return int|false
+ */
+function sqlsrv_num_fields($stmt): int|false {}
+
+/**
+ * @param resource $stmt
+ *
+ * @return int|false
+ */
+function sqlsrv_num_rows($stmt): int|false {}
+
+/**
+ * @param resource $stmt
+ *
+ * @return int|false
+ */
+function sqlsrv_rows_affected($stmt): int|false {}
+
+/**
+ * @param resource $conn
+ *
+ * @return array<string, mixed>|false
+ */
+function sqlsrv_client_info($conn): array|false {}
+
+/**
+ * @param resource $conn
+ *
+ * @return array<string, mixed>
+ */
+function sqlsrv_server_info($conn): array {}
+
+/**
+ * @param resource $stmt
+ */
+function sqlsrv_cancel($stmt): bool {}
+
+/**
+ * @param resource $stmt
+ */
+function sqlsrv_free_stmt($stmt): bool {}
+
+/**
+ * @param resource $stmt
+ */
+function sqlsrv_send_stream_data($stmt): bool {}
+
+function SQLSRV_PHPTYPE_STREAM(string $encoding): int {}
+
+function SQLSRV_PHPTYPE_STRING(string $encoding): int {}
+
+function SQLSRV_SQLTYPE_BINARY(int $byteCount): int {}
+
+function SQLSRV_SQLTYPE_CHAR(int $charCount): int {}
+
+function SQLSRV_SQLTYPE_DECIMAL(int $precision, int $scale): int {}
+
+function SQLSRV_SQLTYPE_NCHAR(int $charCount): int {}
+
+function SQLSRV_SQLTYPE_NUMERIC(int $precision, int $scale): int {}
+
+/**
+ * @param int|'max' $charCount
+ */
+function SQLSRV_SQLTYPE_NVARCHAR(int|string $charCount): int {}
+
+/**
+ * @param int|'max' $byteCount
+ */
+function SQLSRV_SQLTYPE_VARBINARY(int|string $byteCount): int {}
+
+/**
+ * @param int|'max' $charCount
+ */
+function SQLSRV_SQLTYPE_VARCHAR(int|string $charCount): int {}

--- a/crates/prelude/assets/extensions/sqlsrv.php
+++ b/crates/prelude/assets/extensions/sqlsrv.php
@@ -1,14 +1,10 @@
 <?php
 
-// Error / warning selectors
-
 const SQLSRV_ERR_ERRORS = 0;
 
 const SQLSRV_ERR_WARNINGS = 1;
 
 const SQLSRV_ERR_ALL = 2;
-
-// Logging subsystems
 
 const SQLSRV_LOG_SYSTEM_ALL = -1;
 
@@ -22,8 +18,6 @@ const SQLSRV_LOG_SYSTEM_STMT = 4;
 
 const SQLSRV_LOG_SYSTEM_UTIL = 8;
 
-// Logging severities
-
 const SQLSRV_LOG_SEVERITY_ALL = -1;
 
 const SQLSRV_LOG_SEVERITY_ERROR = 1;
@@ -32,15 +26,11 @@ const SQLSRV_LOG_SEVERITY_WARNING = 2;
 
 const SQLSRV_LOG_SEVERITY_NOTICE = 4;
 
-// Fetch types
-
 const SQLSRV_FETCH_NUMERIC = 1;
 
 const SQLSRV_FETCH_ASSOC = 2;
 
 const SQLSRV_FETCH_BOTH = 3;
-
-// PHP types (values 4 and 6 belong to SQLSRV_PHPTYPE_STRING() and SQLSRV_PHPTYPE_STREAM())
 
 const SQLSRV_PHPTYPE_NULL = 1;
 
@@ -52,21 +42,15 @@ const SQLSRV_PHPTYPE_DATETIME = 5;
 
 const SQLSRV_PHPTYPE_TABLE = 7;
 
-// Encodings
-
 const SQLSRV_ENC_BINARY = 'binary';
 
 const SQLSRV_ENC_CHAR = 'char';
-
-// Nullability
 
 const SQLSRV_NULLABLE_NO = 0;
 
 const SQLSRV_NULLABLE_YES = 1;
 
 const SQLSRV_NULLABLE_UNKNOWN = 2;
-
-// SQL types
 
 const SQLSRV_SQLTYPE_BIGINT = -5;
 
@@ -128,15 +112,11 @@ const SQLSRV_SQLTYPE_VARCHAR = 12;
 
 const SQLSRV_SQLTYPE_XML = -152;
 
-// Parameter directions
-
 const SQLSRV_PARAM_IN = 1;
 
 const SQLSRV_PARAM_INOUT = 2;
 
 const SQLSRV_PARAM_OUT = 4;
-
-// Transaction isolation levels
 
 const SQLSRV_TXN_READ_UNCOMMITTED = 1;
 
@@ -147,8 +127,6 @@ const SQLSRV_TXN_REPEATABLE_READ = 4;
 const SQLSRV_TXN_SERIALIZABLE = 8;
 
 const SQLSRV_TXN_SNAPSHOT = 32;
-
-// Cursor scroll options
 
 const SQLSRV_SCROLL_NEXT = 1;
 
@@ -162,8 +140,6 @@ const SQLSRV_SCROLL_ABSOLUTE = 5;
 
 const SQLSRV_SCROLL_RELATIVE = 6;
 
-// Cursor types
-
 const SQLSRV_CURSOR_FORWARD = 'forward';
 
 const SQLSRV_CURSOR_STATIC = 'static';
@@ -175,11 +151,12 @@ const SQLSRV_CURSOR_KEYSET = 'keyset';
 const SQLSRV_CURSOR_CLIENT_BUFFERED = 'buffered';
 
 /**
- * @param array<string, mixed> $connectionInfo
+ * @param non-empty-string     $server_name
+ * @param array<string, mixed> $connection_info
  *
  * @return resource|false
  */
-function sqlsrv_connect(string $serverName, array $connectionInfo = []): mixed {}
+function sqlsrv_connect(string $server_name, array $connection_info = []): mixed {}
 
 /**
  * @param resource $conn
@@ -202,9 +179,9 @@ function sqlsrv_commit($conn): bool {}
 function sqlsrv_rollback($conn): bool {}
 
 /**
- * @return array<int, array<string, mixed>>|null
+ * @return non-empty-list<array<string, mixed>>|null
  */
-function sqlsrv_errors(int $errorsOrWarnings = SQLSRV_ERR_ALL): ?array {}
+function sqlsrv_errors(int $errors_and_or_warnings = SQLSRV_ERR_ALL): ?array {}
 
 function sqlsrv_configure(string $setting, mixed $value): bool {}
 
@@ -217,7 +194,7 @@ function sqlsrv_get_config(string $setting): mixed {}
  *
  * @return resource|false
  */
-function sqlsrv_prepare($conn, string $sql, array $params = [], array $options = []): mixed {}
+function sqlsrv_prepare($conn, string $tsql, array $params = [], array $options = []): mixed {}
 
 /**
  * @param resource $stmt
@@ -231,7 +208,7 @@ function sqlsrv_execute($stmt): bool {}
  *
  * @return resource|false
  */
-function sqlsrv_query($conn, string $sql, array $params = [], array $options = []): mixed {}
+function sqlsrv_query($conn, string $tsql, array $params = [], array $options = []): mixed {}
 
 /**
  * @param resource $stmt
@@ -243,19 +220,19 @@ function sqlsrv_fetch($stmt, ?int $row = null, ?int $offset = null): ?bool {}
  *
  * @return array<array-key, mixed>|null|false
  */
-function sqlsrv_fetch_array($stmt, ?int $fetchType = null, ?int $row = null, ?int $offset = null): array|false|null {}
+function sqlsrv_fetch_array($stmt, ?int $fetch_type = null, ?int $row = null, ?int $offset = null): array|false|null {}
 
 /**
- * @param resource          $stmt
- * @param class-string|null      $className
- * @param array<int, mixed>|null $ctorParams
+ * @param resource               $stmt
+ * @param class-string|null      $class_name
+ * @param array<int, mixed>|null $ctor_params
  *
  * @return object|null|false
  */
 function sqlsrv_fetch_object(
     $stmt,
-    ?string $className = null,
-    ?array $ctorParams = null,
+    ?string $class_name = null,
+    ?array $ctor_params = null,
     ?int $row = null,
     ?int $offset = null,
 ): object|false|null {}
@@ -268,12 +245,12 @@ function sqlsrv_next_result($stmt): ?bool {}
 /**
  * @param resource $stmt
  */
-function sqlsrv_get_field($stmt, int $fieldIndex, ?int $getAsType = null): mixed {}
+function sqlsrv_get_field($stmt, int $field_index, ?int $get_as_type = null): mixed {}
 
 /**
  * @param resource $stmt
  *
- * @return array<int, array<string, mixed>>|false
+ * @return list<array<string, mixed>>|false
  */
 function sqlsrv_field_metadata($stmt): array|false {}
 
@@ -285,21 +262,21 @@ function sqlsrv_has_rows($stmt): bool {}
 /**
  * @param resource $stmt
  *
- * @return int|false
+ * @return int<0, max>|false
  */
 function sqlsrv_num_fields($stmt): int|false {}
 
 /**
  * @param resource $stmt
  *
- * @return int|false
+ * @return int<0, max>|false
  */
 function sqlsrv_num_rows($stmt): int|false {}
 
 /**
  * @param resource $stmt
  *
- * @return int|false
+ * @return int<-1, max>|false
  */
 function sqlsrv_rows_affected($stmt): int|false {}
 
@@ -332,31 +309,54 @@ function sqlsrv_free_stmt($stmt): bool {}
  */
 function sqlsrv_send_stream_data($stmt): bool {}
 
+/**
+ * @param 'binary'|'char' $encoding
+ */
 function SQLSRV_PHPTYPE_STREAM(string $encoding): int {}
 
+/**
+ * @param 'binary'|'char' $encoding
+ */
 function SQLSRV_PHPTYPE_STRING(string $encoding): int {}
 
-function SQLSRV_SQLTYPE_BINARY(int $byteCount): int {}
+/**
+ * @param int<1, 8000> $size
+ */
+function SQLSRV_SQLTYPE_BINARY(int $size): int {}
 
-function SQLSRV_SQLTYPE_CHAR(int $charCount): int {}
+/**
+ * @param int<1, 8000> $size
+ */
+function SQLSRV_SQLTYPE_CHAR(int $size): int {}
 
+/**
+ * @param int<1, 38> $precision
+ * @param int<0, 38> $scale
+ */
 function SQLSRV_SQLTYPE_DECIMAL(int $precision, int $scale): int {}
 
-function SQLSRV_SQLTYPE_NCHAR(int $charCount): int {}
+/**
+ * @param int<1, 4000> $size
+ */
+function SQLSRV_SQLTYPE_NCHAR(int $size): int {}
 
+/**
+ * @param int<1, 38> $precision
+ * @param int<0, 38> $scale
+ */
 function SQLSRV_SQLTYPE_NUMERIC(int $precision, int $scale): int {}
 
 /**
- * @param int|'max' $charCount
+ * @param int<1, 4000>|'max' $size
  */
-function SQLSRV_SQLTYPE_NVARCHAR(int|string $charCount): int {}
+function SQLSRV_SQLTYPE_NVARCHAR(int|string $size): int {}
 
 /**
- * @param int|'max' $byteCount
+ * @param int<1, 8000>|'max' $size
  */
-function SQLSRV_SQLTYPE_VARBINARY(int|string $byteCount): int {}
+function SQLSRV_SQLTYPE_VARBINARY(int|string $size): int {}
 
 /**
- * @param int|'max' $charCount
+ * @param int<1, 8000>|'max' $size
  */
-function SQLSRV_SQLTYPE_VARCHAR(int|string $charCount): int {}
+function SQLSRV_SQLTYPE_VARCHAR(int|string $size): int {}


### PR DESCRIPTION
## 📌 What Does This PR Do?

Adds stubs for the `ext/sqlsrv` extension (Microsoft SQL Server Driver for PHP) to the prelude, so Mago recognizes all `sqlsrv_*` functions and `SQLSRV_*` constants instead of reporting them as unknown symbols.

## 🔍 Context & Motivation

Mago currently has no stubs for `ext/sqlsrv`, so any project using the SQL Server driver gets false positives for every function call and constant reference (see #2039). All other database extensions (`mysqli`, `pgsql`, `sqlite3`, `pdo`) already ship stubs — this fills the gap.

## 🛠️ Summary of Changes

- **Feature:** Added `crates/prelude/assets/extensions/sqlsrv.php` covering all 26 `sqlsrv_*` functions documented on php.net, the 10 parameterized type-constructor functions (`SQLSRV_PHPTYPE_STRING()`, `SQLSRV_SQLTYPE_VARCHAR()`, etc.), and all constants registered by the driver. Connection/statement handles are typed as `resource` via docblocks, result-shaping functions carry precise union return types (`array|null|false` etc.), and the `VARCHAR`/`NVARCHAR`/`VARBINARY` constructors accept `int|'max'`.
- **Feature:** Registered the extension's functions in `EXTENSION_FUNCTIONS` (`crates/linter/src/rule/utils/consts.rs`) so the disallowed-functions linter rule can target the `sqlsrv` extension as a whole.

## 📂 Affected Areas

- [x] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Prelude (extension stubs)

## 🔗 Related Issues or PRs

Fixes #2039