### PR TITLE
fix(reporting): make issue output reproducible across runs

### DIFF
--- a/crates/reporting/src/formatter/checkstyle.rs
+++ b/crates/reporting/src/formatter/checkstyle.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::io::Write;
 
 use mago_database::DatabaseReader;
@@ -24,7 +24,9 @@ impl Formatter for CheckstyleFormatter {
         database: &ReadDatabase,
         config: &FormatterConfig,
     ) -> Result<(), ReportingError> {
-        let mut issues_by_file: HashMap<String, Vec<String>> = HashMap::new();
+        // Ordered, not hashed: `HashMap` iteration order is randomised per process, so grouping
+        // through one made this format's output differ between two runs over unchanged code.
+        let mut issues_by_file: BTreeMap<String, Vec<String>> = BTreeMap::new();
 
         for issue in crate::formatter::utils::filter_issues(issues, config, false) {
             let (filename, line, column) = match issue.primary_annotation() {

--- a/crates/reporting/src/formatter/utils.rs
+++ b/crates/reporting/src/formatter/utils.rs
@@ -91,11 +91,13 @@ fn compare_issues(a: &&Issue, b: &&Issue) -> Ordering {
         Ordering::Equal => match a.code.as_deref().cmp(&b.code.as_deref()) {
             Ordering::Less => Ordering::Less,
             Ordering::Greater => Ordering::Greater,
+            // The message is the tiebreak. Without it, level, code and span can all tie and the
+            // order is then decided by whichever worker finished first.
             Ordering::Equal => match (a.primary_span(), b.primary_span()) {
-                (Some(a_span), Some(b_span)) => a_span.cmp(&b_span),
+                (Some(a_span), Some(b_span)) => a_span.cmp(&b_span).then_with(|| a.message.cmp(&b.message)),
                 (Some(_), None) => Ordering::Less,
                 (None, Some(_)) => Ordering::Greater,
-                (None, None) => Ordering::Equal,
+                (None, None) => a.message.cmp(&b.message),
             },
         },
     }

--- a/crates/reporting/src/lib.rs
+++ b/crates/reporting/src/lib.rs
@@ -814,10 +814,16 @@ impl IssueCollection {
         Self { issues: self.issues.into_iter().filter(|issue| !issue.edits.is_empty()).collect() }
     }
 
-    /// Sorts the issues in the collection.
+    /// Sorts the issues in the collection: by level, then code, then primary span, then message.
     ///
-    /// The issues are sorted by severity level in ascending order,
-    /// then by code in ascending order, and finally by the primary annotation span.
+    /// This is not a total order. Two issues agreeing on all four keys compare equal while still
+    /// differing in their notes, annotations or suggested edits, and the sort being stable means such
+    /// a pair keeps the order it arrived in. The message is there because without it the tie is far
+    /// wider, and a tie is settled by whichever worker happened to finish first.
+    ///
+    /// Note that the reporting pipeline does not go through here. `--sort` is applied per formatter,
+    /// by `formatter::utils::compare_issues`, which orders by the same keys. This method is kept in
+    /// step with it so that an external caller gets the same answer.
     #[must_use]
     pub fn sorted(self) -> Self {
         let mut issues = self.issues;
@@ -833,10 +839,10 @@ impl IssueCollection {
                     let b_span = b.primary_span();
 
                     match (a_span, b_span) {
-                        (Some(a_span), Some(b_span)) => a_span.cmp(&b_span),
+                        (Some(a_span), Some(b_span)) => a_span.cmp(&b_span).then_with(|| a.message.cmp(&b.message)),
                         (Some(_), None) => Ordering::Less,
                         (None, Some(_)) => Ordering::Greater,
-                        (None, None) => Ordering::Equal,
+                        (None, None) => a.message.cmp(&b.message),
                     }
                 }
             },

--- a/crates/reporting/src/reporter.rs
+++ b/crates/reporting/src/reporter.rs
@@ -10,8 +10,10 @@
 
 use std::io::Write;
 
+use mago_database::DatabaseReader;
 use mago_database::ReadDatabase;
 
+use crate::Issue;
 use crate::IssueCollection;
 use crate::Level;
 use crate::baseline::Baseline;
@@ -117,6 +119,8 @@ impl Reporter {
     ) -> Result<ReportStatus, ReportingError> {
         let mut writer = self.config.target.resolve();
 
+        issues = in_file_order(issues, &self.database);
+
         // Apply baseline filtering
         let mut baseline_dead_issues = 0;
         let mut baseline_filtered_issues = 0;
@@ -200,6 +204,8 @@ impl Reporter {
     where
         W: Write,
     {
+        issues = in_file_order(issues, &self.database);
+
         // Apply baseline filtering
         let mut baseline_dead_issues = 0;
         let mut baseline_filtered_issues = 0;
@@ -249,6 +255,35 @@ impl Reporter {
             total_reported_issues,
         })
     }
+}
+
+/// Orders issues by file, then by position within it, and nothing else.
+///
+/// Files are analysed in parallel and their issues concatenated as workers finish, so without this
+/// the default is not "the order they appear in files" but the order the thread pool happened to
+/// produce, and two runs over unchanged code print the same findings in a different order.
+///
+/// Two things the key deliberately leaves alone:
+///
+/// Issues that share a file and a position keep the order the analyzer emitted them in, because the
+/// sort is stable and a single file is analysed on one thread. Parallelism reorders files, not the
+/// issues inside one, so that sequence is already reproducible and it reads better than any ordering
+/// this function could impose on it.
+///
+/// An issue with no primary span, or one whose file is not in the database, sorts ahead of everything
+/// else: `None` orders before `Some`. Those are not about a particular file, so leading with them is
+/// the useful place to put them.
+fn in_file_order(issues: IssueCollection, database: &ReadDatabase) -> IssueCollection {
+    let mut issues: Vec<Issue> = issues.into_iter().collect();
+
+    issues.sort_by_cached_key(|issue| {
+        let span = issue.primary_span();
+        let name = span.and_then(|span| database.get_ref(&span.file_id).ok()).map(|file| file.name.to_vec());
+
+        (name, span.map_or(0, |span| span.start.offset))
+    });
+
+    IssueCollection::from(issues)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Two runs of `mago analyze` over unchanged code print the same findings in a different order. On a 921 file corpus, 14 of the 18 combinations of output format and `--sort` produce a different ordering on essentially every run. The set of issues is always identical, only the order moves.

That breaks anything that diffs two runs: CI comparing a report against a stored one, a reviewer diffing before and after a change, or a tool caching output.

There turned out to be three separate causes.

### Files are analysed in parallel and their issues concatenated as workers finish

`--sort`'s own help says that by default "issues are reported in the order they appear in files", and that is not what happens. The reporter now puts issues in file and position order before handing them to a formatter.

### `--sort` was worse than the default, not better

The reporter previously skipped that ordering whenever `--sort` was set, on the reasoning that the formatter would sort instead. Five formatters ask `filter_issues` not to sort (`github`, `gitlab`, `emacs`, `sarif`, `checkstyle`), so for those `--sort` removed the only ordering there was and emitted raw worker order.

Normalising unconditionally costs nothing measurable (0.667s against 0.673s CPU on the corpus above) and means every formatter, sorting or not, starts from the same sequence.

### `checkstyle` grouped its output through a `HashMap`

Rust randomises that iteration order per process, so this format was unstable whatever the reporter did. It groups through a `BTreeMap` now.

### Two smaller things that follow

`compare_issues`, which is what `--sort` actually uses, ties on level, code and span and then keeps worker order. It now breaks that tie on the message.

`IssueCollection::sorted` has no callers in the workspace but is public and orders by the same keys, so it is kept in step with `compare_issues` and its documentation now points at where the real sorting happens.

## Verifying it

I used a script that runs 18 format and `--sort` combinations 8 times each, cycling `--threads` through 1, 2, 3, 5 and 8 so that consecutive runs cannot share a schedule:

| | result |
|:--|:--|
| `1ec88688e` (current main) | 14 of 18 not reproducible |
| with this change | every format reproducible |

One thing worth knowing if you want to reproduce it, because it caught me out: this does not appear on a small tree. Five runs over 17 files agree, and so do five over a single large source root. It needs enough files across enough roots for workers to interleave. I used five separate vendor directories totalling 921 files.

Varying `--threads` matters more than repeating the run. An idle machine will happily reproduce its own schedule several times over.

## Notes

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-features -- -D warnings` and `cargo test --workspace --locked --all-targets` are all clean on this commit.

The behaviour change to be aware of: for formats that do sort, ties that previously fell out in worker order now fall out in file and position order. That is the point of the change, but it does mean output can differ from before where issues tied.

Happy to split this into three commits if you would rather review the causes separately.
