### PR TITLE
fix(analyzer, codex): allow void for nullable PHPDoc returns

### DIFF
--- a/crates/analyzer/src/statement/class_like/method_signature.rs
+++ b/crates/analyzer/src/statement/class_like/method_signature.rs
@@ -263,12 +263,10 @@ pub fn validate_method_signature_compatibility(
 
         if !expanded_parent_return_type.has_template_types() && !expanded_child_return_type.has_template_types() {
             let mut comparison_result = ComparisonResult::new();
-            let is_compatible = union_comparator::is_contained_by(
+            let is_compatible = union_comparator::is_return_type_contained_by(
                 codebase,
                 &expanded_child_return_type,
                 &expanded_parent_return_type,
-                false,
-                false,
                 false,
                 &mut comparison_result,
             );

--- a/crates/analyzer/tests/cases/issue_2081.php
+++ b/crates/analyzer/tests/cases/issue_2081.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @template R of int|null
+ * @mago-expect analysis:unused-template-parameter
+ */
+interface QueryInterface
+{}
+
+/**
+ * @template R of int|null
+ * @template Q of QueryInterface<R>
+ * @method R handle(Q $query)
+ */
+interface QueryHandlerInterface
+{}
+
+/**
+ * @implements QueryInterface<null>
+ */
+class Foo implements QueryInterface
+{}
+
+/**
+ * @implements QueryHandlerInterface<null, Foo>
+ */
+class MyHandler implements QueryHandlerInterface
+{
+    public function handle(Foo $query): void
+    {
+        return;
+    }
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -2352,6 +2352,7 @@ test_case!(issue_2029);
 test_case!(issue_2037);
 test_case!(issue_2071);
 test_case!(issue_2073);
+test_case!(issue_2081);
 test_case!(issue_2048);
 test_case!(issue_2050);
 test_case!(issue_2054);

--- a/crates/codex/src/populator/docblock.rs
+++ b/crates/codex/src/populator/docblock.rs
@@ -482,12 +482,10 @@ fn apply_inheritance_work(codebase: &mut CodebaseMetadata, mut inheritance_work:
                 codebase.function_likes.get(&child_method_id).and_then(|m| m.return_type_declaration_metadata.as_ref());
 
             let narrowed_type = if let Some(child_native_return) = child_native_return {
-                let child_is_more_specific = union_comparator::is_contained_by(
+                let child_is_more_specific = union_comparator::is_return_type_contained_by(
                     codebase,
                     &child_native_return.type_union,
                     &type_union,
-                    false,
-                    false,
                     false,
                     &mut ComparisonResult::new(),
                 );

--- a/crates/codex/src/ttype/comparator/callable_comparator.rs
+++ b/crates/codex/src/ttype/comparator/callable_comparator.rs
@@ -131,21 +131,11 @@ pub(crate) fn is_contained_by(
         return false;
     };
 
-    if input_return_type.is_void() && container_return_type.accepts_null() {
-        return true;
-    }
-
-    if input_return_type.is_never() {
-        return true;
-    }
-
-    union_comparator::is_contained_by(
+    union_comparator::is_return_type_contained_by(
         codebase,
         input_return_type,
         container_return_type,
-        false,
         input_return_type.ignore_falsable_issues(),
-        false,
         atomic_comparison_result,
     )
 }

--- a/crates/codex/src/ttype/comparator/union_comparator.rs
+++ b/crates/codex/src/ttype/comparator/union_comparator.rs
@@ -54,6 +54,18 @@ pub fn is_contained_by(
 }
 
 #[inline]
+pub fn is_return_type_contained_by(
+    codebase: &CodebaseMetadata,
+    input_type: &TUnion,
+    container_type: &TUnion,
+    ignore_false: bool,
+    union_comparison_result: &mut ComparisonResult,
+) -> bool {
+    (input_type.is_void() && container_type.accepts_null())
+        || is_contained_by(codebase, input_type, container_type, false, ignore_false, false, union_comparison_result)
+}
+
+#[inline]
 #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
 fn is_contained_by_atomic(
     codebase: &CodebaseMetadata,


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes incorrect return type handling when a generic `@method` return type resolves to `null` and the implementing method declares `void`.

## 🔍 Context & Motivation

Before, inherited PHPDoc narrowing removed `null` from a null-only union, producing `never` and causing false `invalid-return-statement` and `incompatible-return-type` diagnostics.

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed generic nullable PHPDoc return types being incorrectly narrowed to `never` when implemented with `void`.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): `analyzer` and `codex`

## 🔗 Related Issues or PRs

Fixes #2081
