### PR TITLE
fix(analyzer): resolve @property tags by call-site visibility

### DIFF
--- a/crates/analyzer/src/expression/assignment/property_assignment.rs
+++ b/crates/analyzer/src/expression/assignment/property_assignment.rs
@@ -69,7 +69,11 @@ where
     let mut matched_all_properties = true;
     let mut widened_assigned_type: Option<TUnion> = None;
     for resolved_property in resolution_result.properties {
-        if let Some(declaring_class_id) = resolved_property.declaring_class_id {
+        // A magic-governed write goes through `__set()`, never through the real property of the
+        // same name that may exist on the declaring class (e.g. a `readonly` backing property).
+        if !resolved_property.is_magic
+            && let Some(declaring_class_id) = resolved_property.declaring_class_id
+        {
             crate::readonly::check_property_write(
                 context,
                 block_context,

--- a/crates/analyzer/src/plugin/libraries/stdlib/array/array_column.rs
+++ b/crates/analyzer/src/plugin/libraries/stdlib/array/array_column.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
+use mago_codex::metadata::CodebaseMetadata;
 use mago_codex::metadata::class_like::ClassLikeMetadata;
 use mago_codex::ttype::atomic::TAtomic;
 use mago_codex::ttype::atomic::array::TArray;
@@ -22,6 +23,7 @@ use crate::plugin::provider::Provider;
 use crate::plugin::provider::ProviderMeta;
 use crate::plugin::provider::function::FunctionReturnTypeProvider;
 use crate::plugin::provider::function::FunctionTarget;
+use crate::resolver::property::resolve_property_for_external_access;
 
 static META: ProviderMeta = ProviderMeta::new(
     "php::array::array_column",
@@ -82,7 +84,7 @@ fn try_resolve_from_named_object(
     element_type: &TUnion,
     column_key_type: &TUnion,
     index_key_type: Option<&TUnion>,
-    codebase: &mago_codex::metadata::CodebaseMetadata,
+    codebase: &CodebaseMetadata,
 ) -> Option<TUnion> {
     let obj = element_type.get_single_named_object()?;
     let class_like = codebase.get_class_like(obj.name.as_bytes())?;
@@ -91,11 +93,11 @@ fn try_resolve_from_named_object(
         TUnion::from_atomic(TAtomic::Object(TObject::Named(obj.clone())))
     } else {
         let prop_name = column_key_type.get_single_literal_string_value()?;
-        let prop = class_like.properties.get(&concat_word!(b"$", prop_name))?;
-        prop.type_metadata.as_ref()?.type_union.clone()
+        let prop_key = concat_word!(b"$", prop_name);
+        resolve_property_for_external_access(codebase, class_like, prop_key)?.declared_type(codebase)
     };
 
-    let index_type = resolve_index_type_from_property(index_key_type, class_like);
+    let index_type = resolve_index_type_from_property(index_key_type, class_like, codebase);
 
     Some(build_result(column_type, index_type))
 }
@@ -131,7 +133,7 @@ fn try_resolve_from_keyed_array(
         } else {
             let key_str = index_key_type.get_single_literal_string_value()?;
             let (_, value_type) = known_items.get(&ArrayKey::String(word(key_str)))?;
-            extract_scalar_for_key(value_type)
+            extract_scalar_for_key(value_type).cloned()
         }
     } else {
         None
@@ -154,26 +156,27 @@ fn extract_scalar_for_key(value_type: &TUnion) -> Option<&TScalar> {
     }
 }
 
-fn resolve_index_type_from_property<'meta>(
+fn resolve_index_type_from_property(
     index_key_type: Option<&TUnion>,
-    class_like: &'meta ClassLikeMetadata,
-) -> Option<&'meta TScalar> {
+    class_like: &ClassLikeMetadata,
+    codebase: &CodebaseMetadata,
+) -> Option<TScalar> {
     let index_key_type = index_key_type?;
     if index_key_type.is_null() {
         return None;
     }
 
     let prop_name = index_key_type.get_single_literal_string_value()?;
-    let prop = class_like.properties.get(&concat_word!("$", prop_name))?;
-    let prop_type = &prop.type_metadata.as_ref()?.type_union;
+    let prop_key = concat_word!(b"$", prop_name);
+    let prop_type = resolve_property_for_external_access(codebase, class_like, prop_key)?.declared_type(codebase);
 
-    extract_scalar_for_key(prop_type)
+    extract_scalar_for_key(&prop_type).cloned()
 }
 
-fn build_result(column_type: TUnion, index_type: Option<&TScalar>) -> TUnion {
+fn build_result(column_type: TUnion, index_type: Option<TScalar>) -> TUnion {
     if let Some(index_scalar) = index_type {
         let keyed_array = TKeyedArray::new_with_parameters(
-            Arc::new(TUnion::from_atomic(TAtomic::Scalar(index_scalar.clone()))),
+            Arc::new(TUnion::from_atomic(TAtomic::Scalar(index_scalar))),
             Arc::new(column_type),
         );
 

--- a/crates/analyzer/src/readonly.rs
+++ b/crates/analyzer/src/readonly.rs
@@ -77,7 +77,7 @@ pub(crate) fn check_property_write<A>(
         return;
     };
 
-    if !property_metadata.flags.is_readonly() || property_metadata.flags.is_magic_property() {
+    if !property_metadata.flags.is_readonly() {
         return;
     }
 

--- a/crates/analyzer/src/reconciler/mod.rs
+++ b/crates/analyzer/src/reconciler/mod.rs
@@ -49,6 +49,7 @@ use crate::code::IssueCode;
 use crate::context::Context;
 use crate::context::block::BlockContext;
 use crate::context::scope::var_has_root;
+use crate::resolver::property::resolve_declared_property;
 use mago_bytes::BytesDisplay;
 
 pub mod assertion_reconciler;
@@ -635,7 +636,13 @@ fn adjust_object_property_type<A>(
                 {
                     None
                 } else {
-                    get_property_type(context, named.get_name(), &property_name)
+                    get_property_type(
+                        context,
+                        named.get_name(),
+                        &property_name,
+                        true, // `instance_access`: assertions on `$obj->prop`
+                        block_context.scope.get_class_like_name(),
+                    )
                 }
             }
             _ => None,
@@ -1215,7 +1222,13 @@ where
                         {
                             class_property_type = get_mixed();
                         } else {
-                            class_property_type = get_property_type(context, fq_class_name, &property_name)?;
+                            class_property_type = get_property_type(
+                                context,
+                                fq_class_name,
+                                &property_name,
+                                divider == b"->",
+                                block_context.scope.get_class_like_name(),
+                            )?;
                         }
                     } else {
                         class_property_type = get_mixed();
@@ -1242,33 +1255,34 @@ where
     block_context.locals.get(&base_key_atom).map(|t| (**t).clone())
 }
 
-fn get_property_type<A>(context: &Context<'_, '_, A>, classlike_name: Word, property_name_str: &[u8]) -> Option<TUnion>
+fn get_property_type<A>(
+    context: &Context<'_, '_, A>,
+    classlike_name: Word,
+    property_name_str: &[u8],
+    instance_access: bool,
+    scope: Option<Word>,
+) -> Option<TUnion>
 where
     A: Arena,
 {
     // Add `$` prefix
     let property_name = concat_word!(b"$", property_name_str);
 
-    let declaring_property_class =
-        context.codebase.get_declaring_property_class(classlike_name.as_bytes(), property_name.as_bytes())?;
-    let property_metadata = context.codebase.get_property(classlike_name.as_bytes(), property_name.as_bytes())?;
-    let property_type = property_metadata.type_metadata.as_ref().map(|metadata| metadata.type_union.clone());
+    let class_metadata = context.codebase.get_class_like(classlike_name.as_bytes())?;
+    let resolution =
+        resolve_declared_property(context.codebase, class_metadata, property_name, instance_access, scope)?;
+    let declaring_property_class = resolution.declaring_class.name;
 
-    let property_type = if let Some(mut property_type) = property_type {
-        expander::expand_union(
-            context.codebase,
-            &mut property_type,
-            &TypeExpansionOptions {
-                self_class: Some(declaring_property_class),
-                static_class_type: StaticClassType::Name(declaring_property_class),
-                ..Default::default()
-            },
-        );
-
-        property_type
-    } else {
-        get_mixed()
-    };
+    let mut property_type = resolution.declared_type(context.codebase);
+    expander::expand_union(
+        context.codebase,
+        &mut property_type,
+        &TypeExpansionOptions {
+            self_class: Some(declaring_property_class),
+            static_class_type: StaticClassType::Name(declaring_property_class),
+            ..Default::default()
+        },
+    );
 
     Some(property_type)
 }

--- a/crates/analyzer/src/resolver/property.rs
+++ b/crates/analyzer/src/resolver/property.rs
@@ -3,7 +3,9 @@ use indexmap::IndexMap;
 use mago_allocator::Arena;
 
 use mago_codex::identifier::method::MethodIdentifier;
+use mago_codex::metadata::CodebaseMetadata;
 use mago_codex::metadata::class_like::ClassLikeMetadata;
+use mago_codex::metadata::property::PropertyMetadata;
 use mago_codex::misc::GenericParent;
 use mago_codex::ttype::TType;
 use mago_codex::ttype::atomic::TAtomic;
@@ -12,6 +14,8 @@ use mago_codex::ttype::atomic::object::TObject;
 use mago_codex::ttype::atomic::object::r#enum::TEnum;
 use mago_codex::ttype::atomic::object::named::TNamedObject;
 use mago_codex::ttype::atomic::scalar::TScalar;
+use mago_codex::ttype::comparator::ComparisonResult;
+use mago_codex::ttype::comparator::union_comparator;
 use mago_codex::ttype::expander;
 use mago_codex::ttype::expander::StaticClassType;
 use mago_codex::ttype::expander::TypeExpansionOptions;
@@ -41,8 +45,9 @@ use crate::resolver::class_name::report_non_existent_class_like;
 use crate::resolver::selector::resolve_member_selector;
 use crate::utils::names::display_class_like_name;
 use crate::utils::template::get_template_types_for_class_member;
-use crate::visibility::check_property_read_visibility;
-use crate::visibility::check_property_write_visibility;
+use crate::visibility::check_resolved_property_read_visibility;
+use crate::visibility::check_resolved_property_write_visibility;
+use crate::visibility::is_visible_from_scope;
 use mago_bytes::trim_start_byte;
 
 /// Represents a successfully resolved instance property.
@@ -447,6 +452,160 @@ fn is_backing_store_access(object_expr: &Expression, prop_name: Word, block_cont
     is_this && block_context.scope.get_property_hook().is_some_and(|(hook_prop_name, _)| hook_prop_name == prop_name)
 }
 
+/// How a declared property resolved at a given call site: through its real declaration, or
+/// through a magic `@property`/`@property-read`/`@property-write` annotation.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum DeclaredPropertyKind<'ctx> {
+    /// A real declaration governs the access.  The annotation of the same name on the accessed
+    /// class, when one exists, may refine the declared type (see [`DeclaredProperty::declared_type`]).
+    Real { annotation: Option<&'ctx PropertyMetadata> },
+    /// A magic annotation governs the access, which goes through `__get`/`__set`.
+    Magic,
+}
+
+/// The declaration governing a property access, as resolved by [`resolve_declared_property`].
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DeclaredProperty<'ctx> {
+    /// The class holding the governing declaration: the real property's declaring class, or
+    /// the class whose docblock carries the `@property*` tag.
+    pub declaring_class: &'ctx ClassLikeMetadata,
+    pub property: &'ctx PropertyMetadata,
+    pub kind: DeclaredPropertyKind<'ctx>,
+}
+
+impl DeclaredProperty<'_> {
+    pub(crate) fn is_magic(&self) -> bool {
+        matches!(self.kind, DeclaredPropertyKind::Magic)
+    }
+
+    /// The type the governing declaration gives the property: for a real declaration whose
+    /// annotation narrows the declared type (a wide inherited `public $db` narrowed by
+    /// `@property` on a subclass), the annotation's type; otherwise the declared type, or
+    /// `mixed` when untyped.  A conflicting (non-narrowing) annotation type is ignored.
+    pub(crate) fn declared_type(&self, codebase: &CodebaseMetadata) -> TUnion {
+        if let DeclaredPropertyKind::Real { annotation: Some(annotation) } = self.kind
+            && let Some(annotation_type) = annotation.type_metadata.as_ref().map(|tm| &tm.type_union)
+        {
+            let narrows = match self.property.type_metadata.as_ref().map(|tm| &tm.type_union) {
+                None => true,
+                Some(real_type) => {
+                    real_type.is_mixed()
+                        || union_comparator::is_contained_by(
+                            codebase,
+                            annotation_type,
+                            real_type,
+                            false,
+                            false,
+                            false,
+                            &mut ComparisonResult::default(),
+                        )
+                }
+            };
+
+            if narrows {
+                return annotation_type.clone();
+            }
+        }
+
+        self.property
+            .type_metadata
+            .as_ref()
+            .or(self.property.type_declaration_metadata.as_ref())
+            .map(|tm| tm.type_union.clone())
+            .unwrap_or_else(get_mixed)
+    }
+}
+
+/// Resolves which declaration governs an access to `$obj->prop` (or `Class::$prop` with
+/// `instance_access` false) on `class_metadata` from `scope`, mirroring PHP's runtime rule for
+/// magic properties: a real property applies whenever the access can reach it — for instance
+/// access, when it is non-static and visible at the call site; static properties and
+/// annotations are irrelevant to static access.  Everywhere else `__get`/`__set` fire, so a
+/// magic `@property*` annotation (documenting exactly that interface) applies when present.  A
+/// real property that governs no access path still resolves as `Real` so the caller's
+/// visibility check reports the inaccessible access.  Returns `None` when the name has neither
+/// a real declaration nor an annotation.
+pub(crate) fn resolve_declared_property<'ctx>(
+    codebase: &'ctx CodebaseMetadata,
+    class_metadata: &'ctx ClassLikeMetadata,
+    prop_name: Word,
+    instance_access: bool,
+    scope: Option<Word>,
+) -> Option<DeclaredProperty<'ctx>> {
+    let annotation = if instance_access {
+        class_metadata.magic_property_ids.get(&prop_name).copied().and_then(|tag_class| {
+            let tag_metadata = if tag_class == class_metadata.name {
+                class_metadata
+            } else {
+                codebase.get_class_like(tag_class.as_bytes())?
+            };
+
+            Some((tag_metadata, tag_metadata.magic_properties.get(&prop_name)?))
+        })
+    } else {
+        None
+    };
+
+    let Some((declaring_metadata, real_property)) =
+        class_metadata.declaring_property_ids.get(&prop_name).copied().and_then(|declaring_class| {
+            let declaring_metadata = codebase.get_class_like(declaring_class.as_bytes())?;
+            let real_property = declaring_metadata.properties.get(&prop_name)?;
+
+            Some((declaring_metadata, real_property))
+        })
+    else {
+        return annotation.map(|(tag_metadata, annotation)| DeclaredProperty {
+            declaring_class: tag_metadata,
+            property: annotation,
+            kind: DeclaredPropertyKind::Magic,
+        });
+    };
+
+    // `->` never reaches a static property, whatever its visibility; otherwise the real
+    // property governs exactly where it is visible.  Visibility here means the main (get)
+    // visibility for writes as well: PHP calls `__set()` only for a property that is entirely
+    // inaccessible in the current scope — writing to one that is readable but not writable
+    // (asymmetric visibility, e.g. `public private(set)`) throws instead of falling through.
+    let real_property_reachable = || {
+        !real_property.flags.is_static()
+            && is_visible_from_scope(codebase, real_property.read_visibility, declaring_metadata.name.as_bytes(), scope)
+    };
+
+    if let Some((tag_metadata, annotation)) = annotation
+        && !real_property_reachable()
+    {
+        return Some(DeclaredProperty {
+            declaring_class: tag_metadata,
+            property: annotation,
+            kind: DeclaredPropertyKind::Magic,
+        });
+    }
+
+    Some(DeclaredProperty {
+        declaring_class: declaring_metadata,
+        property: real_property,
+        kind: DeclaredPropertyKind::Real { annotation: annotation.map(|(_, annotation)| annotation) },
+    })
+}
+
+/// Resolves external access to a property of `class_metadata` where the accessing scope is not
+/// a class scope but is certainly outside the class (mixins, intersection members,
+/// `array_column()`): a real property governs when it is publicly visible, a magic
+/// `@property*` annotation otherwise.  Returns `None` when neither reaches a declaration.
+pub(crate) fn resolve_property_for_external_access<'ctx>(
+    codebase: &'ctx CodebaseMetadata,
+    class_metadata: &'ctx ClassLikeMetadata,
+    prop_name: Word,
+) -> Option<DeclaredProperty<'ctx>> {
+    let resolution = resolve_declared_property(codebase, class_metadata, prop_name, true, None)?;
+
+    match resolution.kind {
+        DeclaredPropertyKind::Magic => Some(resolution),
+        DeclaredPropertyKind::Real { .. } if resolution.property.read_visibility.is_public() => Some(resolution),
+        DeclaredPropertyKind::Real { .. } => None,
+    }
+}
+
 /// Finds a property in a class, gets its type, and handles template localization.
 fn find_property_in_class<'ctx, 'ast, 'arena, A>(
     context: &mut Context<'ctx, 'arena, A>,
@@ -464,71 +623,70 @@ fn find_property_in_class<'ctx, 'ast, 'arena, A>(
 where
     A: Arena,
 {
-    let declaring_class_id =
-        context.codebase.get_declaring_property_class(class_id.as_bytes(), prop_name.as_bytes()).unwrap_or(class_id);
-
-    let Some(declaring_class_metadata) = context.codebase.get_class_like(declaring_class_id.as_bytes()) else {
-        report_non_existent_class_like(context, object_expr.span(), declaring_class_id);
+    let Some(class_metadata) = context.codebase.get_class_like(class_id.as_bytes()) else {
+        report_non_existent_class_like(context, object_expr.span(), class_id);
 
         return None;
     };
 
-    let Some(property_metadata) = declaring_class_metadata.properties.get(&prop_name) else {
-        for required_class in
-            declaring_class_metadata.require_extends.iter().chain(declaring_class_metadata.require_implements.iter())
-        {
+    let resolution = resolve_declared_property(
+        context.codebase,
+        class_metadata,
+        prop_name,
+        true, // `instance_access`
+        block_context.scope.get_class_like_name(),
+    );
+
+    let Some(resolution) = resolution else {
+        for required_class in class_metadata.require_extends.iter().chain(class_metadata.require_implements.iter()) {
             let Some(required_metadata) = context.codebase.get_class_like(required_class.as_bytes()) else {
                 continue;
             };
 
-            let required_declaring_class_id = context
-                .codebase
-                .get_declaring_property_class(required_class.as_bytes(), prop_name.as_bytes())
-                .unwrap_or(*required_class);
-            let required_declaring_metadata =
-                context.codebase.get_class_like(required_declaring_class_id.as_bytes()).unwrap_or(required_metadata);
-
-            if let Some(prop_meta) = required_declaring_metadata.properties.get(&prop_name) {
-                let property_type = prop_meta
-                    .type_metadata
-                    .as_ref()
-                    .or(prop_meta.type_declaration_metadata.as_ref())
-                    .map(|type_metadata| type_metadata.type_union.clone())
-                    .unwrap_or_else(get_mixed);
+            // `$this` here is an instance of the required class-like, so the call-site rule
+            // applies there.  The required class also provides `__get`/`__set` at runtime,
+            // which cannot be checked from here — hence `is_magic: false`.
+            if let Some(required_resolution) = resolve_declared_property(
+                context.codebase,
+                required_metadata,
+                prop_name,
+                true, // `instance_access`
+                block_context.scope.get_class_like_name(),
+            ) {
+                let prop_meta = required_resolution.property;
 
                 return Some(ResolvedProperty {
                     property_span: prop_meta.name_span.or(prop_meta.span),
                     property_name: prop_name,
-                    declaring_class_id: Some(required_declaring_class_id),
-                    property_type,
+                    declaring_class_id: Some(required_resolution.declaring_class.name),
+                    property_type: required_resolution.declared_type(context.codebase),
                     is_magic: false,
                 });
             }
         }
 
         // Check mixins.
-        if !declaring_class_metadata.mixins.is_empty() {
+        if !class_metadata.mixins.is_empty() {
             // Try to find property in mixin types
-            if let Some(resolved) = find_property_in_mixins(
-                context,
-                declaring_class_metadata,
-                object,
-                &declaring_class_metadata.mixins,
-                prop_name,
-            ) {
-                if has_magic_method {
+            if let Some(resolved) =
+                find_property_in_mixins(context, class_metadata, object, &class_metadata.mixins, prop_name)
+            {
+                // For an annotation-governed mixin property, the caller reports a missing
+                // `__get`/`__set` on the accessed class; the mixin-specific warnings below
+                // cover real mixin properties only.
+                if has_magic_method || resolved.is_magic {
                     return Some(resolved);
                 }
 
                 let magic_method_name = if for_assignment { "__set" } else { "__get" };
-                if declaring_class_metadata.flags.is_final() {
+                if class_metadata.flags.is_final() {
                     report_non_existent_mixin_property(
                         context,
                         object_expr.span(),
                         selector.span(),
-                        declaring_class_id,
+                        class_id,
                         prop_name,
-                        resolved.declaring_class_id.unwrap_or(declaring_class_id),
+                        resolved.declaring_class_id.unwrap_or(class_id),
                         magic_method_name,
                     );
                     result.has_invalid_path = true;
@@ -537,9 +695,9 @@ where
                         context,
                         object_expr.span(),
                         selector.span(),
-                        declaring_class_id,
+                        class_id,
                         prop_name,
-                        resolved.declaring_class_id.unwrap_or(declaring_class_id),
+                        resolved.declaring_class_id.unwrap_or(class_id),
                         magic_method_name,
                     );
                 }
@@ -559,7 +717,7 @@ where
                 context,
                 object_expr.span(),
                 selector.span(),
-                declaring_class_id,
+                class_id,
                 prop_name,
                 for_assignment,
             );
@@ -567,7 +725,7 @@ where
             return Some(ResolvedProperty {
                 property_span: None,
                 property_name: prop_name,
-                declaring_class_id: Some(declaring_class_id),
+                declaring_class_id: Some(class_id),
                 property_type: get_mixed(),
                 is_magic: true,
             });
@@ -592,16 +750,16 @@ where
 
         result.has_invalid_path = true;
 
-        if !declaring_class_metadata.flags.is_final()
-            || declaring_class_metadata.kind.is_interface()
-            || declaring_class_metadata.kind.is_trait()
-        {
+        if !class_metadata.flags.is_final() || class_metadata.kind.is_interface() || class_metadata.kind.is_trait() {
             result.has_possibly_defined_property = true;
         }
 
         report_non_existent_property(context, class_id, prop_name, selector.span(), object_expr.span(), false);
         return None;
     };
+
+    let DeclaredProperty { declaring_class: declaring_class_metadata, property: property_metadata, .. } = resolution;
+    let declaring_class_id = declaring_class_metadata.name;
 
     let property_display_name = format!("{}::{}", declaring_class_metadata.original_name, prop_name);
     crate::utils::availability::check_property_availability(
@@ -620,20 +778,10 @@ where
         {
             param_type.type_union.clone()
         } else {
-            property_metadata
-                .type_metadata
-                .as_ref()
-                .map(|type_metadata| &type_metadata.type_union)
-                .cloned()
-                .unwrap_or_else(get_mixed)
+            resolution.declared_type(context.codebase)
         }
     } else {
-        property_metadata
-            .type_metadata
-            .as_ref()
-            .map(|type_metadata| &type_metadata.type_union)
-            .cloned()
-            .unwrap_or_else(get_mixed)
+        resolution.declared_type(context.codebase)
     };
 
     expander::expand_union(
@@ -673,23 +821,15 @@ where
     }
 
     let is_visible = if for_assignment {
-        check_property_write_visibility(
+        check_resolved_property_write_visibility(
             context,
             block_context,
-            declaring_class_id.as_bytes(),
-            prop_name.as_bytes(),
+            &resolution,
             access_span,
             Some(selector.span()),
         )
     } else {
-        check_property_read_visibility(
-            context,
-            block_context,
-            declaring_class_id.as_bytes(),
-            prop_name.as_bytes(),
-            access_span,
-            Some(selector.span()),
-        )
+        check_resolved_property_read_visibility(context, block_context, &resolution, access_span, Some(selector.span()))
     };
 
     if !is_visible {
@@ -703,7 +843,7 @@ where
         property_name: prop_name,
         declaring_class_id: Some(declaring_class_id),
         property_type,
-        is_magic: property_metadata.flags.is_magic_property(),
+        is_magic: resolution.is_magic(),
     })
 }
 
@@ -1256,25 +1396,17 @@ where
     A: Arena,
 {
     let mixin_metadata = context.codebase.get_class_like(mixin_class_name.as_bytes())?;
-    let property_metadata = mixin_metadata.properties.get(&prop_name)?;
-
-    if !property_metadata.read_visibility.is_public() {
-        return None;
-    }
-
-    let property_type = property_metadata
-        .type_metadata
-        .as_ref()
-        .or(property_metadata.type_declaration_metadata.as_ref())
-        .map(|type_metadata| type_metadata.type_union.clone())
-        .unwrap_or_else(get_mixed);
+    // Mixin access is always external, so a non-public real property defers to a magic
+    // `@property*` annotation when the mixin class documents one.
+    let resolution = resolve_property_for_external_access(context.codebase, mixin_metadata, prop_name)?;
+    let property_metadata = resolution.property;
 
     Some(ResolvedProperty {
         property_span: property_metadata.name_span.or(property_metadata.span),
         property_name: prop_name,
-        declaring_class_id: Some(mixin_class_name),
-        property_type,
-        is_magic: false,
+        declaring_class_id: Some(resolution.declaring_class.name),
+        property_type: resolution.declared_type(context.codebase),
+        is_magic: resolution.is_magic(),
     })
 }
 
@@ -1292,72 +1424,27 @@ where
 
     for atomic in intersection_types {
         match atomic {
-            TAtomic::Object(TObject::Named(named)) => {
-                let class_name = named.name;
-                let declaring_class_id = context
-                    .codebase
-                    .get_declaring_property_class(class_name.as_bytes(), prop_name.as_bytes())
-                    .unwrap_or(class_name);
-
-                let Some(class_metadata) = context.codebase.get_class_like(declaring_class_id.as_bytes()) else {
+            TAtomic::Object(TObject::Named(TNamedObject { name, .. }) | TObject::Enum(TEnum { name, .. })) => {
+                let Some(class_metadata) = context.codebase.get_class_like(name.as_bytes()) else {
                     continue;
                 };
 
-                let Some(property_metadata) = class_metadata.properties.get(&prop_name) else {
+                // Intersection-member access is external, so a non-public real property defers
+                // to a magic `@property*` annotation when one is documented.
+                let Some(resolution) =
+                    resolve_property_for_external_access(context.codebase, class_metadata, prop_name)
+                else {
                     continue;
                 };
 
-                if !property_metadata.read_visibility.is_public() {
-                    continue;
-                }
-
-                let property_type = property_metadata
-                    .type_metadata
-                    .as_ref()
-                    .or(property_metadata.type_declaration_metadata.as_ref())
-                    .map(|type_metadata| type_metadata.type_union.clone())
-                    .unwrap_or_else(get_mixed);
+                let property_metadata = resolution.property;
 
                 return Some(ResolvedProperty {
                     property_span: property_metadata.name_span.or(property_metadata.span),
                     property_name: prop_name,
-                    declaring_class_id: Some(declaring_class_id),
-                    property_type,
-                    is_magic: false,
-                });
-            }
-            TAtomic::Object(TObject::Enum(enum_type)) => {
-                let class_name = enum_type.name;
-                let declaring_class_id = context
-                    .codebase
-                    .get_declaring_property_class(class_name.as_bytes(), prop_name.as_bytes())
-                    .unwrap_or(class_name);
-
-                let Some(class_metadata) = context.codebase.get_class_like(declaring_class_id.as_bytes()) else {
-                    continue;
-                };
-
-                let Some(property_metadata) = class_metadata.properties.get(&prop_name) else {
-                    continue;
-                };
-
-                if !property_metadata.read_visibility.is_public() {
-                    continue;
-                }
-
-                let property_type = property_metadata
-                    .type_metadata
-                    .as_ref()
-                    .or(property_metadata.type_declaration_metadata.as_ref())
-                    .map(|type_metadata| type_metadata.type_union.clone())
-                    .unwrap_or_else(get_mixed);
-
-                return Some(ResolvedProperty {
-                    property_span: property_metadata.name_span.or(property_metadata.span),
-                    property_name: prop_name,
-                    declaring_class_id: Some(declaring_class_id),
-                    property_type,
-                    is_magic: false,
+                    declaring_class_id: Some(resolution.declaring_class.name),
+                    property_type: resolution.declared_type(context.codebase),
+                    is_magic: resolution.is_magic(),
                 });
             }
             TAtomic::Object(TObject::WithProperties(shaped)) => {

--- a/crates/analyzer/src/resolver/static_property.rs
+++ b/crates/analyzer/src/resolver/static_property.rs
@@ -23,7 +23,7 @@ use crate::error::AnalysisError;
 use crate::resolver::class_name::resolve_classnames_from_expression;
 use crate::resolver::property::PropertyResolutionResult;
 use crate::resolver::property::ResolvedProperty;
-use crate::visibility::check_property_read_visibility;
+use crate::visibility::check_static_property_read_visibility;
 
 /// Resolves all possible static properties from a class expression and a member selector.
 pub fn resolve_static_properties<'ctx, 'ast, 'arena, A>(
@@ -226,7 +226,7 @@ where
         return None;
     }
 
-    if !check_property_read_visibility(
+    if !check_static_property_read_visibility(
         context,
         block_context,
         declaring_class_id.as_bytes(),

--- a/crates/analyzer/src/statement/class_like/mod.rs
+++ b/crates/analyzer/src/statement/class_like/mod.rs
@@ -2382,12 +2382,6 @@ fn check_trait_property_conflicts<'ctx, 'ast, 'arena, A>(
 
     let mut class_properties: IndexMap<Word, &PropertyMetadata> = IndexMap::new();
     for (property_name, property_metadata) in class_like_metadata.properties.iter().sorted_by_key(|(k, _)| *k) {
-        // Magic properties (from `@property` docblock tags) are not real declarations and
-        // never participate in PHP's trait composition, so they cannot conflict with a trait property.
-        if property_metadata.flags.is_magic_property() {
-            continue;
-        }
-
         if let Some(declaring_class) = class_like_metadata.declaring_property_ids.get(property_name)
             && declaring_class == &class_like_metadata.name
         {

--- a/crates/analyzer/src/statement/class_like/unused_members.rs
+++ b/crates/analyzer/src/statement/class_like/unused_members.rs
@@ -88,6 +88,13 @@ where
             continue;
         }
 
+        // A magic `@property*` annotation of the same name exposes this property through
+        // `__get`/`__set`, so it can be reached from outside the class (and typically via
+        // dynamic access inside the magic methods) where this analysis cannot see it.
+        if class_like_metadata.magic_property_ids.contains_key(property_name) {
+            continue;
+        }
+
         if !property.read_visibility.is_private()
             && class_like_metadata.overridden_property_ids.contains_key(property_name)
         {
@@ -286,6 +293,13 @@ pub fn check_write_only_properties<A>(
         }
 
         if !property.hooks.is_empty() {
+            continue;
+        }
+
+        // A magic `@property*` annotation of the same name exposes this property through
+        // `__get`, so reads can occur outside the class (and typically via dynamic access
+        // inside `__get`) where this analysis cannot see them.
+        if class_like_metadata.magic_property_ids.contains_key(property_name) {
             continue;
         }
 

--- a/crates/analyzer/src/statement/function_like/mod.rs
+++ b/crates/analyzer/src/statement/function_like/mod.rs
@@ -55,6 +55,7 @@ use crate::context::block::ReferenceConstraint;
 use crate::context::block::ReferenceConstraintSource;
 use crate::error::AnalysisError;
 use crate::resolver::property::localize_property_type;
+use crate::resolver::property::resolve_declared_property;
 use crate::statement::analyze_statements;
 use crate::statement::attributes::AttributeTarget;
 use crate::statement::attributes::analyze_attributes;
@@ -584,23 +585,36 @@ where
         return Ok(());
     };
 
-    for (property_name, declaring_class) in &class_like_metadata.declaring_property_ids {
-        let Some(property_class_metadata) = context.codebase.get_class_like(declaring_class.as_bytes()) else {
-            return Err(AnalysisError::InternalError(
-                format!("Could not load property class metadata for `{declaring_class}`."),
-                class_like_metadata.span,
-            ));
-        };
+    // Seed every property name reachable on this class: all real declarations, plus magic
+    // `@property*` annotations for names without one.
+    let property_names = class_like_metadata.declaring_property_ids.keys().chain(
+        class_like_metadata
+            .magic_property_ids
+            .keys()
+            .filter(|name| !class_like_metadata.declaring_property_ids.contains_key(name)),
+    );
 
-        let Some(property_metadata) = property_class_metadata.properties.get(property_name) else {
+    for property_name in property_names {
+        // These types seed `$this->prop`, i.e. internal access: the real property when it is
+        // visible from within this class, the `@property*` annotation otherwise.
+        let Some(resolution) = resolve_declared_property(
+            context.codebase,
+            class_like_metadata,
+            *property_name,
+            true, // `instance_access`
+            Some(calling_class),
+        ) else {
             return Err(AnalysisError::InternalError(
                 format!(
-                    "Could not load property metadata for `{property_name}` in class `{declaring_class}` (class-like: `{}`).",
+                    "Could not load property metadata for `{property_name}` in class-like `{}`.",
                     class_like_metadata.name,
                 ),
                 class_like_metadata.span,
             ));
         };
+
+        let property_metadata = resolution.property;
+        let property_class_metadata = resolution.declaring_class;
 
         if !property_metadata.hooks.is_empty()
             && property_metadata.hooks.contains_key(&word(b"set"))
@@ -609,12 +623,7 @@ where
             continue;
         }
 
-        let mut property_type = property_metadata
-            .type_metadata
-            .as_ref()
-            .map(|type_metadata| &type_metadata.type_union)
-            .cloned()
-            .unwrap_or_else(get_mixed);
+        let mut property_type = resolution.declared_type(context.codebase);
 
         let property_name_bytes = property_name.as_bytes();
         let raw_property_name = property_name_bytes.strip_prefix(b"$").unwrap_or(property_name_bytes);

--- a/crates/analyzer/src/visibility/mod.rs
+++ b/crates/analyzer/src/visibility/mod.rs
@@ -2,6 +2,7 @@ use mago_allocator::Arena;
 use mago_word::Word;
 use mago_word::word;
 
+use mago_codex::metadata::CodebaseMetadata;
 use mago_codex::visibility::Visibility;
 use mago_php_version::feature::Feature;
 use mago_reporting::Annotation;
@@ -11,6 +12,9 @@ use mago_span::Span;
 use crate::code::IssueCode;
 use crate::context::Context;
 use crate::context::block::BlockContext;
+use crate::resolver::property::DeclaredProperty;
+use crate::resolver::property::DeclaredPropertyKind;
+use crate::resolver::property::resolve_declared_property;
 use mago_bytes::BytesDisplay;
 
 /// Checks if a method is visible from the current scope and reports a detailed
@@ -56,7 +60,7 @@ where
     }
 
     let is_visible = is_visible_from_scope(
-        context,
+        context.codebase,
         visibility,
         declaring_class.as_bytes(),
         block_context.scope.get_class_like_name(),
@@ -117,12 +121,20 @@ where
         return true;
     }
 
-    is_visible_from_scope(context, visibility, declaring_class.as_bytes(), block_context.scope.get_class_like_name())
+    is_visible_from_scope(
+        context.codebase,
+        visibility,
+        declaring_class.as_bytes(),
+        block_context.scope.get_class_like_name(),
+    )
 }
 
-/// Checks if a property is readable from the current scope and reports a detailed
-/// error if it is not.
-pub fn check_property_read_visibility<'ctx, A>(
+/// Checks if a static property (`Class::$prop`) is readable from the current scope and
+/// reports a detailed error if it is not.  Magic `@property*` annotations never apply to
+/// static access, so this entry point resolves annotation-blind; instance accesses go through
+/// [`check_resolved_property_read_visibility`] with a resolution from
+/// [`resolve_declared_property`] instead.
+pub fn check_static_property_read_visibility<'ctx, A>(
     context: &mut Context<'ctx, '_, A>,
     block_context: &BlockContext<'ctx>,
     fqcn: &[u8],
@@ -139,19 +151,39 @@ where
         return true;
     };
 
-    let Some(declaring_class_id) = class_metadata.declaring_property_ids.get(&property_name) else {
+    let Some(resolution) = resolve_declared_property(
+        context.codebase,
+        class_metadata,
+        property_name,
+        false, // `instance_access`: this entry point serves `Class::$prop` resolution
+        block_context.scope.get_class_like_name(),
+    ) else {
         return true;
     };
 
-    let Some(declaring_class_metadata) = context.codebase.get_class_like(declaring_class_id.as_bytes()) else {
-        return true;
-    };
+    check_resolved_property_read_visibility(context, block_context, &resolution, access_span, member_span)
+}
 
-    let Some(property_metadata) = declaring_class_metadata.properties.get(&property_name) else {
-        return true;
-    };
+/// Checks if a property access already resolved by [`resolve_declared_property`] is readable
+/// from the current scope and reports a detailed error if it is not.
+pub(crate) fn check_resolved_property_read_visibility<'ctx, A>(
+    context: &mut Context<'ctx, '_, A>,
+    block_context: &BlockContext<'ctx>,
+    resolution: &DeclaredProperty<'_>,
+    access_span: Span,
+    member_span: Option<Span>,
+) -> bool
+where
+    A: Arena,
+{
+    let DeclaredProperty { declaring_class: declaring_class_metadata, property: property_metadata, kind } = *resolution;
+    let property_name = property_metadata.name.0;
 
-    if property_metadata.flags.is_magic_property() && property_metadata.flags.is_writeonly() {
+    if matches!(kind, DeclaredPropertyKind::Magic) {
+        if !property_metadata.flags.is_writeonly() {
+            return true;
+        }
+
         let class_name = &declaring_class_metadata.original_name;
 
         context.collector.report_with_code(
@@ -199,9 +231,9 @@ where
 
     let visibility = property_metadata.read_visibility;
     let is_visible = is_visible_from_scope(
-        context,
+        context.codebase,
         visibility,
-        declaring_class_id.as_bytes(),
+        declaring_class_metadata.name.as_bytes(),
         block_context.scope.get_class_like_name(),
     );
 
@@ -230,34 +262,37 @@ where
     is_visible
 }
 
-pub fn check_property_write_visibility<'ctx, A>(
+/// The write-access counterpart of [`check_resolved_property_read_visibility`].
+pub(crate) fn check_resolved_property_write_visibility<'ctx, A>(
     context: &mut Context<'ctx, '_, A>,
     block_context: &BlockContext<'ctx>,
-    fqcn: &[u8],
-    property_name: &[u8],
+    resolution: &DeclaredProperty<'_>,
     access_span: Span,
     member_span: Option<Span>,
 ) -> bool
 where
     A: Arena,
 {
-    let property_name = word(property_name);
+    let DeclaredProperty { declaring_class: declaring_class_metadata, property: property_metadata, kind } = *resolution;
+    let property_name = property_metadata.name.0;
 
-    let Some(class_metadata) = context.codebase.get_class_like(fqcn) else {
-        return true;
-    };
+    if matches!(kind, DeclaredPropertyKind::Magic) {
+        if property_metadata.flags.is_readonly() {
+            let class_name = &declaring_class_metadata.original_name;
+            context.collector.report_with_code(
+                IssueCode::InvalidPropertyWrite,
+                Issue::error(format!("Cannot write to documented read-only property `{class_name}::{property_name}`."))
+                    .with_annotation(
+                        Annotation::primary(member_span.unwrap_or(access_span)).with_message("This property is read-only"),
+                    )
+                    .with_help("Remove the assignment or change the property documentation to `@property` if writes are supported."),
+            );
+        }
 
-    let Some(declaring_class_name) = class_metadata.declaring_property_ids.get(&property_name) else {
+        // Keep resolving the access so the resolver can independently report a
+        // missing `__set()` implementation when applicable.
         return true;
-    };
-
-    let Some(declaring_class_metadata) = context.codebase.get_class_like(declaring_class_name.as_bytes()) else {
-        return true;
-    };
-
-    let Some(property_metadata) = declaring_class_metadata.properties.get(&property_name) else {
-        return true;
-    };
+    }
 
     if !property_metadata.hooks.is_empty()
         && property_metadata.hooks.contains_key(&word(b"get"))
@@ -282,22 +317,6 @@ where
         return false;
     }
 
-    if property_metadata.flags.is_magic_property() && property_metadata.flags.is_readonly() {
-        let class_name = &declaring_class_metadata.original_name;
-        context.collector.report_with_code(
-            IssueCode::InvalidPropertyWrite,
-            Issue::error(format!("Cannot write to documented read-only property `{class_name}::{property_name}`."))
-                .with_annotation(
-                    Annotation::primary(member_span.unwrap_or(access_span)).with_message("This property is read-only"),
-                )
-                .with_help("Remove the assignment or change the property documentation to `@property` if writes are supported."),
-        );
-
-        // Keep resolving the access so the resolver can independently report a
-        // missing `__set()` implementation when applicable.
-        return true;
-    }
-
     let visibility = if property_metadata.flags.is_readonly() {
         if context.settings.version.is_supported(Feature::AsymmetricVisibility) {
             match property_metadata.write_visibility {
@@ -312,9 +331,9 @@ where
     };
 
     let is_visible = is_visible_from_scope(
-        context,
+        context.codebase,
         visibility,
-        declaring_class_name.as_bytes(),
+        declaring_class_metadata.name.as_bytes(),
         block_context.scope.get_class_like_name(),
     );
     if !is_visible {
@@ -343,23 +362,20 @@ where
     is_visible
 }
 
-fn is_visible_from_scope<A>(
-    context: &Context<'_, '_, A>,
+pub(crate) fn is_visible_from_scope(
+    codebase: &CodebaseMetadata,
     visibility: Visibility,
     declaring_class_id: &[u8],
     current_class_opt: Option<Word>,
-) -> bool
-where
-    A: Arena,
-{
+) -> bool {
     match visibility {
         Visibility::Public => true,
         Visibility::Protected => {
             if let Some(current_class_id) = current_class_opt {
                 current_class_id.as_bytes().eq_ignore_ascii_case(declaring_class_id)
-                    || context.codebase.is_instance_of(current_class_id.as_bytes(), declaring_class_id)
-                    || context.codebase.is_instance_of(declaring_class_id, current_class_id.as_bytes())
-                    || is_visible_via_required_extends(context, current_class_id.as_bytes(), declaring_class_id)
+                    || codebase.is_instance_of(current_class_id.as_bytes(), declaring_class_id)
+                    || codebase.is_instance_of(declaring_class_id, current_class_id.as_bytes())
+                    || is_visible_via_required_extends(codebase, current_class_id.as_bytes(), declaring_class_id)
             } else {
                 false
             }
@@ -367,8 +383,8 @@ where
         Visibility::Private => {
             if let Some(current_class_id) = current_class_opt {
                 current_class_id.as_bytes().eq_ignore_ascii_case(declaring_class_id)
-                    || context.codebase.class_uses_trait(current_class_id.as_bytes(), declaring_class_id)
-                    || context.codebase.class_uses_trait(declaring_class_id, current_class_id.as_bytes())
+                    || codebase.class_uses_trait(current_class_id.as_bytes(), declaring_class_id)
+                    || codebase.class_uses_trait(declaring_class_id, current_class_id.as_bytes())
             } else {
                 false
             }
@@ -379,17 +395,14 @@ where
 /// Checks if a protected member declared in `declaring_class_id` is accessible from
 /// `current_class_id` via `@require-extends`. This handles the case where a trait has
 /// `@require-extends BaseClass` and `BaseClass` uses another trait that declares the method.
-fn is_visible_via_required_extends<A>(
-    context: &Context<'_, '_, A>,
+fn is_visible_via_required_extends(
+    codebase: &CodebaseMetadata,
     current_class_id: &[u8],
     declaring_class_id: &[u8],
-) -> bool
-where
-    A: Arena,
-{
+) -> bool {
     let current_class_id_lc = mago_word::ascii_lowercase_word(current_class_id);
 
-    let Some(current_metadata) = context.codebase.get_class_like(current_class_id_lc.as_bytes()) else {
+    let Some(current_metadata) = codebase.get_class_like(current_class_id_lc.as_bytes()) else {
         return false;
     };
 
@@ -398,8 +411,8 @@ where
     }
 
     for required_class in current_metadata.require_extends.iter() {
-        if context.codebase.is_instance_of(required_class.as_bytes(), declaring_class_id)
-            || context.codebase.class_uses_trait(required_class.as_bytes(), declaring_class_id)
+        if codebase.is_instance_of(required_class.as_bytes(), declaring_class_id)
+            || codebase.class_uses_trait(required_class.as_bytes(), declaring_class_id)
         {
             return true;
         }

--- a/crates/analyzer/tests/cases/arrays_array_column.php
+++ b/crates/analyzer/tests/cases/arrays_array_column.php
@@ -10,3 +10,65 @@ function names(array $rows): array
 {
     return array_column($rows, 'name');
 }
+
+/**
+ * `array_column()` reads from outside the class: a private property with a magic `@property*`
+ * annotation resolves to the annotation's type, and a private property shadowed by an
+ * annotation is keyed by the annotation's type as well.
+ *
+ * @property-read int $magicId
+ * @property-read string $label
+ */
+final class ColumnEntry
+{
+    public string $name = '';
+    private int $magicId = 0;
+
+    /**
+     * @var int
+     */
+    private $label = 0;
+
+    public function __get(string $prop): mixed
+    {
+        return 0;
+    }
+}
+
+/**
+ * @param list<ColumnEntry> $entries
+ * @return list<int>
+ */
+function magic_ids(array $entries): array
+{
+    return array_column($entries, 'magicId');
+}
+
+/**
+ * @param list<ColumnEntry> $entries
+ */
+function keyed_by_magic_label(array $entries): void
+{
+    take_entries_by_label(array_column($entries, null, 'label'));
+}
+
+/**
+ * @param array<string, ColumnEntry> $_entries
+ */
+function take_entries_by_label(array $_entries): void {}
+
+final class UntypedColumnEntry
+{
+    public $untyped;
+}
+
+/**
+ * An untyped public property resolves the column to `mixed`.
+ *
+ * @param list<UntypedColumnEntry> $entries
+ * @return list<mixed>
+ */
+function untyped_column(array $entries): array
+{
+    return array_column($entries, 'untyped');
+}

--- a/crates/analyzer/tests/cases/magic_property_overridden_by_parent.php
+++ b/crates/analyzer/tests/cases/magic_property_overridden_by_parent.php
@@ -15,3 +15,115 @@ class ChildClass extends ParentClass
     {
     }
 }
+
+function i_take_string(string $_): void {}
+function i_take_int(int $_): void {}
+
+// A @property annotation with a different type than the trait's real property:
+//
+// - Internal access ($this->val) must use the real property type (string), not the
+//   annotation type (int).  No missing-magic-method or invalid-property-assignment-value.
+//
+// - External access ($obj->val) must use the annotation type (int), because the
+//   protected property is inaccessible from outside and __get is invoked instead.
+trait PropTrait
+{
+    protected string $val;
+}
+
+/**
+ * @property int $val
+ */
+class UsesTraitWithAnnotation
+{
+    use PropTrait;
+
+    public function __construct()
+    {
+        $this->val = 'hello'; // OK: internal write uses real property (string)
+    }
+
+    public function read_internally(): void
+    {
+        i_take_string($this->val);                                 // OK: internal read is string
+        i_take_int($this->val); // @mago-expect analysis:invalid-argument
+    }
+
+    public function __get(string $name): mixed
+    {
+        return 0;
+    }
+
+    public function __set(string $name, mixed $value): void {}
+}
+
+function test_external_access_uses_annotation_type(): void
+{
+    $obj = new UsesTraitWithAnnotation();
+    i_take_int($obj->val);                                 // OK: annotation says int
+    i_take_string($obj->val); // @mago-expect analysis:invalid-argument
+
+    // External write: the protected real property is inaccessible, so __set is invoked.
+    // The write is not redirected to the real `string` property, hence assigning a
+    // non-string value is accepted by `__set(mixed)`.
+    $obj->val = 123; // OK: protected -> __set
+}
+
+// Same rules apply when the real property is inherited from a parent class rather than a trait.
+class BaseWithProtected
+{
+    protected string $val = '';
+}
+
+/**
+ * @property int $val
+ */
+class InheritsProtectedWithAnnotation extends BaseWithProtected
+{
+    public function read_internally(): void
+    {
+        i_take_string($this->val);                                 // OK: internal read is string
+        i_take_int($this->val); // @mago-expect analysis:invalid-argument
+    }
+
+    public function __get(string $name): mixed
+    {
+        return 0;
+    }
+
+    public function __set(string $name, mixed $value): void {}
+}
+
+function test_inherited_protected_external(): void
+{
+    $obj = new InheritsProtectedWithAnnotation();
+    i_take_int($obj->val);                                 // OK: protected -> __get, annotation int
+    i_take_string($obj->val); // @mago-expect analysis:invalid-argument
+}
+
+// A `public` real property is reached directly even from outside, so the annotation never
+// applies and no magic method is required.
+trait PublicPropTrait
+{
+    public string $val = '';
+}
+
+/**
+ * @property int $val
+ */
+class UsesTraitWithPublicProperty
+{
+    use PublicPropTrait;
+}
+
+function test_public_property_ignores_annotation(): void
+{
+    $obj = new UsesTraitWithPublicProperty();
+    i_take_string($obj->val);                              // OK: real public property is string
+    i_take_int($obj->val); // @mago-expect analysis:invalid-argument
+
+    // External write: the public real property is reached directly, so the write is redirected
+    // to it and must satisfy its `string` type rather than the annotation's `int`.
+    $obj->val = 'world';                                   // OK: real public property is string
+    $obj->val = 123; // @mago-expect analysis:invalid-property-assignment-value
+}

--- a/crates/analyzer/tests/cases/magic_property_shadowing_real_property.php
+++ b/crates/analyzer/tests/cases/magic_property_shadowing_real_property.php
@@ -1,0 +1,541 @@
+<?php
+
+// A magic `@property*` annotation and a real property of the same name, declared on the SAME
+// class.  Which one governs an access mirrors PHP's runtime rule: the real property whenever it
+// is visible at the call site, the annotation (via `__get`/`__set`) otherwise.
+
+function take_string(string $_): void {}
+function take_int(int $_): void {}
+
+// Common framework pattern (e.g. Yii): a private backing property documented for external,
+// magic-method-based read access.  Internal writes hit the real property and must not be
+// treated as writes to a readonly property.
+class MagicMethodsBase
+{
+    public function __get(string $name): mixed
+    {
+        return 0;
+    }
+
+    public function __set(string $name, mixed $value): void {}
+}
+
+/**
+ * @property-read int $id
+ */
+class DocumentedBackingProperty extends MagicMethodsBase
+{
+    /**
+     * @var int
+     */
+    private $id;
+
+    public function login(): void
+    {
+        $this->id = 42; // OK: internal write to the real (non-readonly) private property
+    }
+
+    public function read_internally(): void
+    {
+        take_int($this->id); // OK: internal read uses the real property
+    }
+}
+
+function test_documented_backing_property(): void
+{
+    $obj = new DocumentedBackingProperty();
+    take_int($obj->id);                                 // OK: annotation says int (via __get)
+    take_string($obj->id); // @mago-expect analysis:invalid-argument
+    $obj->id = 1; // @mago-expect analysis:invalid-property-write
+}
+
+// The real property and the annotation disagree on the type: internal access uses the real
+// type, external access the annotation type.
+/**
+ * @property-read int $val
+ */
+class ConflictingTypes extends MagicMethodsBase
+{
+    private string $val = '';
+
+    public function read_internally(): void
+    {
+        take_string($this->val);                        // OK: internal read is string
+        take_int($this->val); // @mago-expect analysis:invalid-argument
+    }
+}
+
+function test_conflicting_types(): void
+{
+    $obj = new ConflictingTypes();
+    take_int($obj->val);                                // OK: annotation says int (via __get)
+    take_string($obj->val); // @mago-expect analysis:invalid-argument
+    $obj->val = 1; // @mago-expect analysis:invalid-property-write
+}
+
+// Without magic methods anywhere in the hierarchy, annotation-governed access reports the
+// missing `__get`/`__set` implementation.
+/**
+ * @property-read int $hidden
+ */
+class NoMagicMethods
+{
+    private int $hidden = 0;
+
+    public function touch(): void
+    {
+        $this->hidden = 1;                              // OK: real property, visible here
+    }
+}
+
+function test_no_magic_methods(): void
+{
+    $obj = new NoMagicMethods();
+    take_int($obj->hidden); // @mago-expect analysis:missing-magic-method
+    $obj->hidden = 1; // @mago-expect analysis:invalid-property-write,missing-magic-method
+}
+
+// Ecosystem pattern: a wide public property on a base class, narrowed by a `@property`
+// annotation on a subclass.  The real property is visible everywhere, so it always governs,
+// but the annotation refines its type.
+class WideBase
+{
+    /**
+     * @var mixed
+     */
+    public $db;
+}
+
+/**
+ * @property string $db
+ */
+class NarrowingChild extends WideBase
+{
+    public function read_internally(): void
+    {
+        take_string($this->db);                         // OK: narrowed to string
+        take_int($this->db); // @mago-expect analysis:invalid-argument
+    }
+}
+
+function test_narrowing_refinement(): void
+{
+    $obj = new NarrowingChild();
+    take_string($obj->db);                              // OK: narrowed to string
+    take_int($obj->db); // @mago-expect analysis:invalid-argument
+}
+
+// A conflicting annotation on a typed public property is ignored: `int` does not narrow
+// `string`, and the public real property is visible everywhere.
+/**
+ * @property int $name
+ */
+class ConflictingAnnotationOnPublic extends MagicMethodsBase
+{
+    public string $name = '';
+}
+
+function test_conflicting_annotation_on_public(): void
+{
+    $obj = new ConflictingAnnotationOnPublic();
+    take_string($obj->name);                            // OK: real public property is string
+    take_int($obj->name); // @mago-expect analysis:invalid-argument
+    $obj->name = 'world';                               // OK: real public property is writable
+}
+
+// A `readonly` (keyword) backing property documented as writable: external writes go through
+// `__set()` and must not be reported as writes to a readonly property.
+/**
+ * @property int $token
+ */
+class ReadonlyBackingProperty extends MagicMethodsBase
+{
+    private readonly int $token;
+
+    public function __construct()
+    {
+        $this->token = 1;
+    }
+}
+
+function test_readonly_backing_property(): void
+{
+    $obj = new ReadonlyBackingProperty();
+    $obj->token = 2;                                    // OK: handled by __set(), not the readonly property
+    take_int($obj->token);                              // OK: annotation says int (via __get)
+}
+
+// A `@property-write` tag over a private backing property: external writes are allowed through
+// `__set()`, external reads are rejected.
+/**
+ * @property-write string $secret
+ */
+class WriteOnlyTag extends MagicMethodsBase
+{
+    private string $secret = '';
+
+    public function reveal(): string
+    {
+        return $this->secret;                           // OK: internal read of the real property
+    }
+}
+
+function test_write_only_tag_write(): void
+{
+    $obj = new WriteOnlyTag();
+    $obj->secret = 'x';                                 // OK: writable via __set()
+}
+
+function test_write_only_tag_read(WriteOnlyTag $obj): void
+{
+    take_string($obj->secret); // @mago-expect analysis:invalid-property-read,no-value
+}
+
+// The refined type also governs assignments.
+/**
+ * @property string $db
+ */
+class NarrowingWriter extends WideBase
+{
+    public function write_internally(): void
+    {
+        $this->db = 'ok';                               // OK: narrowed to string
+        $this->db = 1; // @mago-expect analysis:invalid-property-assignment-value
+    }
+}
+
+function test_narrowing_refinement_write(): void
+{
+    $obj = new NarrowingWriter();
+    $obj->db = 'ok';                                    // OK: narrowed to string
+    $obj->db = 1; // @mago-expect analysis:invalid-property-assignment-value
+}
+
+// A static property is never reachable through `->`: even where it is visible, instance
+// access falls through to `__get`/`__set`, so the annotation governs every `->` access while
+// `self::$counter` keeps using the real declaration.
+/**
+ * @property-read int $counter
+ */
+class StaticBackingProperty extends MagicMethodsBase
+{
+    private static string $counter = '';
+
+    public static function bump(string $value): void
+    {
+        self::$counter = $value;                        // OK: real static property, visible here
+        take_string(self::$counter);                    // OK: static access keeps the real type
+        take_int(self::$counter); // @mago-expect analysis:invalid-argument
+    }
+
+    public function read_via_arrow(): void
+    {
+        take_int($this->counter);                       // OK: `->` goes through __get(), annotation says int
+    }
+}
+
+function test_static_backing_property(StaticBackingProperty $obj): void
+{
+    take_int($obj->counter);                            // OK: annotation says int (via __get)
+    take_string($obj->counter); // @mago-expect analysis:invalid-argument
+}
+
+// Type reconciliation on a documented property uses the annotation type for external accesses,
+// not the conflicting type of the private backing property.
+/**
+ * @property-read null|int $maybe
+ */
+class NullableDocumented extends MagicMethodsBase
+{
+    private string $maybe = '';
+}
+
+function test_reconciled_documented_property(NullableDocumented $obj): void
+{
+    if (isset($obj->maybe)) {
+        take_int($obj->maybe);                          // OK: annotation says null|int, narrowed to int
+    }
+
+    if ($obj->maybe !== null) {
+        take_int($obj->maybe);                          // OK: annotation says null|int, narrowed to int
+    }
+}
+
+// `@mixin` access is always external: the mixin's private backing property defers to the
+// annotation on the mixin class.
+/**
+ * @property-read int $mixedIn
+ */
+class MixinSource
+{
+    private string $mixedIn = '';
+
+    public string $plain = '';
+}
+
+/**
+ * @mixin MixinSource
+ */
+class MixinHost extends MagicMethodsBase
+{
+}
+
+function test_mixin_magic_deferral(MixinHost $host): void
+{
+    take_string($host->plain);                          // OK: public real property on the mixin
+    take_int($host->mixedIn);                           // OK: annotation says int (via __get)
+    take_string($host->mixedIn); // @mago-expect analysis:invalid-argument
+}
+
+// Intersection-member access is external as well: the member's private backing property defers
+// to its annotation.
+/**
+ * @property-read int $badge
+ */
+class BadgeSource
+{
+    private string $badge = '';
+}
+
+/**
+ * @param MagicMethodsBase&BadgeSource $obj
+ */
+function test_intersection_magic_deferral($obj): void
+{
+    take_int($obj->badge);                              // OK: annotation says int (via __get)
+    take_string($obj->badge); // @mago-expect analysis:invalid-argument
+}
+
+// The annotation may be inherited: a tag on the parent still governs external access to a
+// private real property declared on the child.
+/**
+ * @property-read int $inheritedTag
+ */
+class TagOnParent extends MagicMethodsBase
+{
+}
+
+class RealOnChild extends TagOnParent
+{
+    private string $inheritedTag = '';
+
+    public function read_internally(): void
+    {
+        take_string($this->inheritedTag);               // OK: real property, visible here
+    }
+}
+
+function test_tag_inherited_from_parent(RealOnChild $obj): void
+{
+    take_int($obj->inheritedTag);                       // OK: parent's annotation says int (via __get)
+    take_string($obj->inheritedTag); // @mago-expect analysis:invalid-argument
+}
+
+// When both parent and child document the same name, the nearest annotation wins.
+/**
+ * @property-read int $level
+ */
+class TagBase extends MagicMethodsBase
+{
+}
+
+/**
+ * @property-read string $level
+ */
+class TagOverride extends TagBase
+{
+}
+
+function test_nearest_tag_wins(TagOverride $obj): void
+{
+    take_string($obj->level);                           // OK: nearest annotation says string
+    take_int($obj->level); // @mago-expect analysis:invalid-argument
+}
+
+// Annotation-governed access through `@mixin` and intersection members is magic as well:
+// writes go through the host's `__set()`, never the mixin's readonly backing property, and a
+// host without magic methods reports them as missing.
+/**
+ * @property int $slot
+ */
+class MixinWithReadonlyBacking
+{
+    private readonly int $slot;
+
+    public function __construct()
+    {
+        $this->slot = 1;
+    }
+}
+
+/**
+ * @mixin MixinWithReadonlyBacking
+ */
+class MixinWriteHost extends MagicMethodsBase
+{
+}
+
+/**
+ * @mixin MixinWithReadonlyBacking
+ */
+class MixinWriteHostNoMagic
+{
+}
+
+function test_mixin_magic_write(MixinWriteHost $host): void
+{
+    $host->slot = 2;                                    // OK: handled by __set(), not the readonly property
+    take_int($host->slot);                              // OK: annotation says int
+}
+
+function test_mixin_magic_write_no_set(MixinWriteHostNoMagic $host): void
+{
+    $host->slot = 2; // @mago-expect analysis:missing-magic-method
+}
+
+function test_mixin_magic_read_no_get(MixinWriteHostNoMagic $host): void
+{
+    take_int($host->slot); // @mago-expect analysis:missing-magic-method
+}
+
+/**
+ * @property string $note
+ */
+class NoteSource
+{
+    private readonly string $note;
+
+    public function __construct()
+    {
+        $this->note = 'n';
+    }
+}
+
+/**
+ * @param MagicMethodsBase&NoteSource $obj
+ */
+function test_intersection_magic_write($obj): void
+{
+    $obj->note = 'x';                                   // OK: handled by __set(), not the readonly property
+}
+
+// Asymmetric visibility: a `public private(set)` property is visible from everywhere, so it is
+// never handed to `__set()` — PHP throws on an out-of-scope write instead of falling through
+// to the magic methods.  The annotation must not turn such writes into accepted magic writes.
+/**
+ * @property int $guarded
+ */
+class AsymmetricBackingProperty extends MagicMethodsBase
+{
+    public private(set) int $guarded = 0;
+}
+
+function test_asymmetric_visibility_not_magic(AsymmetricBackingProperty $obj): void
+{
+    take_int($obj->guarded);                            // OK: real property, readable everywhere
+    $obj->guarded = 1; // @mago-expect analysis:invalid-property-write
+}
+
+// Static access ignores annotations entirely: `Class::$prop` for a tag-only name is an access
+// to an undeclared static property, and the real static property keeps its own type for
+// `self::` access.
+/**
+ * @property-read int $tagOnlyStatic
+ */
+class TagOnlyStaticAccess extends MagicMethodsBase
+{
+}
+
+function test_static_access_to_tag_only_name(): void
+{
+    take_int(TagOnlyStaticAccess::$tagOnlyStatic); // @mago-expect analysis:non-existent-property,null-argument
+}
+
+// Tags are also inherited through implemented interfaces.
+/**
+ * @property-read int $viaInterface
+ */
+interface DocumentsMagicId
+{
+}
+
+class InterfaceTagImpl extends MagicMethodsBase implements DocumentsMagicId
+{
+    private string $viaInterface = '';
+}
+
+function test_tag_inherited_from_interface(InterfaceTagImpl $obj): void
+{
+    take_int($obj->viaInterface);                       // OK: interface annotation says int (via __get)
+    take_string($obj->viaInterface); // @mago-expect analysis:invalid-argument
+}
+
+// Inside a trait, `$this` is an instance of the `@require-extends` class, so a tag documented
+// there governs exactly like it would on a real subclass.
+/**
+ * @property-read int $fromBase
+ */
+class RequiredBase extends MagicMethodsBase
+{
+    private string $fromBase = '';
+}
+
+/**
+ * @require-extends RequiredBase
+ */
+trait UsesRequiredBase
+{
+    public function read_tag(): void
+    {
+        take_int($this->fromBase);                      // OK: tag on the required base (via __get)
+        take_string($this->fromBase); // @mago-expect analysis:invalid-argument
+    }
+}
+
+class ConcreteWithRequiredBase extends RequiredBase
+{
+    use UsesRequiredBase;
+}
+
+// Structural `object{...}` requirements are satisfied by the documented interface: the tag
+// counts even when the backing property is private (or absent).
+/**
+ * @property-read int $shape
+ */
+class ShapeSource extends MagicMethodsBase
+{
+    private string $shape = '';
+}
+
+/**
+ * @param object{shape: int} $_o
+ */
+function take_shape(object $_o): void {}
+
+function test_structural_containment_via_tag(ShapeSource $obj): void
+{
+    take_shape($obj);                                   // OK: tag documents `shape` as int
+}
+
+// Promoted constructor properties behave like any other real declaration.
+/**
+ * @property-read int $count
+ */
+class PromotedBackingProperty extends MagicMethodsBase
+{
+    public function __construct(private int $count)
+    {
+    }
+
+    public function bump(): void
+    {
+        $this->count = $this->count + 1;                // OK: real property, visible here
+    }
+}
+
+function test_promoted_backing_property(): void
+{
+    $obj = new PromotedBackingProperty(1);
+    take_int($obj->count);                              // OK: annotation says int (via __get)
+    $obj->count = 2; // @mago-expect analysis:invalid-property-write
+}

--- a/crates/analyzer/tests/cases/trait_class_property_conflicts.php
+++ b/crates/analyzer/tests/cases/trait_class_property_conflicts.php
@@ -132,6 +132,11 @@ class C9
 {
     use T10;
 
+    public function __construct()
+    {
+        $this->prop = 0;
+    }
+
     public function __get(string $name): int
     {
         return $this->prop;

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -647,6 +647,7 @@ test_case!(array_key_exists);
 test_case!(magic_methods);
 test_case!(magic_properties);
 test_case!(magic_property_overridden_by_parent);
+test_case!(magic_property_shadowing_real_property);
 test_case!(magic_methods_args);
 test_case!(method_annotation_with_inheritance);
 test_case!(array_shape_access);

--- a/crates/codex/src/metadata/class_like.rs
+++ b/crates/codex/src/metadata/class_like.rs
@@ -72,6 +72,19 @@ pub struct ClassLikeMetadata {
     pub inheritable_method_ids: WordMap<MethodIdentifier>,
     pub overridden_method_ids: WordMap<IndexMap<Word, MethodIdentifier, RandomState>>,
     pub properties: WordMap<PropertyMetadata>,
+    /// Magic properties documented via `@property`/`@property-read`/`@property-write` in this
+    /// class-like's own docblock.
+    ///
+    /// These describe the external `__get`/`__set` interface and are kept separate from the
+    /// real declarations in `properties`; which of the two governs a given access is decided
+    /// at resolution time from the call site's scope.  Inherited tags are reachable through
+    /// `magic_property_ids`, mirroring how `declaring_property_ids` works for real properties.
+    pub magic_properties: WordMap<PropertyMetadata>,
+    /// Maps every magic property name reachable on this class-like (own or inherited) to the
+    /// class-like whose docblock declares the tag.  An own tag beats inherited ones; between
+    /// tags inherited from unrelated parents, the first-populated parent wins (as with real
+    /// property inheritance).
+    pub magic_property_ids: WordMap<Word>,
     pub appearing_property_ids: WordMap<Word>,
     pub declaring_property_ids: WordMap<Word>,
     pub inheritable_property_ids: WordMap<Word>,
@@ -137,6 +150,8 @@ impl ClassLikeMetadata {
             overridden_method_ids: WordMap::default(),
             overridden_property_ids: WordMap::default(),
             properties: WordMap::default(),
+            magic_properties: WordMap::default(),
+            magic_property_ids: WordMap::default(),
             template_variance: Vec::new(),
             template_type_extends_count: WordMap::default(),
             template_extended_parameters: WordMap::default(),
@@ -799,8 +814,6 @@ impl ClassLikeMetadata {
 
                 slot.type_declaration_metadata.clone_from(&prop_metadata.type_declaration_metadata);
                 slot.type_metadata.clone_from(&prop_metadata.type_metadata);
-            } else if prop_metadata.flags.is_magic_property() {
-                self.add_property(*name, prop_metadata.clone());
             } else {
                 patch.issues.push(
                     Issue::error(format!(
@@ -817,6 +830,13 @@ impl ClassLikeMetadata {
                     )),
                 );
             }
+        }
+
+        // Magic `@property*` annotations carry no runtime existence claim: a patch may both
+        // refine an existing annotation and introduce a new one.
+        for (name, prop_metadata) in &patch.magic_properties {
+            self.magic_properties.insert(*name, prop_metadata.clone());
+            self.magic_property_ids.insert(*name, self.name);
         }
     }
 
@@ -901,6 +921,8 @@ impl ClassLikeMetadata {
     #[inline]
     pub fn shrink_to_fit(&mut self) {
         self.properties.shrink_to_fit();
+        self.magic_properties.shrink_to_fit();
+        self.magic_property_ids.shrink_to_fit();
         self.initialized_properties.shrink_to_fit();
         self.appearing_property_ids.shrink_to_fit();
         self.declaring_property_ids.shrink_to_fit();
@@ -1063,15 +1085,15 @@ mod tests {
 
         let mut patch = make("VendorClass");
         let prop_magic = word("$magic");
-        patch.properties.insert(
-            prop_magic,
-            PropertyMetadata::new(VariableIdentifier(prop_magic), MetadataFlags::PATCH | MetadataFlags::MAGIC_PROPERTY),
-        );
+        patch
+            .magic_properties
+            .insert(prop_magic, PropertyMetadata::new(VariableIdentifier(prop_magic), MetadataFlags::PATCH));
 
         vendored.apply_patch(&mut patch, &WordSet::default());
         let issues = patch.issues;
 
-        assert!(vendored.properties.contains_key(&prop_magic));
+        assert!(vendored.magic_properties.contains_key(&prop_magic));
+        assert_eq!(vendored.magic_property_ids.get(&prop_magic), Some(&vendored.name));
         assert!(issues.is_empty());
     }
 

--- a/crates/codex/src/metadata/flags.rs
+++ b/crates/codex/src/metadata/flags.rs
@@ -35,7 +35,8 @@ impl MetadataFlags {
     pub const ASYMMETRIC_PROPERTY: MetadataFlags = MetadataFlags(1 << 31);
     pub const STATIC: MetadataFlags = MetadataFlags(1 << 32);
     pub const WRITEONLY: MetadataFlags = MetadataFlags(1 << 33);
-    pub const MAGIC_PROPERTY: MetadataFlags = MetadataFlags(1 << 34);
+    // Bit 34 was MAGIC_PROPERTY; magic properties are now identified by their entry in
+    // `ClassLikeMetadata::magic_properties` instead of a flag.
     pub const MAGIC_METHOD: MetadataFlags = MetadataFlags(1 << 35);
     pub const API: MetadataFlags = MetadataFlags(1 << 36);
     pub const MUTATION_FREE: MetadataFlags = MetadataFlags(1 << 37);
@@ -264,12 +265,6 @@ impl MetadataFlags {
     #[must_use]
     pub const fn is_virtual_property(self) -> bool {
         self.contains(Self::VIRTUAL_PROPERTY)
-    }
-
-    #[inline]
-    #[must_use]
-    pub const fn is_magic_property(self) -> bool {
-        self.contains(Self::MAGIC_PROPERTY)
     }
 
     #[inline]

--- a/crates/codex/src/metadata/mod.rs
+++ b/crates/codex/src/metadata/mod.rs
@@ -237,6 +237,8 @@ impl CodebaseMetadata {
 
     /// Checks if a property exists on a class-like, including inherited properties.
     /// Class name is case-insensitive, property name is case-sensitive.
+    /// Sees real declarations only; magic `@property*` tags are reachable through
+    /// `ClassLikeMetadata::magic_property_ids`.
     #[inline]
     #[must_use]
     pub fn property_exists(&self, class: &[u8], property: &[u8]) -> bool {
@@ -447,6 +449,8 @@ impl CodebaseMetadata {
 
     /// Retrieves metadata for a property directly from the class where it's declared.
     /// Class name is case-insensitive, property name is case-sensitive.
+    /// Sees real declarations only; magic `@property*` tags are reachable through
+    /// `ClassLikeMetadata::magic_property_ids`.
     #[inline]
     #[must_use]
     pub fn get_property(&self, class: &[u8], property: &[u8]) -> Option<&PropertyMetadata> {
@@ -834,6 +838,8 @@ impl CodebaseMetadata {
     }
 
     /// Gets the class where a property is declared.
+    /// Sees real declarations only; magic `@property*` tags are reachable through
+    /// `ClassLikeMetadata::magic_property_ids`.
     #[inline]
     #[must_use]
     pub fn get_declaring_property_class(&self, class: &[u8], property: &[u8]) -> Option<Word> {

--- a/crates/codex/src/populator/hierarchy.rs
+++ b/crates/codex/src/populator/hierarchy.rs
@@ -337,6 +337,20 @@ pub fn populate_class_like_types(
         }
     }
 
+    for (property_name, property_metadata) in &mut metadata.magic_properties {
+        let property_reference_source = ReferenceSource::ClassLikeMember(true, name, *property_name);
+
+        if let Some(signature) = property_metadata.type_metadata.as_mut() {
+            populate_union_type(
+                &mut signature.type_union,
+                codebase_symbols,
+                Some(&property_reference_source),
+                symbol_references,
+                force_repopulation,
+            );
+        }
+    }
+
     for template in metadata.template_types.values_mut() {
         if template.constraint.needs_population() || force_repopulation {
             populate_union_type(

--- a/crates/codex/src/populator/properties.rs
+++ b/crates/codex/src/populator/properties.rs
@@ -7,6 +7,12 @@ pub fn inherit_properties_from_parent(metadata: &mut ClassLikeMetadata, parent_m
     let is_trait = metadata.kind.is_trait();
     let parent_is_trait = parent_metadata.kind.is_trait();
 
+    // Magic `@property*` annotations document the inherited `__get`/`__set` interface, so they
+    // apply to descendants as well; an own tag beats inherited ones.
+    for (property_name, declaring_classlike) in &parent_metadata.magic_property_ids {
+        metadata.magic_property_ids.entry(*property_name).or_insert(*declaring_classlike);
+    }
+
     for (property_name, appearing_classlike) in &parent_metadata.appearing_property_ids {
         if metadata.has_appearing_property(*property_name) {
             continue;
@@ -39,11 +45,7 @@ pub fn inherit_properties_from_parent(metadata: &mut ClassLikeMetadata, parent_m
         }
 
         if metadata.declaring_property_ids.contains_key(property_name) {
-            if !parent_is_trait && metadata.properties.get(property_name).is_some_and(|p| p.flags.is_magic_property()) {
-                metadata.properties.remove(property_name);
-            } else {
-                continue;
-            }
+            continue;
         }
 
         metadata.declaring_property_ids.insert(*property_name, *declaring_classlike);

--- a/crates/codex/src/scanner/class_like.rs
+++ b/crates/codex/src/scanner/class_like.rs
@@ -1179,9 +1179,8 @@ where
                 new_property.type_metadata.replace(type_metadata);
             }
 
-            new_property.flags.set(MetadataFlags::MAGIC_PROPERTY, true);
-
-            class_like_metadata.add_property_metadata(new_property);
+            class_like_metadata.magic_properties.insert(property_name, new_property);
+            class_like_metadata.magic_property_ids.insert(property_name, class_like_metadata.name);
         }
     }
 
@@ -1491,15 +1490,7 @@ where
                 let properties =
                     scan_properties(property, &mut class_like_metadata, name, &type_context, context, scope);
 
-                for mut property_metadata in properties {
-                    if let Some(existing_property) = class_like_metadata.properties.get_mut(&property_metadata.name.0) {
-                        property_metadata.read_visibility = existing_property.read_visibility;
-                        property_metadata.write_visibility = existing_property.read_visibility;
-
-                        property_metadata.flags.set(MetadataFlags::VIRTUAL_PROPERTY, false);
-                        property_metadata.flags.set(MetadataFlags::READONLY, existing_property.flags.is_readonly());
-                    }
-
+                for property_metadata in properties {
                     class_like_metadata.add_property_metadata(property_metadata);
                 }
             }

--- a/crates/codex/src/ttype/comparator/atomic_comparator.rs
+++ b/crates/codex/src/ttype/comparator/atomic_comparator.rs
@@ -357,19 +357,31 @@ pub fn is_contained_by(
                 {
                     let property_name = concat_word!(b"$", container_property_name);
 
-                    let Some(declaring_class) = class_like_metadata.declaring_property_ids.get(&property_name) else {
+                    let real_property = class_like_metadata
+                        .declaring_property_ids
+                        .get(&property_name)
+                        .and_then(|declaring_class| codebase.get_class_like(declaring_class.as_bytes()))
+                        .and_then(|declaring_metadata| declaring_metadata.properties.get(&property_name));
+
+                    // Structural containment is an external view: a publicly readable real
+                    // property governs; otherwise a magic `@property*` tag documents the
+                    // `__get` interface and applies instead.  A non-public real property
+                    // without a tag is still accepted, as it always was here.
+                    let declared_property = match real_property {
+                        Some(real) if real.read_visibility.is_public() => Some(real),
+                        real => class_like_metadata
+                            .magic_property_ids
+                            .get(&property_name)
+                            .and_then(|tag_class| codebase.get_class_like(tag_class.as_bytes()))
+                            .and_then(|tag_metadata| tag_metadata.magic_properties.get(&property_name))
+                            .or(real),
+                    };
+
+                    let Some(declared_property) = declared_property else {
                         if *container_property_indefinite {
                             continue;
                         }
                         return false;
-                    };
-
-                    let Some(declaring_class_metadata) = codebase.get_class_like(declaring_class.as_bytes()) else {
-                        return false; // should not happen
-                    };
-
-                    let Some(declared_property) = declaring_class_metadata.properties.get(&property_name) else {
-                        return false; // should not happen
                     };
 
                     match declared_property.type_metadata.as_ref() {


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes false positives on classes where a `@property*` tag and a real
property share a name (the classic private-backing-property-with-
documented-`__get`-interface pattern): bogus readonly-write reports on
internal writes, tag types leaking into internal accesses, and
populator-order-dependent masking between inherited real properties
and tags.

## 🔍 Context & Motivation

A `@property`/`@property-read`/`@property-write` tag documents the
interface a class exposes through `__get`/`__set`. Which declaration
governs an access follows PHP's runtime rule — the real property
wherever it is visible, the magic methods (and thus the tag) elsewhere
— so the decision depends on the call site and cannot be baked into
the stored metadata. The scanner nevertheless merges tags into the
regular property map at scan time, collapsing both declarations into
one entry with blended flags.

## 🛠️ Summary of Changes

- **Bug Fix:** Store tags separately
  (`ClassLikeMetadata::magic_properties` plus a `magic_property_ids`
  inheritance map) and decide per usage in the new
  `resolve_declared_property()` which declaration governs, mirroring
  PHP's rules: visibility is checked at the call site, `->` never
  reaches a static property, and asymmetric-visibility writes throw
  rather than fall through to `__set()`.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Analyzer, Codex

## 📝 Notes for Reviewers

A tag whose type narrows a visible real property's type refines it
(wide inherited `public $db` narrowed by `@property` on a subclass);
a conflicting tag type is ignored wherever the real property is
visible. Two deliberate behavioral changes ride along: structural
`object{...}` containment now consults tags alongside real
declarations, and `properties-of<T>` excludes them (they are not real
properties), matching Psalm.