### PR TITLE
feat(cli): add `--stats` shorthand for count output

### DIFF
--- a/docs/content/en/fundamentals/shared-reporting-options.md
+++ b/docs/content/en/fundamentals/shared-reporting-options.md
@@ -28,6 +28,7 @@ How Mago presents the issues it finds.
 | Flag | Description |
 | :--- | :--- |
 | `--sort` | Sort reported issues by level, then code, then location. |
+| `--stats` | Show a summary of issue counts per code, ordered from highest to lowest, instead of individual issues. Shorthand for `--reporting-format code-count`. |
 | `--reporting-target <TARGET>` | Where to write the report. Values: `stdout` (default), `stderr`. |
 | `--reporting-format <FORMAT>` | Output format. See below; defaults to auto-detected. |
 | `--minimum-fail-level <LEVEL>`, `-m` | Lowest level that triggers a non-zero exit. Values: `note`, `help`, `warning`, `error`. Defaults to the value in the config file, or `error` if absent. |

--- a/docs/content/fr/fundamentals/shared-reporting-options.md
+++ b/docs/content/fr/fundamentals/shared-reporting-options.md
@@ -28,6 +28,7 @@ Comment Mago présente les problèmes trouvés.
 | Drapeau | Description |
 | :--- | :--- |
 | `--sort` | Trie les problèmes signalés par niveau, puis par code, puis par emplacement. |
+| `--stats` | Affiche un résumé du nombre de problèmes par code, du plus fréquent au moins fréquent, au lieu des problèmes individuels. Raccourci pour `--reporting-format code-count`. |
 | `--reporting-target <TARGET>` | Où écrire le rapport. Valeurs : `stdout` (par défaut), `stderr`. |
 | `--reporting-format <FORMAT>` | Format de sortie. Voir ci-dessous ; par défaut auto-détecté. |
 | `--minimum-fail-level <LEVEL>`, `-m` | Niveau le plus bas qui déclenche un code de sortie non nul. Valeurs : `note`, `help`, `warning`, `error`. Par défaut, la valeur du fichier de configuration, ou `error` si absent. |

--- a/docs/content/zh/fundamentals/shared-reporting-options.md
+++ b/docs/content/zh/fundamentals/shared-reporting-options.md
@@ -28,6 +28,7 @@ Mago 如何呈现它发现的问题。
 | 参数 | 说明 |
 | :--- | :--- |
 | `--sort` | 按级别、code、位置依次排序报告中的问题。 |
+| `--stats` | 显示每个 code 的问题数量汇总（按数量从高到低排序），而不是逐条列出问题。等同于 `--reporting-format code-count` 的简写。 |
 | `--reporting-target <TARGET>` | 报告写入的目标。可选值:`stdout`(默认)、`stderr`。 |
 | `--reporting-format <FORMAT>` | 输出格式。详见下文;默认自动检测。 |
 | `--minimum-fail-level <LEVEL>`, `-m` | 触发非零退出的最低级别。可选值:`note`、`help`、`warning`、`error`。默认采用配置文件中的值,若无则为 `error`。 |

--- a/src/commands/args/reporting.rs
+++ b/src/commands/args/reporting.rs
@@ -62,6 +62,14 @@ pub struct ReportingArgs {
     #[arg(long)]
     pub sort: bool,
 
+    /// Show a summary of issue counts per code instead of individual issues.
+    ///
+    /// Instead of reporting each issue, displays all issue codes along with
+    /// how many times each occurred, ordered from highest to lowest count.
+    /// This is a shorthand for `--reporting-format code-count`.
+    #[arg(long, conflicts_with_all = ["fix", "reporting_format"])]
+    pub stats: bool,
+
     /// Apply automatic fixes to the source code where possible.
     ///
     /// This will modify your files to fix issues that have automatic solutions.
@@ -217,7 +225,7 @@ impl ReportingArgs {
             dry_run: self.dry_run,
             fail_on_remaining: self.fail_on_remaining,
             reporting_target: self.reporting_target.clone(),
-            reporting_format: self.reporting_format,
+            reporting_format: if self.stats { ReportingFormat::CodeCount } else { self.reporting_format },
             minimum_fail_level: self.minimum_fail_level.unwrap_or(config_minimum_fail_level),
             minimum_report_level: self.minimum_report_level,
             retain_code: self.retain_code.clone(),

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -12,6 +12,7 @@
 //! - **Semantics Only** (`--semantics`): Only validate syntax and basic semantic structure
 //! - **Pedantic Mode** (`--pedantic`): Enable all available rules for maximum thoroughness
 //! - **Targeted Linting** (`--only`): Run only specific rules by code
+//! - **Statistics** (`--stats`): Summarize issue counts per rule code instead of listing issues
 //!
 //! # Rule Discovery
 //!
@@ -76,6 +77,11 @@ use crate::utils::git;
 /// ```text
 /// mago lint --explain no-empty
 /// ```
+///
+/// Show issue counts per rule code:
+/// ```text
+/// mago lint --stats
+/// ```
 #[derive(Parser, Debug)]
 #[command(
     name = "lint",
@@ -91,6 +97,7 @@ use crate::utils::git;
 
             mago lint
             mago lint src/
+            mago lint --stats
             mago lint --list-rules
             mago lint --explain no-empty
             mago lint --only no-empty,constant-condition
@@ -130,7 +137,7 @@ pub struct LintCommand {
     /// such as 'no-empty' or 'prefer-while-loop'.
     #[arg(
         long,
-        conflicts_with_all = ["list_rules", "sort", "fixable_only", "semantics", "reporting_target", "reporting_format"]
+        conflicts_with_all = ["list_rules", "sort", "stats", "fixable_only", "semantics", "reporting_target", "reporting_format"]
     )]
     pub explain: Option<String>,
 
@@ -141,7 +148,7 @@ pub struct LintCommand {
     /// Combine with --json for machine-readable output.
     #[arg(
         long,
-        conflicts_with_all = ["explain", "sort", "fixable_only", "semantics", "reporting_target", "reporting_format"]
+        conflicts_with_all = ["explain", "sort", "stats", "fixable_only", "semantics", "reporting_target", "reporting_format"]
     )]
     pub list_rules: bool,
 

--- a/tests/lint_stats.rs
+++ b/tests/lint_stats.rs
@@ -1,0 +1,184 @@
+//! Integration tests for the `--stats` flag on `mago lint`.
+//!
+//! `--stats` is a shorthand for `--reporting-format code-count`: it reports a
+//! summary of issue counts per code, ordered from highest to lowest, instead
+//! of individual issues. These tests run the mago binary against a temporary
+//! workspace and verify the output shape, the ordering, the equivalence with
+//! `--reporting-format code-count`, the exit-code semantics, and the clap
+//! conflicts.
+
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+use std::process::Stdio;
+
+fn mago_bin() -> PathBuf {
+    // Prefer runtime env (set when cargo runs the test), then compile-time (set when cargo builds the test).
+    let path = std::env::var("CARGO_BIN_EXE_mago")
+        .ok()
+        .or_else(|| option_env!("CARGO_BIN_EXE_mago").map(String::from))
+        .unwrap_or_else(|| "mago".to_string());
+
+    PathBuf::from(path)
+}
+
+/// Returns true if the mago binary can actually execute on this host.
+/// This is false when cross-compiling (e.g., building aarch64 on x86_64).
+fn can_run_mago() -> bool {
+    Command::new(mago_bin())
+        .arg("--help")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
+/// Creates a workspace with a single PHP file that triggers 3 `constant-condition`
+/// issues (help) and 1 `strict-types` issue (warning).
+fn setup_workspace() -> tempfile::TempDir {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let workspace = temp_dir.path();
+
+    std::fs::create_dir(workspace.join("src")).unwrap();
+    std::fs::write(
+        workspace.join("mago.toml"),
+        r#"
+php-version = "8.4"
+[source]
+paths = ["src"]
+[linter]
+"#,
+    )
+    .unwrap();
+
+    let php = r#"<?php
+
+if (true) {
+    echo 'a';
+}
+
+if (false) {
+    echo 'b';
+}
+
+if (true) {
+    echo 'c';
+}
+"#;
+    std::fs::write(workspace.join("src").join("example.php"), php).unwrap();
+
+    temp_dir
+}
+
+fn run_lint(workspace: &Path, extra_args: &[&str]) -> std::process::Output {
+    Command::new(mago_bin())
+        .args(["--workspace", workspace.to_str().unwrap(), "lint"])
+        .args(extra_args)
+        .current_dir(workspace)
+        .output()
+        .expect("failed to run mago")
+}
+
+/// Parses `level[code]: count` lines from stats output into (label, count) pairs.
+fn parse_count_lines(stdout: &str) -> Vec<(String, usize)> {
+    stdout
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            let (label, count) =
+                line.rsplit_once(": ").unwrap_or_else(|| panic!("unexpected stats line: {line:?}"));
+            let count =
+                count.trim().parse::<usize>().unwrap_or_else(|_| panic!("unexpected count in line: {line:?}"));
+
+            (label.to_string(), count)
+        })
+        .collect()
+}
+
+#[test]
+fn test_lint_stats_reports_counts_ordered_descending() {
+    if !can_run_mago() {
+        return;
+    }
+
+    let temp_dir = setup_workspace();
+    let output = run_lint(temp_dir.path(), &["--stats"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Only help/warning issues are present, which is below the default fail level (error).
+    assert!(
+        output.status.success(),
+        "lint --stats should succeed when no issue reaches the fail level; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let entries = parse_count_lines(&stdout);
+    assert!(entries.len() >= 2, "expected at least two issue codes in stats output; got: {stdout:?}");
+    assert!(
+        entries.iter().any(|(label, count)| label.contains("[constant-condition]") && *count == 3),
+        "expected 3 constant-condition issues in stats output; got: {stdout:?}"
+    );
+    assert!(
+        entries.windows(2).all(|pair| pair[0].1 >= pair[1].1),
+        "stats output should be ordered from highest to lowest count; got: {stdout:?}"
+    );
+}
+
+#[test]
+fn test_lint_stats_matches_code_count_format() {
+    if !can_run_mago() {
+        return;
+    }
+
+    let temp_dir = setup_workspace();
+    let stats_output = run_lint(temp_dir.path(), &["--stats"]);
+    let format_output = run_lint(temp_dir.path(), &["--reporting-format", "code-count"]);
+
+    assert_eq!(
+        String::from_utf8_lossy(&stats_output.stdout),
+        String::from_utf8_lossy(&format_output.stdout),
+        "--stats should produce the same output as --reporting-format code-count"
+    );
+    assert_eq!(stats_output.status.code(), format_output.status.code());
+}
+
+#[test]
+fn test_lint_stats_honors_minimum_fail_level() {
+    if !can_run_mago() {
+        return;
+    }
+
+    let temp_dir = setup_workspace();
+    let output = run_lint(temp_dir.path(), &["--stats", "--minimum-fail-level", "help"]);
+
+    assert!(
+        !output.status.success(),
+        "lint --stats should fail when issues reach the minimum fail level; stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn test_lint_stats_conflicts_with_explicit_reporting_format_and_fix() {
+    if !can_run_mago() {
+        return;
+    }
+
+    let temp_dir = setup_workspace();
+
+    for conflicting_args in [&["--stats", "--reporting-format", "json"][..], &["--stats", "--fix"][..]] {
+        let output = run_lint(temp_dir.path(), conflicting_args);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "lint {} should be rejected by clap; stderr: {stderr}",
+            conflicting_args.join(" ")
+        );
+        assert!(
+            stderr.contains("--stats"),
+            "conflict error should mention --stats; got: {stderr}"
+        );
+    }
+}

--- a/tests/lint_stats.rs
+++ b/tests/lint_stats.rs
@@ -85,10 +85,8 @@ fn parse_count_lines(stdout: &str) -> Vec<(String, usize)> {
         .lines()
         .filter(|line| !line.trim().is_empty())
         .map(|line| {
-            let (label, count) =
-                line.rsplit_once(": ").unwrap_or_else(|| panic!("unexpected stats line: {line:?}"));
-            let count =
-                count.trim().parse::<usize>().unwrap_or_else(|_| panic!("unexpected count in line: {line:?}"));
+            let (label, count) = line.rsplit_once(": ").unwrap_or_else(|| panic!("unexpected stats line: {line:?}"));
+            let count = count.trim().parse::<usize>().unwrap_or_else(|_| panic!("unexpected count in line: {line:?}"));
 
             (label.to_string(), count)
         })
@@ -176,9 +174,6 @@ fn test_lint_stats_conflicts_with_explicit_reporting_format_and_fix() {
             "lint {} should be rejected by clap; stderr: {stderr}",
             conflicting_args.join(" ")
         );
-        assert!(
-            stderr.contains("--stats"),
-            "conflict error should mention --stats; got: {stderr}"
-        );
+        assert!(stderr.contains("--stats"), "conflict error should mention --stats; got: {stderr}");
     }
 }


### PR DESCRIPTION
## Summary

Adds a `--stats` flag to the shared reporting options, so `mago lint --stats` (and `analyze` / `guard` / `cst`) shows a summary of issue counts per code, ordered from highest to lowest, instead of listing individual issues.

```console
$ mago lint --stats
help[constant-condition]: 3
warning[strict-types]: 1
```

## Motivation

When adopting Mago on an existing codebase (or after enabling new rules, or running `--pedantic`), a run can produce thousands of individual issues -- too many to read one by one. The first thing you actually need is the shape of the problem: which rules fire and how often. That tells you what to fix first, which rules to disable or downgrade, and what belongs in a baseline.

Mago can already produce this summary via `--reporting-format code-count`, but it is easy to miss as one of many format values. A dedicated `--stats` flag makes the workflow discoverable directly in `--help`, matches what other linters offer as a first-class option, and is quicker to type and remember.

## Implementation

`--stats` is a thin shorthand: when set, the issue processor selects `ReportingFormat::CodeCount`. No new output code paths -- baseline filtering, `--minimum-report-level`, `--retain-code`, reporting targets, and exit-code semantics all behave exactly like any other report.

- `--stats` conflicts with `--fix` and with an explicit `--reporting-format`.
- Added `stats` to the `--explain` / `--list-rules` conflict lists in `mago lint`.
- Documented the flag on the shared reporting options page (en/fr/zh) and in the lint command docs.

## Testing

- New integration tests in `tests/lint_stats.rs` run the binary against a temp workspace and cover: output shape and descending count order, byte-for-byte equivalence with `--reporting-format code-count`, `--minimum-fail-level` exit-code semantics, and the clap conflicts with `--fix` / `--reporting-format`.
- `cargo build` / `cargo clippy` clean.