### PR TITLE
refactor(analyzer): use loop labels for unused-template checks

### DIFF
--- a/crates/analyzer/src/statement/class_like/mod.rs
+++ b/crates/analyzer/src/statement/class_like/mod.rs
@@ -269,41 +269,25 @@ fn check_unused_template_parameters<'ctx, A>(
     let class_kind_str = class_like_metadata.kind.as_str();
     let class_name_span = class_like_metadata.name_span.unwrap_or(class_like_metadata.span);
 
-    for (template_name, _) in &class_like_metadata.template_types {
+    'templates: for (template_name, _) in &class_like_metadata.template_types {
         if template_name.as_bytes().starts_with(b"_") {
             continue;
         }
 
-        let mut is_used = false;
-
         for extended_params in class_like_metadata.template_extended_parameters.values() {
             for (_param_name, param_type) in extended_params {
                 if type_contains_template_param(param_type, *template_name, class_name) {
-                    is_used = true;
-                    break;
+                    continue 'templates;
                 }
             }
-
-            if is_used {
-                break;
-            }
-        }
-
-        if is_used {
-            continue;
         }
 
         for property_metadata in class_like_metadata.properties.values() {
             if let Some(type_metadata) = &property_metadata.type_metadata
                 && type_contains_template_param(&type_metadata.type_union, *template_name, class_name)
             {
-                is_used = true;
-                break;
+                continue 'templates;
             }
-        }
-
-        if is_used {
-            continue;
         }
 
         for method_id in class_like_metadata.declaring_method_ids.values() {
@@ -319,33 +303,22 @@ fn check_unused_template_parameters<'ctx, A>(
                 if let Some(type_metadata) = &param.type_metadata
                     && type_contains_template_param(&type_metadata.type_union, *template_name, class_name)
                 {
-                    is_used = true;
-                    break;
+                    continue 'templates;
                 }
 
                 if let Some(type_metadata) = &param.closure_this_type
                     && type_contains_template_param(&type_metadata.type_union, *template_name, class_name)
                 {
-                    is_used = true;
-                    break;
+                    continue 'templates;
                 }
-            }
-
-            if is_used {
-                break;
             }
 
             // Check return type
             if let Some(return_type_metadata) = &function_like.return_type_metadata
                 && type_contains_template_param(&return_type_metadata.type_union, *template_name, class_name)
             {
-                is_used = true;
-                break;
+                continue 'templates;
             }
-        }
-
-        if is_used {
-            continue;
         }
 
         // Report warning if template parameter is unused

--- a/crates/analyzer/src/statement/function_like/mod.rs
+++ b/crates/analyzer/src/statement/function_like/mod.rs
@@ -1278,24 +1278,17 @@ pub fn check_unused_function_template_parameters<'ctx, A>(
         return;
     };
 
-    for (template_name, _) in &function_like_metadata.template_types {
+    'templates: for (template_name, _) in &function_like_metadata.template_types {
         if template_name.as_bytes().starts_with(b"_") {
             continue;
         }
-
-        let mut is_used = false;
 
         for param in &function_like_metadata.parameters {
             if let Some(type_metadata) = &param.type_metadata
                 && type_contains_function_template_param(&type_metadata.type_union, *template_name, function_identifier)
             {
-                is_used = true;
-                break;
+                continue 'templates;
             }
-        }
-
-        if is_used {
-            continue;
         }
 
         if let Some(return_type_metadata) = &function_like_metadata.return_type_metadata
@@ -1305,10 +1298,6 @@ pub fn check_unused_function_template_parameters<'ctx, A>(
                 function_identifier,
             )
         {
-            is_used = true;
-        }
-
-        if is_used {
             continue;
         }
 


### PR DESCRIPTION
## 📌 What Does This PR Do?

Simplifies the unused-template-parameter checks in the analyzer by
replacing the manual `is_used` bookkeeping with labeled-loop control
flow.

## 🔍 Context & Motivation

The checks for unused `@template` parameters walk several nested
collections (extended parameters, properties, method signatures) and
must bail out to the next template as soon as any usage is found. Today
that early-out is expressed with an `is_used` flag plus a cascade of
`if is_used { continue; }` re-checks after every collection, which
buries a very simple "found it, move on" flow under boilerplate.

## 🛠️ Summary of Changes

- **Refactor:** Label the outer template loop and `continue` it
  directly from the inner checks, dropping the `is_used` flag and the
  intermediate re-checks in both the class-like and function-like
  analyzers.

## 📂 Affected Areas

- [x] Other (please specify): Analyzer

## 📝 Notes for Reviewers

Pure refactor — no behavioral change.