### PR TITLE
fix(composer): exclude the new "tests" testsuite from the package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,4 +19,6 @@ flake.nix export-ignore
 flake.lock export-ignore
 mago.toml export-ignore
 scripts/ export-ignore
+/cases/ export-ignore
 /src/ export-ignore
+/tests/ export-ignore


### PR DESCRIPTION
## 📌 What Does This PR Do?

exclude the new "tests" testsuite from the package

## 🔍 Context & Motivation

The files end up in the composer package

## 🛠️ Summary of Changes

- **Bug Fix:** Strip internal test files from the composer package

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Composer

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
