### PR TITLE
fix(prelude): drop @no-named-arguments from native functions that allow named args

### DIFF
--- a/crates/prelude/assets/extensions/core.php
+++ b/crates/prelude/assets/extensions/core.php
@@ -733,7 +733,6 @@ function func_get_arg(int $position): mixed {}
 
 /**
  * @pure
- * @no-named-arguments
  */
 function func_get_args(): array {}
 
@@ -741,96 +740,79 @@ function func_get_args(): array {}
  * @return int<0, max>
  *
  * @pure
- * @no-named-arguments
  */
 function strlen(string $string): int {}
 
 /**
  * @pure
- * @no-named-arguments
  */
 function strcmp(string $string1, string $string2): int {}
 
 /**
  * @pure
- * @no-named-arguments
  */
 function strncmp(string $string1, string $string2, int $length): int {}
 
 /**
  * @pure
- * @no-named-arguments
  */
 function strcasecmp(string $string1, string $string2): int {}
 
 /**
  * @pure
- * @no-named-arguments
  */
 function strncasecmp(string $string1, string $string2, int $length): int {}
 
 /**
  * @pure
- * @no-named-arguments
  */
 #[Mago\AvailableSince(80000)]
 function str_starts_with(string $haystack, string $needle): bool {}
 
 /**
  * @pure
- * @no-named-arguments
  */
 function str_ends_with(string $haystack, string $needle): bool {}
 
 /**
  * @pure
- * @no-named-arguments
  */
 #[Mago\AvailableSince(80000)]
 function str_contains(string $haystack, string $needle): bool {}
 
 /**
  * @pure
- * @no-named-arguments
  */
 #[Mago\AvailableSince(80300)]
 function str_decrement(string $string): string {}
 
 /**
  * @pure
- * @no-named-arguments
  */
 #[Mago\AvailableSince(80300)]
 function str_increment(string $string): string {}
 
-/**
- * @no-named-arguments
- */
 function error_reporting(?int $error_level = null): int {}
 
 function define(string $constant_name, mixed $value, bool $case_insensitive = false): bool {}
 
 /**
  * @pure
- * @no-named-arguments
  */
 function defined(string $constant_name): bool {}
 
 /**
  * @pure
- * @no-named-arguments
  */
 function get_class(object $object): string {}
 
 /**
  * @pure
- * @no-named-arguments
  */
 function get_called_class(): string {}
 
 /**
  * @pure
- * @no-named-arguments
  */
 function get_parent_class(object|string $object_or_class): string|false {}
 
@@ -838,7 +820,6 @@ function get_parent_class(object|string $object_or_class): string|false {}
  * @param object|class-string $object_or_class
  *
  * @pure
- * @no-named-arguments
  */
 function method_exists(object|string $object_or_class, string $method): bool {}
 
@@ -846,7 +827,6 @@ function method_exists(object|string $object_or_class, string $method): bool {}
  * @param object|class-string $object_or_class
  *
  * @pure
- * @no-named-arguments
  */
 function property_exists(object|string $object_or_class, string $property): bool {}
 
@@ -856,7 +836,6 @@ function property_exists(object|string $object_or_class, string $property): bool
  * @assert-if-true =trait-string $trait
  *
  * @pure
- * @no-named-arguments
  */
 function trait_exists(string $trait, bool $autoload = true): bool {}
 
@@ -866,7 +845,6 @@ function trait_exists(string $trait, bool $autoload = true): bool {}
  * @assert-if-true =class-string $class
  *
  * @pure
- * @no-named-arguments
  */
 function class_exists(string $class, bool $autoload = true): bool {}
 
@@ -876,7 +854,6 @@ function class_exists(string $class, bool $autoload = true): bool {}
  * @assert-if-true =interface-string $interface
  *
  * @pure
- * @no-named-arguments
  */
 function interface_exists(string $interface, bool $autoload = true): bool {}
 
@@ -886,7 +863,6 @@ function interface_exists(string $interface, bool $autoload = true): bool {}
  * @assert-if-true =non-empty-string $function
  *
  * @pure
- * @no-named-arguments
  */
 function function_exists(string $function): bool {}
 
@@ -896,7 +872,6 @@ function function_exists(string $function): bool {}
  * @assert-if-true =enum-string $enum
  *
  * @pure
- * @no-named-arguments
  */
 #[Mago\AvailableSince(80100)]
 function enum_exists(string $enum, bool $autoload = true): bool {}
@@ -905,7 +880,6 @@ function enum_exists(string $enum, bool $autoload = true): bool {}
  * @param class-string $class
  * @param non-empty-string $alias
  *
- * @no-named-arguments
  */
 function class_alias(string $class, string $alias, bool $autoload = true): bool {}
 

--- a/crates/prelude/assets/extensions/standard.php
+++ b/crates/prelude/assets/extensions/standard.php
@@ -818,7 +818,6 @@ const PASSWORD_ARGON2_PROVIDER = 'standard';
  *   'options': array{'salt'?: int, 'cost'?: int, 'memory_cost'?: int, 'time_cost'?: int, 'threads'?: int, ...},
  * }
  *
- * @no-named-arguments
  * @pure
  */
 function password_get_info(string $hash): array {}
@@ -828,7 +827,6 @@ function password_get_info(string $hash): array {}
  *
  * @return non-empty-string
  *
- * @no-named-arguments
  * @pure
  */
 function password_hash(string $password, string|int|null $algo, array $options = []): string {}
@@ -836,13 +834,11 @@ function password_hash(string $password, string|int|null $algo, array $options =
 /**
  * @param array{'salt'?:int, 'cost'?: int, 'memory_cost'?: int, 'time_cost'?: int, 'threads'?: int, ...} $options
  *
- * @no-named-arguments
  * @pure
  */
 function password_needs_rehash(string $hash, string|int|null $algo, array $options = []): bool {}
 
 /**
- * @no-named-arguments
  * @pure
  */
 function password_verify(string $password, string $hash): bool {}
@@ -850,7 +846,6 @@ function password_verify(string $password, string $hash): bool {}
 /**
  * @return list<non-empty-string>
  *
- * @no-named-arguments
  * @pure
  */
 function password_algos(): array {}
@@ -3618,7 +3613,6 @@ function array_replace_recursive(array $array, array ...$replacements): array {}
  *
  * @return ($array is non-empty-array|non-empty-list ? non-empty-list<K> : list<K>)
  *
- * @no-named-arguments
  * @pure
  */
 function array_keys(array $array, mixed $filter_value = null, bool $strict = false): array {}
@@ -3631,7 +3625,6 @@ function array_keys(array $array, mixed $filter_value = null, bool $strict = fal
  *
  * @return ($array is non-empty-array|non-empty-list ? non-empty-list<V> : list<V>)
  *
- * @no-named-arguments
  * @pure
  */
 function array_values(array $array): array {}
@@ -3644,7 +3637,6 @@ function array_values(array $array): array {}
  *
  * @return array<V, int>
  *
- * @no-named-arguments
  * @pure
  */
 function array_count_values(array $array): array {}
@@ -3659,7 +3651,6 @@ function array_count_values(array $array): array {}
  *
  * @return array<array-key, V>
  *
- * @no-named-arguments
  * @pure
  */
 function array_column(array $array, string|int|null $column_key, string|int|null $index_key = null): array {}
@@ -3673,7 +3664,6 @@ function array_column(array $array, string|int|null $column_key, string|int|null
  *
  * @return ($array is list<V> ? ($preserve_keys is true ? array<K, V> : list<V>) : array<K, V>)
  *
- * @no-named-arguments
  * @pure
  */
 function array_reverse(array $array, bool $preserve_keys = false): array {}


### PR DESCRIPTION
## 📌 What Does This PR Do?

Removes the `@no-named-arguments` docblock tag from native functions that actually accept named arguments, so the analyzer no longer reports `named-argument-not-allowed` for calls like `str_contains(haystack: $x, needle: $y)`.

## 🔍 Context & Motivation

Native functions such as `str_contains()` carried `@no-named-arguments` in their prelude stubs, causing Mago to flag perfectly valid named-argument calls as errors (see #2043). The only workaround was to disable the `named-argument-not-allowed` rule globally, which then also suppressed genuine `@no-named-arguments` declarations made by library authors — exactly the signal the rule exists to surface. PHP 8.0+ supports named arguments for these functions, so the annotation was a false positive.

## 🛠️ Summary of Changes

- **Bug Fix:** Removed `@no-named-arguments` from the 34 non-variadic native functions in `core.php` and `standard.php` (`str_*`, `get_class`/`class_exists`/`function_exists`/…, `password_*`, `array_keys`, `array_values`, `array_count_values`, `array_column`, `array_reverse`, `func_get_args`, `error_reporting`, `defined`), whose named-argument support was verified against PHP 8.5.
- **Bug Fix:** Kept `@no-named-arguments` on the 13 purely variadic collector functions (`array_udiff`, `array_merge_recursive`, `array_replace`, `array_diff_ukey`, `array_uintersect`, and the other `array_*_u*` variants) where PHP genuinely throws `does not accept unknown named parameters`, because their meaningful arguments live in an unnamed variadic tail.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Prelude (native function stubs)

## 🔗 Related Issues or PRs

Fixes #2043

## 📝 Notes for Reviewers

The keep/remove split was determined empirically: each of the 47 annotated functions was probed on PHP 8.5 via reflection plus a named-argument call, and only the variadic collectors reject named arguments. This follows the precedent set in commit 45b299b9, which already removed `@no-named-arguments` from `define()` and `Closure::bind()` to reduce false positives. The linter's `NO_NAMED_ARGUMENTS_FUNCTIONS` list (used only by the `literal-named-argument` clarity suggestion) is intentionally left untouched — suppressing that suggestion for native functions is still desirable since their internal parameter names have historically changed between PHP versions. The diff is deletion-only.