### PR TITLE
fix(analyzer): preserve array_map shape for untyped closures

### DIFF
--- a/crates/analyzer/src/plugin/libraries/stdlib/array/array_map.rs
+++ b/crates/analyzer/src/plugin/libraries/stdlib/array/array_map.rs
@@ -79,19 +79,35 @@ impl FunctionReturnTypeProvider for ArrayMapProvider {
         }
 
         let array_arg = invocation.get_argument(1, &[b"array"])?;
-        let callback_metadata = context.get_callable_metadata(callback_arg)?;
-        let raw_return_type = &callback_metadata.return_type_metadata.as_ref()?.type_union;
+        let callback_metadata = context.get_callable_metadata(callback_arg);
+
+        // Fall back to the inferred return type when none is declared, e.g. for
+        // an untyped arrow function.
+        let declared_return_type =
+            callback_metadata.and_then(|metadata| metadata.return_type_metadata.as_ref()).map(|r| &r.type_union);
+        let inferred_return_type = if callback_type.is_single()
+            && let TAtomic::Callable(callable) = callback_type.get_single()
+        {
+            callable.get_signature().and_then(|signature| signature.get_return_type())
+        } else {
+            None
+        };
+        let raw_return_type = declared_return_type.or(inferred_return_type)?.clone();
 
         let array_type = context.get_expression_type(array_arg)?;
         let array = array_type.get_single_array()?;
 
         let codebase = context.codebase();
-        let first_parameter_name = callback_metadata.parameters.first().map(|parameter| parameter.name.0);
+        // Only a declared return type can reference the callback's parameter.
+        let first_parameter_name = declared_return_type
+            .and(callback_metadata)
+            .and_then(|metadata| metadata.parameters.first())
+            .map(|parameter| parameter.name.0);
 
         let resolve_for = |element: &TUnion| -> TUnion {
             match first_parameter_name {
                 Some(parameter_name) => {
-                    resolve_conditionals_in_return(codebase, raw_return_type, parameter_name, element)
+                    resolve_conditionals_in_return(codebase, &raw_return_type, parameter_name, element)
                 }
                 None => raw_return_type.clone(),
             }

--- a/crates/analyzer/tests/cases/arrays_array_map_optional_keys_untyped_closure.php
+++ b/crates/analyzer/tests/cases/arrays_array_map_optional_keys_untyped_closure.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * `array_map` must preserve the sealed shape rather than widen it to include
+ * a `list<string>` that would clash with the declared return type.
+ *
+ * @param array{foo?: string} $x
+ * @return array<string, string>
+ */
+function map_optional_shape(array $x): array
+{
+    return array_map(fn($value) => $value, $x);
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -93,6 +93,7 @@ test_case!(arrays_array_intersect);
 test_case!(arrays_array_keys);
 test_case!(arrays_array_map_keyed);
 test_case!(arrays_array_map_list);
+test_case!(arrays_array_map_optional_keys_untyped_closure);
 test_case!(arrays_array_map_multi);
 test_case!(arrays_array_merge_two_lists);
 test_case!(arrays_max_on_possibly_empty);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Keeps `array_map()` from widening a sealed, only-optional array shape
(e.g. `array{foo?: string}`) when the callback is an untyped closure.

## 🔍 Context & Motivation

The `array_map` return-type provider only reads a callback's *declared*
return type. An untyped arrow function like `fn($v) => $v` has none, so
the provider bails and `array_map` falls back to its stub signature. That
widens the shape to `array<string('foo'), string>|list<string>`. The
`list<...>` part is bogus — an only-optional sealed shape can never carry
integer keys, so it is never a list — and it then clashes with a declared
`array<string, ...>` return type, producing a spurious error.

The analyzer has in fact already inferred a return type for the closure
and recorded it on the callback expression's callable signature (e.g.
`(closure(mixed): string)`). Fall back to that inferred type so the
precise shape is preserved.

## 🛠️ Summary of Changes

- **Bug Fix:** `array_map()` preserves array shapes when the callback is
  an untyped closure/arrow function.

## 📂 Affected Areas

- [x] Other: analyzer