### PR TITLE
fix(semantics): allow `__call`, `__callStatic` and `__invoke` in enums

### DIFF
--- a/crates/semantics/src/internal/checker/class_like/mod.rs
+++ b/crates/semantics/src/internal/checker/class_like/mod.rs
@@ -25,7 +25,7 @@ use mago_syntax::cst::TraitUseAliasAdaptation;
 use crate::internal::checker::partial_application;
 use crate::internal::consts::ANONYMOUS_CLASS_NAME;
 use crate::internal::consts::CONSTRUCTOR_MAGIC_METHOD;
-use crate::internal::consts::MAGIC_METHODS;
+use crate::internal::consts::ENUM_FORBIDDEN_MAGIC_METHODS;
 use crate::internal::consts::RESERVED_KEYWORDS;
 use crate::internal::consts::SOFT_RESERVED_KEYWORDS_MINUS_SYMBOL_ALLOWED;
 use crate::internal::context::Context;
@@ -924,8 +924,9 @@ pub fn check_enum<'ast, 'arena>(r#enum: &'ast Enum<'arena>, context: &mut Contex
                 let method_name_bytes: &[u8] = method.name.value;
                 let method_name = BytesDisplay(method_name_bytes);
 
-                if let Some(magic_method) =
-                    MAGIC_METHODS.iter().find(|magic_method| magic_method.eq_ignore_ascii_case(method_name_bytes))
+                if let Some(magic_method) = ENUM_FORBIDDEN_MAGIC_METHODS
+                    .iter()
+                    .find(|magic_method| magic_method.eq_ignore_ascii_case(method_name_bytes))
                 {
                     let magic_method = BytesDisplay(magic_method);
                     context.report(

--- a/crates/semantics/src/internal/consts.rs
+++ b/crates/semantics/src/internal/consts.rs
@@ -18,12 +18,11 @@ pub const INVOKE_MAGIC_METHOD: &[u8] = b"__invoke";
 pub const SET_STATE_MAGIC_METHOD: &[u8] = b"__set_state";
 pub const DEBUG_INFO_MAGIC_METHOD: &[u8] = b"__debugInfo";
 
-pub const MAGIC_METHODS: &[&[u8]] = &[
+// Enums forbid all magic methods except `__call`, `__callStatic` and `__invoke`.
+pub const ENUM_FORBIDDEN_MAGIC_METHODS: &[&[u8]] = &[
     CONSTRUCTOR_MAGIC_METHOD,
     DESTRUCTOR_MAGIC_METHOD,
     CLONE_MAGIC_METHOD,
-    CALL_MAGIC_METHOD,
-    CALL_STATIC_MAGIC_METHOD,
     GET_MAGIC_METHOD,
     SET_MAGIC_METHOD,
     ISSET_MAGIC_METHOD,
@@ -33,7 +32,6 @@ pub const MAGIC_METHODS: &[&[u8]] = &[
     SERIALIZE_MAGIC_METHOD,
     UNSERIALIZE_MAGIC_METHOD,
     TO_STRING_MAGIC_METHOD,
-    INVOKE_MAGIC_METHOD,
     SET_STATE_MAGIC_METHOD,
     DEBUG_INFO_MAGIC_METHOD,
 ];

--- a/crates/semantics/tests/enum_magic_methods.rs
+++ b/crates/semantics/tests/enum_magic_methods.rs
@@ -1,0 +1,49 @@
+use std::borrow::Cow;
+
+use mago_allocator::LocalArena;
+
+use mago_database::file::File;
+use mago_names::resolver::NameResolver;
+use mago_php_version::PHPVersion;
+use mago_semantics::SemanticsChecker;
+use mago_syntax::parser::parse_file;
+
+fn collect_codes(source: &str) -> Vec<String> {
+    let arena = LocalArena::new();
+    let file = File::ephemeral(Cow::Borrowed(b"test.php"), Cow::Owned(source.as_bytes().to_vec()));
+    let program = parse_file(&arena, &file);
+    assert!(program.errors.is_empty(), "test source did not parse: {:?}", program.errors);
+
+    let names = NameResolver::new(&arena).resolve(program);
+    let issues = SemanticsChecker::new(PHPVersion::new(8, 4, 0)).check(&file, program, &names);
+
+    issues.iter().filter_map(|issue| issue.code.clone()).collect()
+}
+
+fn assert_reports_semantics(source: &str) {
+    let codes = collect_codes(source);
+    assert!(codes.iter().any(|c| c == "semantics"), "expected a semantics issue, got {codes:?}");
+}
+
+fn assert_no_semantics(source: &str) {
+    let codes = collect_codes(source);
+    assert!(!codes.iter().any(|c| c == "semantics"), "did not expect a semantics issue, got {codes:?}");
+}
+
+#[test]
+fn forbidden_magic_methods_in_enum_are_rejected() {
+    assert_reports_semantics("<?php enum E { public function __construct() {} }");
+    assert_reports_semantics("<?php enum E { public function __destruct() {} }");
+    assert_reports_semantics("<?php enum E { public function __clone(): void {} }");
+    assert_reports_semantics("<?php enum E { public function __get(string $name): mixed {} }");
+    assert_reports_semantics("<?php enum E { public function __toString(): string {} }");
+}
+
+#[test]
+fn call_magic_methods_in_enum_are_ok() {
+    assert_no_semantics("<?php enum E { public function __call(string $name, array $arguments): mixed {} }");
+    assert_no_semantics(
+        "<?php enum E { public static function __callStatic(string $name, array $arguments): mixed {} }",
+    );
+    assert_no_semantics("<?php enum E { public function __invoke(): mixed {} }");
+}


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes magic method checks for enums.

## 🔍 Context & Motivation

The enum checker reports every magic method as forbidden, but PHP permits `__call`, `__callStatic` and `__invoke` in enums. The magic method list has no other consumer, so we can encode the exception directly in the list and name it after its actual purpose.

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed incorrect semantics error diagnostics for certain magic methods on enums.
- 
## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): semantics

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
