### PR TITLE
fix(cli): restore default SIGPIPE handling so piped output does not panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,6 +1401,7 @@ dependencies = [
  "flate2",
  "indicatif",
  "indoc",
+ "libc",
  "libtest-mimic",
  "mago-algebra",
  "mago-allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -309,6 +309,10 @@ mago-prelude = { workspace = true, features = ["build"] }
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_env = "musl", target_env = "gnu"))'.dependencies]
 mimalloc = { version = "0.1.47" }
 
+# TODO(azjezz): replace with https://dev-doc.rust-lang.org/beta/unstable-book/language-features/unix-sigpipe.html once stable.
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
 [features]
 dhat-heap = ["dhat"]
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,22 @@ static ALLOC: dhat::Alloc = dhat::Alloc;
 /// Exit code 2 indicates the tool itself failed to complete its operation.
 const EXIT_CODE_ERROR: u8 = 2;
 
+/// Restores the default SIGPIPE behavior so output piped into `head` or `less` exits quietly.
+///
+/// Rust ignores SIGPIPE by default, turning writes to a closed pipe into EPIPE errors that make
+/// `println!` panic. Restoring the default lets standard Unix pipe behavior terminate the process.
+#[cfg(unix)]
+fn reset_sigpipe() {
+    // SAFETY: Resetting SIGPIPE to default (SIG_DFL) is safe.
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+}
+
+/// Windows has no SIGPIPE.
+#[cfg(not(unix))]
+fn reset_sigpipe() {}
+
 /// Entry point for the Mago CLI application.
 ///
 /// This function initializes the heap profiler (if enabled), runs the main application logic,
@@ -113,6 +129,7 @@ pub fn main() -> ExitCode {
     // trace event is emitted from inside `run` once tracing is wired up;
     // telemetry in this function only matters when `MAGO_LOG=trace`.
     let main_start = Instant::now();
+    reset_sigpipe();
 
     #[cfg(feature = "dhat-heap")]
     let _profiler = dhat::Profiler::new_heap();


### PR DESCRIPTION
## 📌 What Does This PR Do?

Restores the default `SIGPIPE` disposition on Unix, so piping a Mago command into a reader that exits early (`head`, `less`) terminates quietly instead of panicking.

## 🔍 Context & Motivation

`mago format --dry-run | head -n10` currently panics:

```
thread 'main' panicked at library/std/src/io/stdio.rs:1165:9:
failed printing to stdout: Broken pipe (os error 32)
```

Rust ignores `SIGPIPE` at startup, so writing to a closed pipe surfaces as an `EPIPE` error instead of terminating the process, and `println!` panics on it.

`apply_update` in `src/utils/mod.rs` is only where #2090 happened to surface. There are ~176 `println!` call sites across `src/`, so `mago ast | head`, `mago cst | less` and friends are exposed the same way, and @cweiske reported the same panic with `| less` after quitting the first page. Patching individual call sites would leave the rest of that surface broken, so this restores the default disposition once at startup, which is what `cat`, `grep` and `rg` do.

## 🛠️ Summary of Changes

- **Bug Fix:** Restore default `SIGPIPE` handling at CLI startup so piped output no longer panics with "failed printing to stdout: Broken pipe".
- **Dependencies:** Add a Unix-gated `libc` dependency to the `mago` crate. `libc` is already declared in `[workspace.dependencies]`, so this references it with `{ workspace = true }`.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [x] CLI
- [x] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Fixes #2090

## 📝 Notes for Reviewers

Verified against the reported reproduction, same fixture and same command (`mago format --dry-run | head -n5`):

| build | result |
|---|---|
| before | `thread 'main' panicked ... failed printing to stdout: Broken pipe (os error 32)` |
| after | no panic, no stderr output; Mago is terminated by `SIGPIPE` (the pipeline shows exit `0` because `head` exits `0`, or `141` under `set -o pipefail`) |

`reset_sigpipe()` is called immediately after `main_start` is captured, so the existing "captured before anything else" timing comment still holds. The `libc::signal` call runs before any threads are spawned, which is why the `unsafe` block is sound.

Windows is unaffected: it has no `SIGPIPE`, so the `#[cfg(not(unix))]` arm is a no-op.

One behavioral note worth a second opinion: on a closed pipe the process now dies from `SIGPIPE` rather than unwinding, so destructors do not run in that path. That is conventional for CLI tools, but flag it if Mago relies on teardown work at exit.

Local runs of the CI checks all pass: `cargo check --workspace --locked`, `cargo fmt --all -- --check`, `cargo clippy --workspace --all-features -- -D warnings`.

