### PR TITLE
feat(codex): record attributes on property metadata

### DIFF
--- a/crates/codex/src/metadata/property.rs
+++ b/crates/codex/src/metadata/property.rs
@@ -4,6 +4,7 @@ use mago_php_version::PHPVersionRange;
 use mago_span::Span;
 use mago_word::WordMap;
 
+use crate::metadata::attribute::AttributeMetadata;
 use crate::metadata::flags::MetadataFlags;
 use crate::metadata::property_hook::PropertyHookMetadata;
 use crate::metadata::ttype::TypeMetadata;
@@ -29,6 +30,12 @@ pub struct PropertyMetadata {
     /// The source code location (span) covering the entire property declaration statement.
     /// `None` if the location is unknown or not relevant.
     pub span: Option<Span>,
+
+    /// Attributes (e.g. `#[SomeAttribute]`) applied to the property declaration.
+    ///
+    /// For grouped declarations (`public int $a, $b;`), every item carries the
+    /// attributes of the shared declaration, matching PHP semantics.
+    pub attributes: Vec<AttributeMetadata>,
 
     /// The visibility level required for reading the property's value.
     ///
@@ -96,6 +103,7 @@ impl PropertyMetadata {
             name,
             name_span: None,
             span: None,
+            attributes: Vec::new(),
             read_visibility: Visibility::Public,
             write_visibility: Visibility::Public,
             type_declaration_metadata: None,

--- a/crates/codex/src/scanner/mod.rs
+++ b/crates/codex/src/scanner/mod.rs
@@ -792,6 +792,47 @@ mod polyfill_tests {
         codebase.constants.get(&word(name)).unwrap_or_else(|| panic!("constant `{name}` not found")).flags
     }
 
+    fn property_attribute_names(codebase: &CodebaseMetadata, class: &str, property: &str) -> Vec<String> {
+        codebase
+            .class_likes
+            .get(&ascii_lowercase_word(class.as_bytes()))
+            .unwrap_or_else(|| panic!("class-like `{class}` not found"))
+            .properties
+            .get(&word(property))
+            .unwrap_or_else(|| panic!("property `{property}` not found on `{class}`"))
+            .attributes
+            .iter()
+            .map(|attribute| attribute.name.to_string())
+            .collect()
+    }
+
+    #[test]
+    fn property_attributes_are_recorded() {
+        let codebase = scan(
+            "<?php
+            #[Attribute]
+            final class Marker {}
+
+            final class Subject {
+                #[Marker]
+                public int $declared = 0;
+
+                #[Marker]
+                public int $grouped = 0, $alsoGrouped = 0;
+
+                public function __construct(#[Marker] public readonly int $promoted) {}
+            }
+        ",
+        );
+
+        assert_eq!(vec!["Marker"], property_attribute_names(&codebase, "Subject", "$declared"));
+        // A grouped declaration shares one attribute list; PHP applies it to every item.
+        assert_eq!(vec!["Marker"], property_attribute_names(&codebase, "Subject", "$grouped"));
+        assert_eq!(vec!["Marker"], property_attribute_names(&codebase, "Subject", "$alsoGrouped"));
+        // Attributes on a promoted parameter belong to the property it creates.
+        assert_eq!(vec!["Marker"], property_attribute_names(&codebase, "Subject", "$promoted"));
+    }
+
     #[test]
     fn class_in_not_class_exists_is_polyfill() {
         let code = "<?php

--- a/crates/codex/src/scanner/property.rs
+++ b/crates/codex/src/scanner/property.rs
@@ -90,6 +90,7 @@ where
 
     let mut property_metadata = PropertyMetadata::new(*name, flags);
 
+    property_metadata.attributes.clone_from(&parameter_metadata.attributes);
     property_metadata.set_default_type_metadata(default_type_metadata);
     property_metadata.set_name_span(Some(name_span));
     property_metadata.set_span(Some(parameter.span()));
@@ -182,6 +183,7 @@ where
     match property {
         Property::Plain(plain_property) => {
             let verdict = evaluate_version_attributes(&plain_property.attribute_lists, context, context.php_version);
+            let attributes = scan_attribute_lists(&plain_property.attribute_lists, context);
 
             plain_property
                 .items
@@ -230,6 +232,7 @@ where
 
                     let mut metadata = PropertyMetadata::new(name, item_flags);
 
+                    metadata.attributes.clone_from(&attributes);
                     metadata.set_name_span(Some(name_span));
                     metadata.set_default_type_metadata(default_type);
                     metadata.set_visibility(read_visibility, write_visibility);
@@ -293,6 +296,7 @@ where
 
             let mut metadata = PropertyMetadata::new(name, flags);
 
+            metadata.attributes = scan_attribute_lists(&hooked_property.attribute_lists, context);
             metadata.set_name_span(Some(name_span));
             metadata.set_default_type_metadata(default_type);
             metadata.set_span(Some(hooked_property.span()));


### PR DESCRIPTION
Class-likes, function-likes, parameters, constants and enum cases already keep
their attributes in the codex. Properties were the only symbol kind that did
not, so nothing downstream can reason about attribute-mapped properties.

Two shapes needed care, both matching PHP semantics:

- a grouped declaration (`public int $a, $b;`) gives every item the attributes
  of the shared declaration;
- a promoted constructor parameter passes its attributes to the property it
  creates. `scan_promoted_property` was dropping them — the synthesized
  `PropertyMetadata` had none even though the parameter metadata carried them.

The test covers the three shapes in the existing scanner harness.

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`
and `cargo test --workspace --locked --all-targets` all pass locally.