### PR TITLE
fix(analyzer): report incomparable property override types

### DIFF
--- a/crates/analyzer/src/statement/class_like/mod.rs
+++ b/crates/analyzer/src/statement/class_like/mod.rs
@@ -115,6 +115,7 @@ fn is_type_compatible(codebase: &CodebaseMetadata, child: &TUnion, parent: &TUni
 /// - When the parent has only a `get` hook, covariance (declaring narrower than parent) is allowed.
 /// - When the parent has only a `set` hook, contravariance (declaring wider than parent) is allowed.
 /// - Otherwise, invariance is required.
+/// - Types incomparable with the parent's are invalid under any variance.
 ///
 /// Returns `true` when the declaring type is incompatible with the parent under these rules.
 #[inline]
@@ -130,8 +131,9 @@ fn is_property_type_variance_invalid(
 
     let declaring_is_narrower = declaring_is_subtype_of_parent && !parent_is_subtype_of_declaring;
     let declaring_is_wider = parent_is_subtype_of_declaring && !declaring_is_subtype_of_parent;
+    let incomparable = !declaring_is_subtype_of_parent && !parent_is_subtype_of_declaring;
 
-    (declaring_is_wider && !parent_only_set) || (declaring_is_narrower && !parent_only_get)
+    incomparable || (declaring_is_wider && !parent_only_set) || (declaring_is_narrower && !parent_only_get)
 }
 
 /// Represents different types of property conflicts between traits

--- a/crates/analyzer/tests/cases/property_override_incomparable_type.php
+++ b/crates/analyzer/tests/cases/property_override_incomparable_type.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PropertyOverrideIncomparableType;
+
+class Wide
+{
+}
+
+class Unrelated
+{
+}
+
+class Base
+{
+    public ?Wide $native = null;
+}
+
+// @mago-expect analysis:incompatible-property-type
+class NativeIncomparable extends Base
+{
+    public ?Unrelated $native = null;
+}
+
+class DocblockBase
+{
+    /** @var Wide|null */
+    public mixed $value = null;
+}
+
+// @mago-expect analysis:incompatible-property-type
+class DocblockIncomparable extends DocblockBase
+{
+    /** @var Unrelated|null */
+    public mixed $value = null;
+}
+
+class VirtualBase
+{
+    public ?Wide $virtual {
+        get => null;
+    }
+}
+
+// A get-only virtual property allows covariant overrides, but an
+// incomparable type is not covariant.
+// @mago-expect analysis:incompatible-property-type
+class VirtualIncomparable extends VirtualBase
+{
+    public ?Unrelated $virtual {
+        get => null;
+    }
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -641,6 +641,7 @@ test_case!(private_static_method);
 test_case!(method_docblock);
 test_case!(property_docblock);
 test_case!(untyped_property_docblock);
+test_case!(property_override_incomparable_type);
 test_case!(count);
 test_case!(array_key_exists);
 test_case!(magic_methods);


### PR DESCRIPTION
# 📌 What Does This PR Do?

Reports an `incompatible-property-type` issue when a property
override's type is incomparable with the parent's (neither a subtype
nor a supertype).

## 🔍 Context & Motivation

The property variance check classifies an override type as narrower
or wider than the parent's and validates the direction against the
allowed variance. An incomparable type matches neither classification
and is silently accepted, although it is invalid under any variance
rules.

## 🛠️ Summary of Changes

- **Bug Fix:** Treat property override types incomparable with the
  parent's as incompatible, for native, docblock, and hooked
  (virtual) properties alike.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Analyzer