### PR TITLE
fix(codex): preserve generic type parameters when narrowing with enum type arguments

### DIFF
--- a/crates/analyzer/tests/cases/narrow_class_string_enum_generic.php
+++ b/crates/analyzer/tests/cases/narrow_class_string_enum_generic.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fruits;
+
+/**
+ * @template-covariant T
+ * @template-covariant E
+ * @inheritors Ripe|Spoiled
+ * @phpstan-sealed Ripe|Spoiled
+ */
+abstract class Basket
+{
+    /** @return T */
+    abstract public function fruit();
+
+    /** @return E */
+    abstract public function spoilage();
+}
+
+/**
+ * @template-covariant T
+ * @template-covariant E
+ * @extends Basket<T, E>
+ */
+final class Ripe extends Basket
+{
+    /** @param T $fruit */
+    public function __construct(
+        private mixed $fruit,
+    ) {}
+
+    /** @return T */
+    public function fruit()
+    {
+        return $this->fruit;
+    }
+
+    /** @return never */
+    public function spoilage(): never
+    {
+        exit();
+    }
+}
+
+/**
+ * @template-covariant T
+ * @template-covariant E
+ * @extends Basket<T, E>
+ */
+final class Spoiled extends Basket
+{
+    /** @param E $spoilage */
+    public function __construct(
+        private mixed $spoilage,
+    ) {}
+
+    /** @return never */
+    public function fruit(): never
+    {
+        exit();
+    }
+
+    /** @return E */
+    public function spoilage()
+    {
+        return $this->spoilage;
+    }
+}
+
+final class Apple {}
+
+enum Spoilage
+{
+    case Bruised;
+    case Moldy;
+}
+
+final class Worm {}
+
+function eat(Apple $apple): void {}
+
+/** Enum as the second type argument: BROKEN — fruit() is inferred as `mixed`. */
+/** @param Basket<Apple, Spoilage> $basket */
+function with_enum_argument(Basket $basket): void
+{
+    if ($basket instanceof Ripe) {
+        eat($basket->fruit());
+    }
+}
+
+/** Class as the second type argument: works — fruit() is correctly `Apple`. */
+/** @param Basket<Apple, Worm> $basket */
+function with_class_argument(Basket $basket): void
+{
+    if ($basket instanceof Ripe) {
+        eat($basket->fruit());
+    }
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -617,6 +617,7 @@ test_case!(reconcile_literl_class_string);
 test_case!(class_string_is_never_equal_to_literal_string);
 test_case!(narrow_class_string_match);
 test_case!(narrow_non_final_class_string_match);
+test_case!(narrow_class_string_enum_generic);
 test_case!(expand_class_constant_type);
 test_case!(iterator_to_array);
 test_case!(arrow_function_inherits_method_templates);

--- a/crates/codex/src/ttype/comparator/atomic_comparator.rs
+++ b/crates/codex/src/ttype/comparator/atomic_comparator.rs
@@ -194,6 +194,12 @@ pub fn is_contained_by(
         return true;
     }
 
+    if input_type_part.is_mixed() || input_type_part.is_templated_as_mixed() {
+        atomic_comparison_result.type_coerced = Some(true);
+        atomic_comparison_result.type_coerced_from_nested_mixed = Some(true);
+        return false;
+    }
+
     if let TAtomic::Object(TObject::Enum(enum_container)) = container_type_part {
         return match input_type_part {
             TAtomic::Object(TObject::Enum(enum_input)) => {
@@ -223,12 +229,6 @@ pub fn is_contained_by(
             }
             _ => false,
         };
-    }
-
-    if input_type_part.is_mixed() || input_type_part.is_templated_as_mixed() {
-        atomic_comparison_result.type_coerced = Some(true);
-        atomic_comparison_result.type_coerced_from_nested_mixed = Some(true);
-        return false;
     }
 
     if matches!(input_type_part, TAtomic::Null) {


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes a false `mixed-argument` / `mixed-return-statement` where narrowing a generic
type to one of its subtypes dropped **all** of its template arguments whenever one of
those arguments was an `enum`.

## 🔍 Context & Motivation

Reported in #2035. When a value of a generic type is narrowed to a subtype — via
`instanceof`, `match ($x::class)`, or `$x::class === Sub::class` — Mago lost the
generic's template arguments if **any** argument was an enum. A method returning a
template parameter (e.g. `fruit(): T`) was then inferred as `mixed`, producing false
positives below the narrowing. The identical code with a **class** in that argument
position worked, which isolated the bug to enum handling in the type comparator.
(Narrowing via an `@assert-if-true` method was unaffected, since that assertion carries
the template arguments explicitly.)

**Root cause:** in `atomic_comparator::is_contained_by`, the enum-container branch
returned early for a `mixed` input without setting `type_coerced_from_nested_mixed`,
while the general "a `mixed` input coerces into a specific container" rule that sets it
ran only *after* the enum branch — so it applied to class containers but not enum ones.
Without that coercion signal the generic-parameter check failed, and the reconciler
never copied the parent's template arguments onto the narrowed subtype (leaving it bare
→ `mixed`).

## 🛠️ Summary of Changes

- **Bug Fix:** Move the "`mixed` input coerces into a specific container" rule **ahead
  of** the enum-container branch in `atomic_comparator::is_contained_by`, so an enum
  type argument receives the same coercion signal as a class argument. This restores the
  ordering the named-class handler already relied on.
- **Test:** Add the `narrow_class_string_enum_generic` analyzer fixture — a generic
  `Basket<T, E>` sealed into `Ripe`/`Spoiled`, narrowed with `instanceof`, where `E` is
  an enum — with a class-argument counterpart that confirms the fix is specific to enum
  type arguments.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other: Analyzer / type system (`codex` comparator)

## 🔗 Related Issues or PRs

Fixes #2035. Related to #1375 and #367 (earlier narrowing / template-loss fixes that
didn't cover enum type arguments).

## 📝 Notes for Reviewers

- The fix is a reordering: the `mixed`-coercion rule is general and already sat ahead of
  the named-class handler; the enum handler simply preempted it. Moving it ahead of the
  enum handler makes enum and class type arguments behave identically.
- Only the `mixed` / templated-as-`mixed` input path changes; concrete inputs are
  unaffected. Full `cargo test --workspace` and the `mago-codex` property tests pass.
