### PR TITLE
feat: Add support for the @Final annotation during structure validation.

### DIFF
--- a/crates/guard/src/structural/mod.rs
+++ b/crates/guard/src/structural/mod.rs
@@ -128,7 +128,11 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
             }
 
             if let Some(must_be_final) = structural_rule.must_be_final {
-                let is_final = class.modifiers.contains_final();
+                let is_final = context
+                    .codebase
+                    .get_class(fqn)
+                    .map(|c| c.flags.is_final())
+                    .unwrap_or(class.modifiers.contains_final());
 
                 match (must_be_final, is_final) {
                     (true, false) => {

--- a/crates/guard/tests/mod.rs
+++ b/crates/guard/tests/mod.rs
@@ -22,6 +22,9 @@ use mago_guard::settings::PerimeterSettings;
 use mago_guard::settings::PermittedDependency;
 use mago_guard::settings::PermittedDependencyKind;
 use mago_guard::settings::Settings;
+use mago_guard::settings::StructuralRule;
+use mago_guard::settings::StructuralSettings;
+use mago_guard::settings::StructuralSymbolKind;
 use mago_names::resolver::NameResolver;
 use mago_prelude::Prelude;
 use mago_syntax::parser::parse_file;
@@ -595,5 +598,36 @@ pub fn test_narrow_rule_not_widened_by_broad_catchall() {
     assert!(
         !result.boundary_breaches.is_empty(),
         "Expected violations: Domain should not be allowed to use Infrastructure"
+    );
+}
+
+#[test]
+pub fn test_is_final_annotation_counted() {
+    let code = indoc! {r"
+        <?php
+            namespace App\Entity {
+                /** @final */
+                class Test {
+
+                }
+            }
+    "};
+
+    let settings = Settings {
+        structural: StructuralSettings {
+            rules: vec![StructuralRule {
+                on: "**\\Entity\\*".into(),
+                target: StructuralSymbolKind::Class.into(),
+                must_be_final: Some(true),
+                ..Default::default()
+            }],
+        },
+        ..Default::default()
+    };
+
+    let result = test_guard("count_final_annotation_as_real_final_class", code, settings);
+    assert!(
+        result.structural_flaws.is_empty(),
+        "Expected non violations: Should allow declare final class with annotation"
     );
 }


### PR DESCRIPTION
## 📌 Add support for the ```@final``` annotation during structure validation.

Added the is_final check not only for the Class structure, but also for ClassLikeMetadata.

## 🔍 Context & Motivation

Besides using the final keyword as a class modifier, the ```@final``` annotation is also sometimes used. This is especially common when working with Doctrine.

## 🛠️ Summary of Changes

- **Feature:** Update guard structural, count ```@final``` annotation

## 📂 Affected Areas

- [X] Guard


## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers
