### PR TITLE
fix(analyzer): support split @property-read/@property-write types

### DIFF
--- a/crates/analyzer/src/expression/assignment/property_assignment.rs
+++ b/crates/analyzer/src/expression/assignment/property_assignment.rs
@@ -9,6 +9,7 @@ use mago_codex::ttype::comparator::ComparisonResult;
 use mago_codex::ttype::comparator::union_comparator;
 use mago_codex::ttype::get_mixed;
 use mago_codex::ttype::get_never;
+use mago_codex::ttype::intersect_union_types;
 use mago_codex::ttype::union::TUnion;
 use mago_reporting::Annotation;
 use mago_reporting::Issue;
@@ -66,9 +67,13 @@ where
     block_context.flags.set_inside_assignment(was_inside_assignment);
 
     let mut resolved_property_type = None;
+    let mut readable_type: Option<TUnion> = None;
+    let mut has_read_clamp = false;
     let mut matched_all_properties = true;
     let mut widened_assigned_type: Option<TUnion> = None;
     for resolved_property in resolution_result.properties {
+        has_read_clamp |= resolved_property.read_type.is_some();
+
         // A magic-governed write goes through `__set()`, never through the real property of the
         // same name that may exist on the declaring class (e.g. a `readonly` backing property).
         if !resolved_property.is_magic
@@ -196,6 +201,13 @@ where
             }
         }
 
+        // The type a read yields for this property: the `@property-read` type for a magic
+        // property (writes go through `__set`, reads through `__get`), else the property type
+        // itself (writes round-trip).
+        let property_readable_type =
+            resolved_property.read_type.clone().unwrap_or_else(|| resolved_property.property_type.clone());
+        readable_type = Some(add_optional_union_type(property_readable_type, readable_type.as_ref(), context.codebase));
+
         resolved_property_type = Some(add_optional_union_type(
             resolved_property.property_type,
             resolved_property_type.as_ref(),
@@ -227,7 +239,23 @@ where
     if context.settings.memoize_properties
         && let Some(property_access_id) = property_access_id
     {
-        block_context.locals.insert(property_access_id, Rc::clone(&resulting_type));
+        // Memoize the written value so later reads of the same access see it — but only to the
+        // extent it survives a read. For a magic property a read goes through `__get`, yielding
+        // the `@property-read` type, so only the part of the written value that overlaps that
+        // type is observable on read: intersect with it, and fall back to the full read type when
+        // the write converts (a wider `@property-write` whose value shares nothing with the read
+        // type, e.g. a string coerced to int). Real and dynamic (`stdClass`) properties round-trip
+        // and have no distinct read type, so their written value is memoized as-is.
+        let memoized_type = if has_read_clamp && let Some(readable) = &readable_type {
+            let observable = intersect_union_types(readable, &resulting_type, context.codebase)
+                .filter(|intersection| !intersection.is_never());
+
+            Rc::new(observable.unwrap_or_else(|| readable.clone()))
+        } else {
+            Rc::clone(&resulting_type)
+        };
+
+        block_context.locals.insert(property_access_id, memoized_type);
     }
 
     artifacts.set_rc_expression_type(property_access, resulting_type);

--- a/crates/analyzer/src/resolver/property.rs
+++ b/crates/analyzer/src/resolver/property.rs
@@ -6,6 +6,7 @@ use mago_codex::identifier::method::MethodIdentifier;
 use mago_codex::metadata::CodebaseMetadata;
 use mago_codex::metadata::class_like::ClassLikeMetadata;
 use mago_codex::metadata::property::PropertyMetadata;
+use mago_codex::metadata::ttype::TypeMetadata;
 use mago_codex::misc::GenericParent;
 use mago_codex::ttype::TType;
 use mago_codex::ttype::atomic::TAtomic;
@@ -58,6 +59,12 @@ pub struct ResolvedProperty {
     pub property_span: Option<Span>,
     pub property_type: TUnion,
     pub is_magic: bool,
+    /// For a magic property resolved for assignment, the `@property-read` type — which a read
+    /// produces via `__get` regardless of the written value. `property_type` here is the (possibly
+    /// wider) `@property-write` type, so a written value that is not assignable to `read_type`
+    /// does not survive a read; memoization clamps to `read_type` in that case. `None` for reads
+    /// and for real/dynamic properties, whose writes round-trip (`property_type` is the read type).
+    pub read_type: Option<TUnion>,
 }
 
 /// Holds the results of a property resolution attempt.
@@ -185,6 +192,7 @@ where
                             declaring_class_id: None,
                             property_type: get_mixed(),
                             is_magic: false,
+                            read_type: None,
                         });
                     }
                 } else {
@@ -219,6 +227,7 @@ where
                             declaring_class_id: None,
                             property_type: get_mixed(),
                             is_magic: false,
+                            read_type: None,
                         });
                     }
                 } else {
@@ -291,6 +300,7 @@ where
                         declaring_class_id: None,
                         property_type,
                         is_magic: false,
+                        read_type: None,
                     };
 
                     result.properties.push(resolved_property);
@@ -423,6 +433,7 @@ where
             declaring_class_id: Some(word(b"UnitEnum")),
             property_type: TUnion::from_vec(name_types),
             is_magic: false,
+            read_type: None,
         })
     } else if prop_str == b"value" {
         let value_types: Vec<TAtomic> = cases.iter().filter_map(|case| case.value_type.clone()).collect();
@@ -439,6 +450,7 @@ where
             declaring_class_id: Some(word(b"BackedEnum")),
             property_type: TUnion::from_vec(value_types),
             is_magic: false,
+            read_type: None,
         })
     } else {
         None
@@ -483,8 +495,28 @@ impl DeclaredProperty<'_> {
     /// `@property` on a subclass), the annotation's type; otherwise the declared type, or
     /// `mixed` when untyped.  A conflicting (non-narrowing) annotation type is ignored.
     pub(crate) fn declared_type(&self, codebase: &CodebaseMetadata) -> TUnion {
+        self.declared_type_impl(codebase, false)
+    }
+
+    /// The type the governing declaration accepts when writing to the property: the distinct
+    /// `@property-write` type when the declaration splits read and write types, otherwise the
+    /// same type [`Self::declared_type`] returns.
+    pub(crate) fn declared_write_type(&self, codebase: &CodebaseMetadata) -> TUnion {
+        self.declared_type_impl(codebase, true)
+    }
+
+    /// [`Self::declared_write_type`] when `for_assignment`, otherwise [`Self::declared_type`].
+    pub(crate) fn declared_type_for(&self, codebase: &CodebaseMetadata, for_assignment: bool) -> TUnion {
+        self.declared_type_impl(codebase, for_assignment)
+    }
+
+    fn declared_type_impl(&self, codebase: &CodebaseMetadata, for_write: bool) -> TUnion {
+        fn annotation_type_metadata(annotation: &PropertyMetadata, for_write: bool) -> Option<&TypeMetadata> {
+            if for_write { annotation.get_write_type_metadata() } else { annotation.type_metadata.as_ref() }
+        }
+
         if let DeclaredPropertyKind::Real { annotation: Some(annotation) } = self.kind
-            && let Some(annotation_type) = annotation.type_metadata.as_ref().map(|tm| &tm.type_union)
+            && let Some(annotation_type) = annotation_type_metadata(annotation, for_write).map(|tm| &tm.type_union)
         {
             let narrows = match self.property.type_metadata.as_ref().map(|tm| &tm.type_union) {
                 None => true,
@@ -507,9 +539,7 @@ impl DeclaredProperty<'_> {
             }
         }
 
-        self.property
-            .type_metadata
-            .as_ref()
+        annotation_type_metadata(self.property, for_write)
             .or(self.property.type_declaration_metadata.as_ref())
             .map(|tm| tm.type_union.clone())
             .unwrap_or_else(get_mixed)
@@ -659,8 +689,13 @@ where
                     property_span: prop_meta.name_span.or(prop_meta.span),
                     property_name: prop_name,
                     declaring_class_id: Some(required_resolution.declaring_class.name),
-                    property_type: required_resolution.declared_type(context.codebase),
+                    property_type: required_resolution.declared_type_for(context.codebase, for_assignment),
                     is_magic: false,
+                    read_type: if for_assignment && required_resolution.is_magic() {
+                        Some(required_resolution.declared_type(context.codebase))
+                    } else {
+                        None
+                    },
                 });
             }
         }
@@ -668,9 +703,14 @@ where
         // Check mixins.
         if !class_metadata.mixins.is_empty() {
             // Try to find property in mixin types
-            if let Some(resolved) =
-                find_property_in_mixins(context, class_metadata, object, &class_metadata.mixins, prop_name)
-            {
+            if let Some(resolved) = find_property_in_mixins(
+                context,
+                class_metadata,
+                object,
+                &class_metadata.mixins,
+                prop_name,
+                for_assignment,
+            ) {
                 // For an annotation-governed mixin property, the caller reports a missing
                 // `__get`/`__set` on the accessed class; the mixin-specific warnings below
                 // cover real mixin properties only.
@@ -707,7 +747,8 @@ where
         }
 
         if let TObject::Named(named_object) = object
-            && let Some(resolved) = find_property_in_intersection_types(context, named_object, prop_name)
+            && let Some(resolved) =
+                find_property_in_intersection_types(context, named_object, prop_name, for_assignment)
         {
             return Some(resolved);
         }
@@ -728,6 +769,9 @@ where
                 declaring_class_id: Some(class_id),
                 property_type: get_mixed(),
                 is_magic: true,
+                // Undocumented access on a class with `__get`/`__set` (e.g. `stdClass` dynamic
+                // properties): the type is unknown, so the written value stays memoizable.
+                read_type: None,
             });
         }
 
@@ -745,6 +789,7 @@ where
                 declaring_class_id: None,
                 property_type: get_mixed(),
                 is_magic: false,
+                read_type: None,
             });
         }
 
@@ -778,7 +823,7 @@ where
         {
             param_type.type_union.clone()
         } else {
-            resolution.declared_type(context.codebase)
+            resolution.declared_write_type(context.codebase)
         }
     } else {
         resolution.declared_type(context.codebase)
@@ -844,6 +889,11 @@ where
         declaring_class_id: Some(declaring_class_id),
         property_type,
         is_magic: resolution.is_magic(),
+        read_type: if for_assignment && resolution.is_magic() {
+            Some(resolution.declared_type(context.codebase))
+        } else {
+            None
+        },
     })
 }
 
@@ -1318,6 +1368,7 @@ fn find_property_in_mixins<A>(
     outer_object: &TObject,
     mixins: &[TUnion],
     prop_name: Word,
+    for_assignment: bool,
 ) -> Option<ResolvedProperty>
 where
     A: Arena,
@@ -1326,12 +1377,15 @@ where
         for mixin_atomic in mixin_type.types.as_ref() {
             match mixin_atomic {
                 TAtomic::Object(TObject::Named(named)) => {
-                    if let Some(result) = find_property_in_single_mixin(context, named.name, prop_name) {
+                    if let Some(result) = find_property_in_single_mixin(context, named.name, prop_name, for_assignment)
+                    {
                         return Some(result);
                     }
                 }
                 TAtomic::Object(TObject::Enum(enum_type)) => {
-                    if let Some(result) = find_property_in_single_mixin(context, enum_type.name, prop_name) {
+                    if let Some(result) =
+                        find_property_in_single_mixin(context, enum_type.name, prop_name, for_assignment)
+                    {
                         return Some(result);
                     }
                 }
@@ -1354,7 +1408,9 @@ where
                                 _ => continue,
                             };
 
-                            if let Some(result) = find_property_in_single_mixin(context, class_name, prop_name) {
+                            if let Some(result) =
+                                find_property_in_single_mixin(context, class_name, prop_name, for_assignment)
+                            {
                                 return Some(result);
                             }
                             resolved = true;
@@ -1371,7 +1427,7 @@ where
                             };
 
                             if let Some(result) =
-                                find_property_in_single_mixin(context, constraint_class_name, prop_name)
+                                find_property_in_single_mixin(context, constraint_class_name, prop_name, for_assignment)
                             {
                                 return Some(result);
                             }
@@ -1391,6 +1447,7 @@ fn find_property_in_single_mixin<A>(
     context: &Context<'_, '_, A>,
     mixin_class_name: Word,
     prop_name: Word,
+    for_assignment: bool,
 ) -> Option<ResolvedProperty>
 where
     A: Arena,
@@ -1405,8 +1462,13 @@ where
         property_span: property_metadata.name_span.or(property_metadata.span),
         property_name: prop_name,
         declaring_class_id: Some(resolution.declaring_class.name),
-        property_type: resolution.declared_type(context.codebase),
+        property_type: resolution.declared_type_for(context.codebase, for_assignment),
         is_magic: resolution.is_magic(),
+        read_type: if for_assignment && resolution.is_magic() {
+            Some(resolution.declared_type(context.codebase))
+        } else {
+            None
+        },
     })
 }
 
@@ -1416,6 +1478,7 @@ fn find_property_in_intersection_types<A>(
     context: &Context<'_, '_, A>,
     named_object: &TNamedObject,
     prop_name: Word,
+    for_assignment: bool,
 ) -> Option<ResolvedProperty>
 where
     A: Arena,
@@ -1443,8 +1506,13 @@ where
                     property_span: property_metadata.name_span.or(property_metadata.span),
                     property_name: prop_name,
                     declaring_class_id: Some(resolution.declaring_class.name),
-                    property_type: resolution.declared_type(context.codebase),
+                    property_type: resolution.declared_type_for(context.codebase, for_assignment),
                     is_magic: resolution.is_magic(),
+                    read_type: if for_assignment && resolution.is_magic() {
+                        Some(resolution.declared_type(context.codebase))
+                    } else {
+                        None
+                    },
                 });
             }
             TAtomic::Object(TObject::WithProperties(shaped)) => {
@@ -1457,6 +1525,7 @@ where
                         declaring_class_id: None,
                         property_type: property_type.clone(),
                         is_magic: false,
+                        read_type: None,
                     });
                 }
             }

--- a/crates/analyzer/src/resolver/static_property.rs
+++ b/crates/analyzer/src/resolver/static_property.rs
@@ -195,6 +195,7 @@ where
                     declaring_class_id: Some(required_declaring_id),
                     property_type,
                     is_magic: false,
+                    read_type: None,
                 });
             }
         }
@@ -258,6 +259,7 @@ where
         declaring_class_id: Some(declaring_class_id),
         property_type,
         is_magic: false,
+        read_type: None,
     })
 }
 

--- a/crates/analyzer/tests/cases/magic_property_asymmetric_write_tracking.php
+++ b/crates/analyzer/tests/cases/magic_property_asymmetric_write_tracking.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MagicPropertyAsymmetricWriteTracking;
+
+/**
+ * A wider `@property-write` than `@property-read` documents a `__set()` that converts: any
+ * `string|int` may be written, but a read always yields `int|false`.
+ *
+ * @property-read int|false $converted
+ * @property-write int|string $converted
+ */
+class Converter
+{
+    public function __get(string $_name): mixed
+    {
+        return 0;
+    }
+
+    public function __set(string $_name, mixed $_value): void
+    {
+    }
+}
+
+function takesInt(int $_value): void
+{
+}
+
+$converter = new Converter();
+
+// An `int` write is assignable to the read type, so a read tracks it: the `false` branch is
+// excluded and the value passes where a plain `int` is required.
+$converter->converted = 5;
+takesInt($converter->converted);
+
+// A `string` write shares nothing with the read type — `__set()` converts it — so the read
+// falls back to the full `@property-read` type, whose `false` is not a valid `int` argument.
+$converter->converted = 'today';
+takesInt($converter->converted); // @mago-expect analysis:possibly-false-argument

--- a/crates/analyzer/tests/cases/magic_property_split_read_write.php
+++ b/crates/analyzer/tests/cases/magic_property_split_read_write.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MagicPropertySplitReadWrite;
+
+class Value
+{
+}
+
+/**
+ * @property-read Value $forward
+ * @property-write Value|string $forward
+ * @property-write Value|string $backward
+ * @property-read Value $backward
+ */
+class Container
+{
+    public function __get(string $_name): mixed
+    {
+        return new Value();
+    }
+
+    public function __set(string $_name, mixed $_value): void
+    {
+    }
+}
+
+function takesValue(Value $_value): void
+{
+}
+
+$container = new Container();
+
+// Reads produce the @property-read type, whichever tag order declared it.
+takesValue($container->forward);
+takesValue($container->backward);
+
+// Writes are checked against the @property-write type, not the read type.
+$container->forward = new Value();
+$container->forward = 'converted';
+$container->backward = 'converted';
+
+// A write does not shadow the read type: a read after assigning a write-only-typed value
+// still produces the @property-read type (the read goes through __get, not the written value).
+takesValue($container->forward);
+takesValue($container->backward);
+
+// A value outside the write type is still rejected.
+$container->forward = 42; // @mago-expect analysis:invalid-property-assignment-value

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -648,6 +648,8 @@ test_case!(magic_methods);
 test_case!(magic_properties);
 test_case!(magic_property_overridden_by_parent);
 test_case!(magic_property_shadowing_real_property);
+test_case!(magic_property_split_read_write);
+test_case!(magic_property_asymmetric_write_tracking);
 test_case!(magic_methods_args);
 test_case!(method_annotation_with_inheritance);
 test_case!(array_shape_access);

--- a/crates/codex/src/metadata/class_like.rs
+++ b/crates/codex/src/metadata/class_like.rs
@@ -814,6 +814,7 @@ impl ClassLikeMetadata {
 
                 slot.type_declaration_metadata.clone_from(&prop_metadata.type_declaration_metadata);
                 slot.type_metadata.clone_from(&prop_metadata.type_metadata);
+                slot.write_type_metadata.clone_from(&prop_metadata.write_type_metadata);
             } else {
                 patch.issues.push(
                     Issue::error(format!(

--- a/crates/codex/src/metadata/property.rs
+++ b/crates/codex/src/metadata/property.rs
@@ -59,6 +59,12 @@ pub struct PropertyMetadata {
     /// in a docblock comment (e.g., `@var string`).
     pub type_metadata: Option<TypeMetadata>,
 
+    /// The type accepted when writing to the property, when it differs from `type_metadata`.
+    ///
+    /// Only set for magic properties declaring split `@property-read` / `@property-write`
+    /// types; `None` means writes accept the same type that reads produce (`type_metadata`).
+    pub write_type_metadata: Option<TypeMetadata>,
+
     /// The type inferred from the property's default value, if it has one.
     ///
     /// e.g., for `public $count = 0;`, this would contain the metadata for `int(0)`.
@@ -94,6 +100,7 @@ impl PropertyMetadata {
             write_visibility: Visibility::Public,
             type_declaration_metadata: None,
             type_metadata: None,
+            write_type_metadata: None,
             default_type_metadata: None,
             flags,
             hooks: WordMap::default(),
@@ -134,6 +141,14 @@ impl PropertyMetadata {
     #[inline]
     pub fn set_type_metadata(&mut self, type_metadata: Option<TypeMetadata>) {
         self.type_metadata = type_metadata;
+    }
+
+    /// Returns the type accepted when writing to the property: the distinct write type
+    /// when one is declared, the read type otherwise.
+    #[inline]
+    #[must_use]
+    pub fn get_write_type_metadata(&self) -> Option<&TypeMetadata> {
+        self.write_type_metadata.as_ref().or(self.type_metadata.as_ref())
     }
 
     /// Returns a reference to the property's name identifier.

--- a/crates/codex/src/populator/hierarchy.rs
+++ b/crates/codex/src/populator/hierarchy.rs
@@ -349,6 +349,16 @@ pub fn populate_class_like_types(
                 force_repopulation,
             );
         }
+
+        if let Some(signature) = property_metadata.write_type_metadata.as_mut() {
+            populate_union_type(
+                &mut signature.type_union,
+                codebase_symbols,
+                Some(&property_reference_source),
+                symbol_references,
+                force_repopulation,
+            );
+        }
     }
 
     for template in metadata.template_types.values_mut() {

--- a/crates/codex/src/scanner/class_like.rs
+++ b/crates/codex/src/scanner/class_like.rs
@@ -1160,6 +1160,44 @@ where
                 None
             };
 
+            // `@property-read` and `@property-write` tags for the same property combine into
+            // one readable and writable declaration; the later tag must not replace the earlier.
+            if let Some(existing_property) = class_like_metadata.magic_properties.get_mut(&property_name) {
+                let existing_is_write_only = existing_property.flags.is_writeonly();
+                let existing_is_read_only = existing_property.flags.is_readonly();
+
+                if is_read {
+                    existing_property.read_visibility = Visibility::Public;
+                    existing_property.flags.set(MetadataFlags::WRITEONLY, false);
+                    if existing_is_write_only {
+                        // The type slot holds the write-only tag's type; the read type takes the
+                        // slot (it is what property accesses produce) and the write type moves
+                        // into the dedicated write slot.
+                        if existing_property.write_type_metadata.is_none() {
+                            existing_property.write_type_metadata = existing_property.type_metadata.take();
+                        }
+
+                        existing_property.type_metadata = type_metadata.clone();
+                    } else if existing_property.type_metadata.is_none() {
+                        existing_property.type_metadata = type_metadata.clone();
+                    }
+                }
+
+                if is_write {
+                    existing_property.write_visibility = Visibility::Public;
+                    existing_property.flags.set(MetadataFlags::READONLY, false);
+                    if existing_is_read_only {
+                        if existing_property.write_type_metadata.is_none() {
+                            existing_property.write_type_metadata = type_metadata;
+                        }
+                    } else if existing_property.type_metadata.is_none() {
+                        existing_property.type_metadata = type_metadata;
+                    }
+                }
+
+                continue;
+            }
+
             let mut new_property = PropertyMetadata::new(VariableIdentifier(property_name), MetadataFlags::empty());
             if is_read {
                 new_property.read_visibility = Visibility::Public;


### PR DESCRIPTION
## 📌 What Does This PR Do?

Makes split `@property-read` / `@property-write` docblock tags on magic
properties work as an asymmetric read/write type pair, so a property
whose `__set()` accepts a wider type than `__get()` returns is analyzed
correctly on both reads and writes.

## 🔍 Context & Motivation

A split declaration exists precisely to express that read and write
types differ — a symmetric one would just be `@property`. Today that
case is broken in three compounding ways: the second tag overwrites the
first (so the property silently becomes read-only or write-only
depending on tag order, and half the documented interface vanishes);
even combined, a single type slot forces the read type onto writes, so
every wider write the `@property-write` tag allows is a false-positive
`invalid-property-assignment-value`; and because property accesses are
memoized, a read after a write returns the written value rather than
what `__get()` would actually yield — a type the property can never
produce.

None of these can be fixed in isolation: combining the tags needs a
dedicated write-type slot to be correct, which in turn needs the
memoized read to be clamped back to the `@property-read` type. Hence a
single change rather than a staged one.

## 🛠️ Summary of Changes

- **Bug Fix:** Combine split `@property-read`/`@property-write` tags into
  one readable-and-writable magic property, check assignments against a
  dedicated write type, and clamp memoized reads to the `@property-read`
  type (intersecting the written value with it, so a read-compatible
  write is still tracked precisely).

## 📂 Affected Areas

- [x] Other (please specify): Analyzer / codex metadata

## 🔗 Related Issues or PRs

Fixes #2079

## 📝 Notes for Reviewers

Real properties and dynamic-property (`stdClass`) accesses are
untouched: they have no distinct read type and their writes round-trip,
so the new `read_type` slot is `None` for them and memoization behaves
exactly as before. The only assumption added is that a read-compatible
write round-trips through `__get()` — the same assumption already made
for real and hooked properties, so this makes magic properties
consistent rather than adding new imprecision.