### PR TITLE
feat(guard): Complete final class guard

### DIFF
--- a/crates/guard/src/structural/mod.rs
+++ b/crates/guard/src/structural/mod.rs
@@ -133,9 +133,10 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                     .get_class(fqn)
                     .map(|c| c.flags.is_final())
                     .unwrap_or(class.modifiers.contains_final());
+                let is_abstract = class.modifiers.contains_abstract();
 
-                match (must_be_final, is_final) {
-                    (true, false) => {
+                match (must_be_final, is_final, is_abstract) {
+                    (true, false, false) => {
                         structural_flaws.push(StructuralFlaw {
                             symbol_fqn: fqn_to_owned(fqn),
                             symbol_kind: StructuralSymbolKind::Class,
@@ -144,7 +145,7 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                             reason: structural_rule.reason.clone(),
                         });
                     }
-                    (false, true) => {
+                    (false, true, true) => {
                         structural_flaws.push(StructuralFlaw {
                             symbol_fqn: fqn_to_owned(fqn),
                             symbol_kind: StructuralSymbolKind::Class,

--- a/crates/guard/src/structural/mod.rs
+++ b/crates/guard/src/structural/mod.rs
@@ -133,9 +133,10 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                     .get_class(fqn)
                     .map(|c| c.flags.is_final())
                     .unwrap_or(class.modifiers.contains_final());
+                let is_abstract = class.modifiers.contains_abstract();
 
-                match (must_be_final, is_final) {
-                    (true, false) => {
+                match (must_be_final, is_final, is_abstract) {
+                    (true, false, false) => {
                         structural_flaws.push(StructuralFlaw {
                             symbol_fqn: fqn_to_owned(fqn),
                             symbol_kind: StructuralSymbolKind::Class,
@@ -144,7 +145,7 @@ impl<'ast, 'ctx, 'arena> MutWalker<'ast, 'arena, GuardContext<'ctx, 'arena>> for
                             reason: structural_rule.reason.clone(),
                         });
                     }
-                    (false, true) => {
+                    (false, true, _) => {
                         structural_flaws.push(StructuralFlaw {
                             symbol_fqn: fqn_to_owned(fqn),
                             symbol_kind: StructuralSymbolKind::Class,

--- a/crates/guard/tests/mod.rs
+++ b/crates/guard/tests/mod.rs
@@ -816,6 +816,34 @@ pub fn test_only_public_methods_restricts_declared_class_api() {
 }
 
 #[test]
+pub fn test_is_guard_non_final_class() {
+    let code = indoc! {r"
+        <?php
+            namespace App\Entity {
+                class Test {
+
+                }
+            }
+    "};
+
+    let settings = Settings {
+        structural: StructuralSettings {
+            rules: vec![StructuralRule {
+                on: "**\\Entity\\*".into(),
+                target: StructuralSymbolKind::Class.into(),
+                must_be_final: Some(true),
+                ..Default::default()
+            }],
+        },
+        ..Default::default()
+    };
+
+    let result = test_guard("get_error_on_non_final_class", code, settings);
+    assert!(!result.structural_flaws.is_empty(), "Expected violations: Should declare final");
+    assert!(result.structural_flaws.iter().all(|flaw| flaw.kind.error_code() == "must-be-final"));
+}
+
+#[test]
 pub fn test_is_final_annotation_counted() {
     let code = indoc! {r"
         <?php
@@ -840,6 +868,36 @@ pub fn test_is_final_annotation_counted() {
     };
 
     let result = test_guard("count_final_annotation_as_real_final_class", code, settings);
+    assert!(
+        result.structural_flaws.is_empty(),
+        "Expected non violations: Should allow declare final class with annotation"
+    );
+}
+
+#[test]
+pub fn test_is_final_ignored_on_abstract_class() {
+    let code = indoc! {r"
+        <?php
+            namespace App\Entity {
+                abstract class Test {
+
+                }
+            }
+    "};
+
+    let settings = Settings {
+        structural: StructuralSettings {
+            rules: vec![StructuralRule {
+                on: "**\\Entity\\*".into(),
+                target: StructuralSymbolKind::Class.into(),
+                must_be_final: Some(true),
+                ..Default::default()
+            }],
+        },
+        ..Default::default()
+    };
+
+    let result = test_guard("skip_abstract_class_on_final_check", code, settings);
     assert!(
         result.structural_flaws.is_empty(),
         "Expected non violations: Should allow declare final class with annotation"


### PR DESCRIPTION
## 📌 What Does This PR Do?

In guard structural check class is abstract or not, If its abstract ignore must-be-final

## 🔍 Context & Motivation

Abstract class cannot be final 

## 🛠️ Summary of Changes

- **Feature:** Ignore abstract class on must-be-final config

## 📂 Affected Areas

- [X] Guard

## 🔗 Related Issues or PRs

https://github.com/carthage-software/mago/issues/2114

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
