### PR TITLE
fix(prelude): assert `non-empty-string` when `json_validate` is successful

### DIFF
--- a/crates/prelude/assets/extensions/json.php
+++ b/crates/prelude/assets/extensions/json.php
@@ -23,6 +23,8 @@ function json_last_error_msg(): string {}
 
 /**
  * @pure
+ *
+ * @assert-if-true non-empty-string $json
  */
 #[Mago\AvailableSince(80300)]
 function json_validate(string $json, int $depth = 512, int $flags = 0): bool {}


### PR DESCRIPTION
## 📌 What Does This PR Do?

Adds an assertion that the `$json` argument is a `non-empty-string` when `json_validate()` returns true

## 🔍 Context & Motivation

Minor type inference improvements to PHP stubs

## 📂 Affected Areas

- [x] Analyzer
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

None

## 📝 Notes for Reviewers

None
