### PR TITLE
feat(analyzer): report overriding methods missing a return type declaration

### DIFF
--- a/crates/analyzer/src/statement/class_like/method_signature.rs
+++ b/crates/analyzer/src/statement/class_like/method_signature.rs
@@ -17,6 +17,7 @@ pub enum SignatureCompatibilityIssue {
     ParameterCountMismatch { child_required_count: usize, parent_required_count: usize },
     IncompatibleParameterType { parameter_index: usize, child_type: Word, parent_type: Word },
     IncompatibleReturnType { child_type: Word, parent_type: Word },
+    MissingReturnTypeDeclaration { parent_type: Word },
     ParameterNameMismatch { parameter_index: usize, child_name: Word, parent_name: Word },
 }
 
@@ -27,6 +28,8 @@ pub enum SignatureCompatibilityIssue {
 /// - Visibility can only widen (public >= protected >= private)
 /// - Parameters are contravariant (child must accept >= parent accepts)
 /// - Return type is covariant (child must return <= parent returns)
+/// - Return type declaration must be present when a non-builtin parent declares one
+///   (builtin declarations may be tentative, where omission only deprecates)
 /// - Parameter count (child must accept at least parent's required parameters)
 /// - Parameter names should match (warning only - breaks named arguments)
 ///
@@ -198,6 +201,29 @@ pub fn validate_method_signature_compatibility(
                 parent_name: parent_param.name.0,
             });
         }
+    }
+
+    if let Some(parent_return) = &parent_method.return_type_declaration_metadata
+        && child_method.return_type_declaration_metadata.is_none()
+        && !parent_method.flags.is_built_in()
+    {
+        let mut expanded_parent_return_type = parent_return.type_union.clone();
+
+        let expansion_options = TypeExpansionOptions {
+            self_class: Some(child_class_name),
+            static_class_type: StaticClassType::Name(child_class_name),
+            function_is_final: child_method_meta.is_final,
+            ..Default::default()
+        };
+
+        if expanded_parent_return_type.is_expandable() {
+            expand_union(codebase, &mut expanded_parent_return_type, &expansion_options);
+        }
+
+        issues.push(SignatureCompatibilityIssue::MissingReturnTypeDeclaration {
+            parent_type: expanded_parent_return_type.get_id(),
+        });
+        return issues;
     }
 
     if let (Some(parent_return), Some(child_return)) =

--- a/crates/analyzer/src/statement/class_like/mod.rs
+++ b/crates/analyzer/src/statement/class_like/mod.rs
@@ -3008,6 +3008,25 @@ fn report_signature_compatibility_issue<'ctx, A>(
                 .with_help("Change the return type to be compatible with the parent method."),
             );
         }
+        SignatureCompatibilityIssue::MissingReturnTypeDeclaration { parent_type } => {
+            context.collector.report_with_code(
+                IssueCode::IncompatibleReturnType,
+                Issue::error(format!(
+                    "`{child_name}::{method_name}()` must declare a return type compatible with `{parent_type}` declared by `{parent_name}::{method_name}()`"
+                ))
+                .with_annotation(Annotation::primary(primary_span).with_message(format!(
+                    "This method has no return type declaration, but the parent declares `{parent_type}`"
+                )))
+                .with_annotation(Annotation::secondary(parent_class_span).with_message(format!(
+                    "Parent method `{parent_name}::{method_name}()` return type declared here"
+                )))
+                .with_annotation(
+                    Annotation::secondary(child_class_span).with_message(format!("In class `{child_name}`")),
+                )
+                .with_note("PHP requires an overriding method to declare a return type when the overridden method declares one.")
+                .with_help(format!("Add a return type declaration compatible with `{parent_type}`.")),
+            );
+        }
         SignatureCompatibilityIssue::ParameterNameMismatch {
             parameter_index,
             child_name: child_param_name,

--- a/crates/analyzer/tests/cases/inheritance_return_type_missing_declaration.php
+++ b/crates/analyzer/tests/cases/inheritance_return_type_missing_declaration.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+interface InhMissingRetIface
+{
+    public function exec(): int;
+}
+
+class InhMissingRetImpl implements InhMissingRetIface
+{
+    /** @mago-expect analysis:incompatible-return-type */
+    public function exec()
+    {
+        return 1;
+    }
+}
+
+abstract class InhMissingRetBase
+{
+    abstract public function run(): int;
+}
+
+class InhMissingRetChild extends InhMissingRetBase
+{
+    /** @mago-expect analysis:incompatible-return-type */
+    public function run()
+    {
+        return 1;
+    }
+}

--- a/crates/analyzer/tests/cases/inheritance_return_type_missing_declaration_allowed.php
+++ b/crates/analyzer/tests/cases/inheritance_return_type_missing_declaration_allowed.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+// Builtin declarations may be tentative: omitting the return type only
+// raises a deprecation at runtime, so no error is reported.
+class InhMissingRetCountable implements Countable
+{
+    public function count()
+    {
+        return 1;
+    }
+}
+
+// A docblock-only return type on the parent imposes no declaration
+// requirement on the child.
+abstract class InhMissingRetDocblockBase
+{
+    /** @return int */
+    abstract public function run();
+}
+
+class InhMissingRetDocblockChild extends InhMissingRetDocblockBase
+{
+    public function run()
+    {
+        return 1;
+    }
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -1925,6 +1925,8 @@ test_case!(inheritance_return_nullable_added);
 test_case!(inheritance_return_nullable_removed);
 test_case!(inheritance_return_type_covariant);
 test_case!(inheritance_return_type_int_to_void);
+test_case!(inheritance_return_type_missing_declaration);
+test_case!(inheritance_return_type_missing_declaration_allowed);
 test_case!(inheritance_return_type_never_ok);
 test_case!(inheritance_return_type_void_to_int);
 test_case!(inheritance_return_type_widened);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Reports an `incompatible-return-type` error when an overriding method
omits its return type declaration while the overridden method declares
one.

## 🔍 Context & Motivation

PHP requires an overriding method to declare a return type whenever the
overridden method declares one, but the analyzer's signature
compatibility check only compares return types when both declarations
are present — a child method that simply drops the declaration passes
silently, even though PHP rejects it at runtime.

Builtin parents are exempt: their declarations may be tentative, where
omission only raises a deprecation. Docblock-only return types on the
parent impose no requirement either, since only real declarations do.

## 🛠️ Summary of Changes

- **Feature:** Added a `MissingReturnTypeDeclaration` signature
  compatibility issue, reported as `incompatible-return-type` when a
  non-builtin parent declares a return type and the child does not.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Analyzer