### PR TITLE
Fine-grained level config for disallowed functions/type instantiations linter rules

### DIFF
--- a/crates/linter/src/rule/security/disallowed_functions.rs
+++ b/crates/linter/src/rule/security/disallowed_functions.rs
@@ -25,18 +25,21 @@ pub struct DisallowedFunctionsRule {
     cfg: DisallowedFunctionsConfig,
 }
 
-/// An entry that can be either a simple string or an object with name and optional help.
+/// An entry that can be either a simple string or an object with name and optional help and level override.
 #[derive(Debug, Clone, Eq, PartialEq, JsonSchema)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
 pub enum DisallowedEntry {
     /// Simple string entry (just the name).
     Simple(String),
-    /// Entry with name and optional help message.
-    WithHelp {
+    /// Entry with name and optional help message and level override.
+    Advanced {
         name: String,
         #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
         help: Option<String>,
+        /// Optional level that supersedes the top-level config level for this entry.
+        #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
+        level: Option<Level>,
     },
 }
 
@@ -46,7 +49,7 @@ impl DisallowedEntry {
     pub fn name(&self) -> &str {
         match self {
             DisallowedEntry::Simple(name) => name,
-            DisallowedEntry::WithHelp { name, .. } => name,
+            DisallowedEntry::Advanced { name, .. } => name,
         }
     }
 
@@ -55,7 +58,16 @@ impl DisallowedEntry {
     pub fn help(&self) -> Option<&str> {
         match self {
             DisallowedEntry::Simple(_) => None,
-            DisallowedEntry::WithHelp { help, .. } => help.as_deref(),
+            DisallowedEntry::Advanced { help, .. } => help.as_deref(),
+        }
+    }
+
+    /// Returns the entry-specific level, if any, which supersedes the top-level config level.
+    #[must_use]
+    pub fn level(&self) -> Option<Level> {
+        match self {
+            DisallowedEntry::Simple(_) => None,
+            DisallowedEntry::Advanced { level, .. } => *level,
         }
     }
 }
@@ -97,12 +109,15 @@ impl LintRule for DisallowedFunctionsRule {
                 `functions` or `extensions` options. This helps enforce coding standards,
                 security restrictions, or the usage of preferred alternatives.
 
-                Each entry can be a simple string or an object with `name` and optional `help`:
+                Each entry can be a simple string or an object with `name`, an optional `help`,
+                and an optional `level` that supersedes the top-level `level` for that entry:
 
                 ```toml
                 functions = [
                     'eval',
                     { name = 'error_log', help = 'Use MyLogger instead.' },
+                    { name = 'var_dump', level = 'error' },
+                    { name = 'var_dump', help = 'Do not commit debug code.', level = 'error' },
                 ]
                 ```
             "},
@@ -155,7 +170,9 @@ impl LintRule for DisallowedFunctionsRule {
                 "Use an alternative function or update your configuration if this restriction is no longer needed.",
             );
 
-            let issue = Issue::new(self.cfg.level, format!("Function `{function_name}` is disallowed."))
+            let level = entry.level().unwrap_or(self.cfg.level);
+
+            let issue = Issue::new(level, format!("Function `{function_name}` is disallowed."))
                 .with_code(self.meta.code)
                 .with_annotation(
                     Annotation::primary(function_call.span())
@@ -181,6 +198,8 @@ impl LintRule for DisallowedFunctionsRule {
                 .help()
                 .unwrap_or("Avoid using this extension or update your configuration if exceptions are acceptable.");
 
+            let level = entry.level().unwrap_or(self.cfg.level);
+
             for function_name in *functions {
                 if !function_call_matches(ctx, function_call, function_name) {
                     continue;
@@ -188,7 +207,7 @@ impl LintRule for DisallowedFunctionsRule {
 
                 ctx.collector.report(
                     Issue::new(
-                        self.cfg.level,
+                        level,
                         format!("Function `{function_name}` from the `{extension}` extension is disallowed."),
                     )
                     .with_code(self.meta.code)

--- a/crates/linter/src/rule/security/disallowed_type_instantiation.rs
+++ b/crates/linter/src/rule/security/disallowed_type_instantiation.rs
@@ -24,18 +24,21 @@ pub struct DisallowedTypeInstantiationRule {
     cfg: DisallowedTypeInstantiationConfig,
 }
 
-/// An entry that can be either a simple string or an object with name and optional help.
+/// An entry that can be either a simple string or an object with name and optional help and level override.
 #[derive(Debug, Clone, Eq, PartialEq, JsonSchema)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
 pub enum DisallowedTypeEntry {
     /// Simple string entry (just the name).
     Simple(String),
-    /// Entry with name and optional help message.
-    WithHelp {
+    /// Entry with name and optional help message and level override.
+    Advanced {
         name: String,
         #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
         help: Option<String>,
+        /// Optional level that supersedes the top-level config level for this entry.
+        #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
+        level: Option<Level>,
     },
 }
 
@@ -45,7 +48,7 @@ impl DisallowedTypeEntry {
     pub fn name(&self) -> &str {
         match self {
             DisallowedTypeEntry::Simple(name) => name,
-            DisallowedTypeEntry::WithHelp { name, .. } => name,
+            DisallowedTypeEntry::Advanced { name, .. } => name,
         }
     }
 
@@ -54,7 +57,16 @@ impl DisallowedTypeEntry {
     pub fn help(&self) -> Option<&str> {
         match self {
             DisallowedTypeEntry::Simple(_) => None,
-            DisallowedTypeEntry::WithHelp { help, .. } => help.as_deref(),
+            DisallowedTypeEntry::Advanced { help, .. } => help.as_deref(),
+        }
+    }
+
+    /// Returns the entry-specific level, if any, which supersedes the top-level config level.
+    #[must_use]
+    pub fn level(&self) -> Option<Level> {
+        match self {
+            DisallowedTypeEntry::Simple(_) => None,
+            DisallowedTypeEntry::Advanced { level, .. } => *level,
         }
     }
 }
@@ -98,7 +110,8 @@ impl LintRule for DisallowedTypeInstantiationRule {
                 by preventing direct instantiation of specific classes. This is useful for ensuring consistent
                 configuration, centralizing object creation, and maintaining architectural boundaries.
 
-                Each entry can be a simple string or an object with `name` and optional `help`:
+                Each entry can be a simple string or an object with `name`, an optional `help`,
+                and an optional `level` that supersedes the top-level `level` for that entry:
 
                 ```toml
                 [linter.rules]
@@ -107,6 +120,8 @@ impl LintRule for DisallowedTypeInstantiationRule {
                     types = [
                         'HttpService\\Client',
                         { name = 'DatabaseConnection', help = 'Use DatabaseFactory::create() instead' },
+                        { name = 'LegacyService', level = 'error' },
+                        { name = 'LegacyService', help = 'Use ShinyNewService instead', level = 'error' },
                     ]
                 }
                 ```
@@ -166,8 +181,10 @@ impl LintRule for DisallowedTypeInstantiationRule {
                 "Use an alternative factory or provider pattern, or update your configuration if this restriction is no longer needed.",
             );
 
+            let level = entry.level().unwrap_or(self.cfg.level);
+
             let issue = Issue::new(
-                self.cfg.level,
+                level,
                 format!("Direct instantiation of type `{disallowed_type}` is disallowed."),
             )
             .with_code(self.meta.code)
@@ -249,9 +266,31 @@ mod tests {
         rule = DisallowedTypeInstantiationRule,
         settings = |s: &mut crate::settings::Settings| {
             s.rules.disallowed_type_instantiation.config.types = vec![
-                DisallowedTypeEntry::WithHelp {
+                DisallowedTypeEntry::Advanced {
                     name: "HttpService\\Client".to_string(),
                     help: Some("Use ClientProvider::getClient() instead".to_string()),
+                    level: None,
+                },
+            ];
+        },
+        code = indoc! {r"
+            <?php
+
+            use HttpService\Client;
+
+            $client = new Client();
+        "}
+    }
+
+    test_lint_failure! {
+        name = disallow_type_with_level_override,
+        rule = DisallowedTypeInstantiationRule,
+        settings = |s: &mut crate::settings::Settings| {
+            s.rules.disallowed_type_instantiation.config.types = vec![
+                DisallowedTypeEntry::Advanced {
+                    name: "HttpService\\Client".to_string(),
+                    help: None,
+                    level: Some(Level::Error),
                 },
             ];
         },
@@ -306,9 +345,10 @@ mod tests {
         settings = |s: &mut crate::settings::Settings| {
             s.rules.disallowed_type_instantiation.config.types = vec![
                 DisallowedTypeEntry::Simple("HttpService\\Client".to_string()),
-                DisallowedTypeEntry::WithHelp {
+                DisallowedTypeEntry::Advanced {
                     name: "DatabaseConnection".to_string(),
                     help: Some("Use DatabaseFactory::create() instead".to_string()),
+                    level: None,
                 },
             ];
         },


### PR DESCRIPTION
## 📌 What Does This PR Do?

Adds an optional `level` attribute to the object variants of the `disallowed-functions` and `disallowed-type-instantiations` linter rule entries, so that those entries can be flagged with a different severity from the rule default.

## 🔍 Context & Motivation

Some "disallowed" functions or type instantiations might be more or less undesirable than others. This allows more fine-grained control over the severity of each entry, falling back to the level at the top of the rule config if one is not provided for a given entry.

## 🛠️ Summary of Changes

- **Feature:** Added optional `level` to the `disallowed-functions` and `disallowed-type-instantiations` entry config objects.

## 📂 Affected Areas

- [x] Linter