### PR TITLE
bugfix: Add non empty codebase metadata to guard

### DIFF
--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -294,13 +294,13 @@ impl<'cfg> Orchestrator<'cfg> {
     /// # Returns
     ///
     /// A [`GuardService`] configured with the orchestrator's guard settings and progress bar preferences.
-    pub fn get_guard_service(&self, database: ReadDatabase, codebase: CodebaseMetadata) -> GuardService {
+    pub fn get_guard_service(&self, database: ReadDatabase) -> GuardService {
         GuardService::new(
             database,
-            codebase,
             self.config.guard_settings.clone(),
             self.config.parser_settings,
             self.config.use_progress_bars,
+            self.config.php_version,
         )
     }
 

--- a/crates/orchestrator/src/service/guard.rs
+++ b/crates/orchestrator/src/service/guard.rs
@@ -1,10 +1,9 @@
-use std::sync::Arc;
-
-use mago_codex::metadata::CodebaseMetadata;
+use mago_codex::scanner::scan_program;
 use mago_database::ReadDatabase;
 use mago_guard::ArchitecturalGuard;
 use mago_guard::settings::Settings;
 use mago_names::resolver::NameResolver;
+use mago_php_version::PHPVersion;
 use mago_reporting::Issue;
 use mago_reporting::IssueCollection;
 use mago_syntax::parser::parse_file_with_settings;
@@ -31,9 +30,6 @@ pub struct GuardService {
     /// The read-only database containing source files to guard.
     database: ReadDatabase,
 
-    /// A codebase metadata of builtin symbols.
-    codebase: CodebaseMetadata,
-
     /// The guard settings to configure the guarding process.
     settings: Settings,
 
@@ -42,6 +38,7 @@ pub struct GuardService {
 
     /// Whether to display progress bars during guarding.
     use_progress_bars: bool,
+    php_version: PHPVersion,
 }
 
 impl GuardService {
@@ -61,12 +58,12 @@ impl GuardService {
     #[must_use]
     pub fn new(
         database: ReadDatabase,
-        codebase: CodebaseMetadata,
         settings: Settings,
         parser_settings: ParserSettings,
         use_progress_bars: bool,
+        php_version: PHPVersion,
     ) -> Self {
-        Self { database, codebase, settings, parser_settings, use_progress_bars }
+        Self { database, settings, parser_settings, use_progress_bars, php_version }
     }
 
     /// Runs the guard pipeline on the codebase.
@@ -89,12 +86,12 @@ impl GuardService {
         let pipeline = StatelessParallelPipeline::new(
             GUARD_PROGRESS_PREFIX,
             self.database,
-            (Arc::new(self.codebase), self.settings, self.parser_settings),
+            (self.settings, self.parser_settings, self.php_version),
             Box::new(GuardResultReducer),
             self.use_progress_bars,
         );
 
-        let issues = pipeline.run(|(codebase, guard_settings, parser_settings), arena, source_file| {
+        let issues = pipeline.run(|(guard_settings, parser_settings, php_version), arena, source_file| {
             let mut issues = IssueCollection::new();
 
             let program = parse_file_with_settings(arena, &source_file, parser_settings);
@@ -103,8 +100,9 @@ impl GuardService {
             }
 
             let resolved_names = NameResolver::new(arena).resolve(program);
+            let user_codebase = scan_program(&arena, &source_file, program, &resolved_names, php_version);
             let guard = ArchitecturalGuard::new(guard_settings);
-            let report = guard.check(&codebase, program, &resolved_names);
+            let report = guard.check(&user_codebase, program, &resolved_names);
 
             issues.extend(
                 // Report as issues

--- a/src/commands/guard.rs
+++ b/src/commands/guard.rs
@@ -157,7 +157,7 @@ impl GuardCommand {
         let command_start = trace_enabled.then(Instant::now);
 
         let prelude_start = trace_enabled.then(Instant::now);
-        let Prelude { database, metadata, .. } = if self.no_stubs {
+        let Prelude { database, .. } = if self.no_stubs {
             Prelude::default()
         } else {
             Prelude::decode(PRELUDE_BYTES).expect("Failed to decode embedded prelude")
@@ -230,7 +230,7 @@ impl GuardCommand {
         }
 
         let guard_run_start = trace_enabled.then(Instant::now);
-        let service = orchestrator.get_guard_service(database.read_only(), metadata);
+        let service = orchestrator.get_guard_service(database.read_only());
         let result = service.run()?;
         let guard_run_duration = guard_run_start.map(|s| s.elapsed());
 


### PR DESCRIPTION
## 📌 What Does This PR Do?

Add codebase metadata from scanned file.

## 🔍 Context & Motivation

To check is class final from dock block annotation require non empty codebase metadata. In current impl, CodebaseMetadata is empty for guard.
In this PR i add codebase for each scanned program

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed empty codebaseMetadata 

## 📂 Affected Areas

- [x] Orchestrator

## 🔗 Related Issues or PRs

https://github.com/carthage-software/mago/issues/2113

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
