### PR TITLE
fix(analyzer): accept @method calls backed by an inherited real method

### DIFF
--- a/crates/analyzer/src/resolver/static_method.rs
+++ b/crates/analyzer/src/resolver/static_method.rs
@@ -2,6 +2,7 @@ use mago_allocator::Arena;
 use std::sync::Arc;
 
 use mago_word::Word;
+use mago_word::ascii_lowercase_word;
 use mago_word::word;
 
 use mago_codex::identifier::method::MethodIdentifier;
@@ -41,6 +42,7 @@ use crate::resolver::selector::resolve_member_selector;
 use crate::utils::names::display_class_like_name;
 use crate::utils::names::display_method_name;
 use crate::visibility::check_method_visibility;
+use crate::visibility::is_method_visible;
 
 /// Resolves all possible static method targets from a class expression and a member selector.
 ///
@@ -396,7 +398,11 @@ where
         result.has_invalid_target = true;
     }
 
-    if function_like.flags.is_magic_method() && !has_magic_static_call && !defining_class_metadata.kind.is_interface() {
+    if function_like.flags.is_magic_method()
+        && !has_magic_static_call
+        && !defining_class_metadata.kind.is_interface()
+        && !has_real_ancestor_method(context, block_context, defining_class_metadata, method_name)
+    {
         let is_static = !classname.is_parent();
 
         if defining_class_metadata.flags.is_final() && !defining_class_metadata.flags.is_abstract() {
@@ -546,6 +552,35 @@ where
         is_this: true,
         intersection_types: if intersections.is_empty() { None } else { Some(intersections) },
         remapped_parameters: false,
+    })
+}
+
+/// Returns `true` if any ancestor class or used trait provides a real, non-magic implementation
+/// of `method_name` that is accessible from the current scope.
+///
+/// An `@method` tag may shadow such an inherited method (e.g. to refine its return type); the
+/// call is then backed by a real implementation, so no `__callStatic` is required. Traits are
+/// consulted directly because an ancestor's method slot may itself hold a pseudo-method even
+/// though a used trait provides the real one. Inaccessible methods don't count: PHP routes those
+/// calls through `__callStatic`, so the magic handler is still required.
+fn has_real_ancestor_method<'ctx, A>(
+    context: &Context<'ctx, '_, A>,
+    block_context: &BlockContext<'ctx>,
+    class_metadata: &ClassLikeMetadata,
+    method_name: Word,
+) -> bool
+where
+    A: Arena,
+{
+    let method_name_lc = ascii_lowercase_word(method_name.as_bytes());
+
+    class_metadata.all_parent_classes.iter().chain(class_metadata.used_traits.iter()).any(|ancestor_name| {
+        context.codebase.get_class_like(ancestor_name.as_bytes()).is_some_and(|ancestor| {
+            ancestor.declaring_method_ids.get(&method_name_lc).is_some_and(|declaring_id| {
+                context.codebase.get_method_by_id(declaring_id).is_some_and(|m| !m.flags.is_magic_method())
+                    && is_method_visible(context, block_context, ancestor_name.as_bytes(), method_name_lc.as_bytes())
+            })
+        })
     })
 }
 

--- a/crates/analyzer/src/visibility/mod.rs
+++ b/crates/analyzer/src/visibility/mod.rs
@@ -93,6 +93,36 @@ where
     is_visible
 }
 
+/// Determines whether a method is visible from the current scope
+///
+/// Returns `true` when the method is visible (or when visibility cannot be determined), and
+/// `false` only when the method definitively exists but is inaccessible from the current scope.
+pub fn is_method_visible<'ctx, A>(
+    context: &Context<'ctx, '_, A>,
+    block_context: &BlockContext<'ctx>,
+    fqcn: &[u8],
+    method_name: &[u8],
+) -> bool
+where
+    A: Arena,
+{
+    let declaring_class = context.codebase.get_declaring_method_class(fqcn, method_name).unwrap_or_else(|| word(fqcn));
+
+    if context.codebase.get_declaring_method(fqcn, method_name).is_none() {
+        return true;
+    }
+
+    let Some(visibility) = context.codebase.get_method_visibility(fqcn, method_name) else {
+        return true;
+    };
+
+    if visibility == Visibility::Public {
+        return true;
+    }
+
+    is_visible_from_scope(context, visibility, declaring_class.as_bytes(), block_context.scope.get_class_like_name())
+}
+
 /// Checks if a property is readable from the current scope and reports a detailed
 /// error if it is not.
 pub fn check_property_read_visibility<'ctx, A>(

--- a/crates/analyzer/tests/cases/trait_method_satisfies_pseudo_method.php
+++ b/crates/analyzer/tests/cases/trait_method_satisfies_pseudo_method.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+trait Doing
+{
+    public static function doit(): void {}
+    protected static function doit_prot(): void {}
+}
+
+class BaseTask
+{
+    use Doing;
+}
+
+/**
+ * @method static void doit()
+ * @method static void doit_prot()
+ */
+final class SubTask extends BaseTask
+{
+}
+
+// `SubTask` re-declares the `@method` tag but inherits the real trait method from `BaseTask`.
+// The documented method is backed by a real implementation reachable through the ancestry, so the
+// call must not be flagged as a missing magic method (regression test for #1184).
+SubTask::doit();
+
+// `doit_prot()` is protected: from the global scope the inherited implementation is inaccessible,
+// so PHP routes the call through `__callStatic`, which `SubTask` lacks.
+SubTask::doit_prot(); // @mago-expect analysis:missing-magic-method
+
+/**
+ * @method static void doit()
+ */
+class DocumentedBase
+{
+    use Doing;
+}
+
+/**
+ * @method static void doit()
+ */
+final class DocumentedSub extends DocumentedBase
+{
+}
+
+// Both the parent and the subclass re-declare the `@method` tag while the real implementation
+// comes from a trait used by the parent. The parent's method slot holds a pseudo-method as well,
+// so the real implementation is only found by consulting the used traits directly.
+DocumentedSub::doit();

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -660,6 +660,7 @@ test_case!(trait_alias_vis_self);
 test_case!(trait_constant_override);
 test_case!(trait_usage_errors);
 test_case!(trait_method_closure_self);
+test_case!(trait_method_satisfies_pseudo_method);
 test_case!(method_signature_parameter_count);
 test_case!(method_signature_param_types);
 test_case!(method_signature_return_types);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes a false `missing-magic-method` / `possibly-non-existent-method`
diagnostic for calls to methods documented with an `@method` tag when a
real implementation is inherited through the class ancestry.

## 🔍 Context & Motivation

A class that re-declares an inherited method with an `@method` tag —
e.g. to document or refine its signature — while the real
implementation comes from a trait used by a parent class is flagged as
needing a `__callStatic` handler: the pseudo-method created from the
tag shadows the inherited implementation, so the resolver only sees
the documented magic method.

The parent's method slot can hold a pseudo-method too (e.g. Saloon's
`MockResponse extends FakeResponse`, where both carry
`@method static static make(...)` and the implementation lives in the
`Makeable` trait), so traits used anywhere in the ancestry are
consulted directly. Inaccessible implementations don't count: PHP
routes calls to inaccessible methods through `__callStatic`, so the
diagnostic stands for such callers.

## 🛠️ Summary of Changes

- **Bug Fix:** Calls to `@method`-documented methods are no longer flagged as missing a magic handler when a real, accessible implementation is reachable through parent classes or their traits.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): analyzer