### PR TITLE
fix(analyzer): stop demanding a return for void conditionals

### DIFF
--- a/crates/analyzer/src/statement/function_like/mod.rs
+++ b/crates/analyzer/src/statement/function_like/mod.rs
@@ -227,30 +227,37 @@ where
     {
         let expanded_type =
             expand_type_metadata(context, block_context, &mut artifacts, function_like_metadata, return_type);
-        let expected_return_type_id = expanded_type.get_id();
 
-        let help_message = if expanded_type.is_nullable() {
-            "Ensure all code paths end with a `return` statement. You may need to add `return null;` to the paths that currently don't return a value.".to_string()
-        } else {
-            format!(
-                "Add a `return` statement that provides a value of type '{expected_return_type_id}' to all paths, or change the function's return type to '{expected_return_type_id}|null' and return `null` explicitly."
-            )
-        };
+        // A conditional return type whose branches are all `void`/`never` erases to `void`, which
+        // the check above cannot see through since it only sees the unexpanded conditional.
+        if !expanded_type.is_void() {
+            let expected_return_type_id = expanded_type.get_id();
 
-        context.collector.report_with_code(
-            IssueCode::MissingReturnStatement,
-            Issue::error(format!("Missing return statement in function `{}`", function_metadata.name))
-                .with_annotation(
-                    Annotation::primary(function_metadata.name_span.unwrap_or(function_metadata.span))
-                        .with_message(format!("This function is declared to return '{expected_return_type_id}'...")),
+            let help_message = if expanded_type.is_nullable() {
+                "Ensure all code paths end with a `return` statement. You may need to add `return null;` to the paths that currently don't return a value.".to_string()
+            } else {
+                format!(
+                    "Add a `return` statement that provides a value of type '{expected_return_type_id}' to all paths, or change the function's return type to '{expected_return_type_id}|null' and return `null` explicitly."
                 )
-                .with_annotation(
-                    Annotation::secondary(body.span())
-                        .with_message("...but this path can exit without returning a value."),
-                )
-                .with_note("A function that does not explicitly return a value will implicitly return `null`.")
-                .with_help(help_message),
-        );
+            };
+
+            context.collector.report_with_code(
+                IssueCode::MissingReturnStatement,
+                Issue::error(format!("Missing return statement in function `{}`", function_metadata.name))
+                    .with_annotation(
+                        Annotation::primary(function_metadata.name_span.unwrap_or(function_metadata.span))
+                            .with_message(format!(
+                                "This function is declared to return '{expected_return_type_id}'..."
+                            )),
+                    )
+                    .with_annotation(
+                        Annotation::secondary(body.span())
+                            .with_message("...but this path can exit without returning a value."),
+                    )
+                    .with_note("A function that does not explicitly return a value will implicitly return `null`.")
+                    .with_help(help_message),
+            );
+        }
     }
 
     check_return_type_width(context, block_context, &mut artifacts, function_like_metadata);

--- a/crates/analyzer/tests/cases/conditional_return_void_never_needs_no_return.php
+++ b/crates/analyzer/tests/cases/conditional_return_void_never_needs_no_return.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @return ($c is true ? void : never)
+ */
+function condVoidNeverAbortUnless(bool $c): void
+{
+    if (!$c) {
+        exit;
+    }
+}
+
+/**
+ * @return ($c is true ? never : void)
+ */
+function condVoidNeverAbortIf(bool $c): void
+{
+    if ($c) {
+        exit;
+    }
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -718,6 +718,7 @@ test_case!(sealed_class_performance);
 test_case!(class_instance);
 test_case!(conditional_return);
 test_case!(conditional_return_void_never_matches_native_void);
+test_case!(conditional_return_void_never_needs_no_return);
 test_case!(literal_int);
 test_case!(calling_interface_methods_from_trait);
 test_case!(parent_class_constant_validation);


### PR DESCRIPTION
## 📌 What Does This PR Do?

A function annotated with a conditional return type whose branches are
all `void` or `never`, such as an abort helper declared
`@return ($c is true ? void : never)`, no longer draws a spurious
`missing-return-statement`.

## 🔍 Context & Motivation

The missing-return check has to decide whether the declared return type
is `void` before it evaluates it. A docblock conditional is still a
single opaque type at that point, so it never looks like `void` no
matter what its branches say, and the function gets told to add a return
statement that it must not have. The evaluation happens immediately
afterwards anyway, purely to name the expected type in the message.

## 🛠️ Summary of Changes

- **Bug Fix:** Decide whether the return type is `void` from the
  evaluated type rather than the declared one.

## 📂 Affected Areas

- [x] Other: analyzer