### PR TITLE
fix(analyzer): resolve `self` in attributes on class-likes

### DIFF
--- a/crates/analyzer/src/context/block_flags.rs
+++ b/crates/analyzer/src/context/block_flags.rs
@@ -21,6 +21,10 @@ impl BlockContextFlags {
     pub const COLLECT_INITIALIZATIONS: u32 = 1 << 15;
     pub const CALLS_PARENT_CONSTRUCTOR: u32 = 1 << 16;
     pub const INSIDE_PIPE_CALLABLE: u32 = 1 << 17;
+    /// Set while analyzing the arguments of an attribute on a class-like declaration. The
+    /// class-like is in scope for name resolution, but the arguments are evaluated outside
+    /// its body.
+    pub const INSIDE_CLASS_LIKE_ATTRIBUTE: u32 = 1 << 18;
 
     #[inline]
     pub const fn new() -> Self {
@@ -140,6 +144,11 @@ impl BlockContextFlags {
     }
 
     #[inline(always)]
+    pub const fn inside_class_like_attribute(&self) -> bool {
+        self.contains(Self::INSIDE_CLASS_LIKE_ATTRIBUTE)
+    }
+
+    #[inline(always)]
     pub fn set_inside_conditional(&mut self, value: bool) {
         self.set(Self::INSIDE_CONDITIONAL, value);
     }
@@ -227,5 +236,10 @@ impl BlockContextFlags {
     #[inline(always)]
     pub fn set_inside_pipe_callable(&mut self, value: bool) {
         self.set(Self::INSIDE_PIPE_CALLABLE, value);
+    }
+
+    #[inline(always)]
+    pub fn set_inside_class_like_attribute(&mut self, value: bool) {
+        self.set(Self::INSIDE_CLASS_LIKE_ATTRIBUTE, value);
     }
 }

--- a/crates/analyzer/src/expression/call/method_call.rs
+++ b/crates/analyzer/src/expression/call/method_call.rs
@@ -197,7 +197,7 @@ where
 {
     if !check_method_visibility(
         context,
-        block_context,
+        block_context.scope.get_class_like_name(),
         method_identifier.get_class_name().as_bytes(),
         method_identifier.get_method_name().as_bytes(),
         span,

--- a/crates/analyzer/src/expression/instantiation.rs
+++ b/crates/analyzer/src/expression/instantiation.rs
@@ -365,7 +365,7 @@ where
 
         if !check_method_visibility(
             context,
-            block_context,
+            block_context.scope.get_class_like_name(),
             constructor_declraing_id.get_class_name().as_bytes(),
             constructor_declraing_id.get_method_name().as_bytes(),
             instantiation_span,

--- a/crates/analyzer/src/expression/mod.rs
+++ b/crates/analyzer/src/expression/mod.rs
@@ -27,8 +27,7 @@ use crate::formula::get_formula;
 use crate::plugin::ExpressionHookResult;
 use crate::plugin::context::HookContext;
 use crate::reconciler::reconcile_keyed_types;
-use crate::statement::attributes::AttributeTarget;
-use crate::statement::attributes::analyze_attributes;
+use crate::statement::attributes::analyze_class_like_attributes;
 use crate::statement::class_like::analyze_class_like;
 use crate::statement::class_like::override_attribute;
 use crate::utils::misc::check_for_paradox;
@@ -112,18 +111,17 @@ impl<'ast, 'arena> Analyzable<'ast, 'arena> for Expression<'arena> {
                 Ok(())
             }
             Expression::AnonymousClass(anonymous_class) => {
-                analyze_attributes(
-                    context,
-                    block_context,
-                    artifacts,
-                    anonymous_class.attribute_lists.as_slice(),
-                    AttributeTarget::ClassLike,
-                )?;
-
                 let Some(class_like_metadata) = context.codebase.get_anonymous_class(context.source_file, self.span())
                 else {
                     return Ok(());
                 };
+
+                analyze_class_like_attributes(
+                    context,
+                    artifacts,
+                    anonymous_class.attribute_lists.as_slice(),
+                    class_like_metadata,
+                )?;
 
                 analyze_anonymous_class_constructor(
                     context,

--- a/crates/analyzer/src/resolver/class_constant.rs
+++ b/crates/analyzer/src/resolver/class_constant.rs
@@ -142,6 +142,7 @@ where
                 class_expr.span(),
                 constant_selector.span(),
                 &class_resolution.origin,
+                block_context.flags.inside_class_like_attribute(),
             ) {
                 result.constants.push(resolved_const);
             } else {
@@ -233,7 +234,14 @@ where
 /// Checks if a trait constant access is valid based on how the trait is referenced.
 /// Valid accesses are via self, static, or $this (which resolve the trait in context).
 /// Direct trait name access (e.g., `TraitName::CONSTANT`) is invalid.
-fn is_valid_trait_constant_access(origin: &ResolutionOrigin) -> bool {
+///
+/// Attribute arguments on the trait declaration are evaluated outside the trait body, so
+/// even `self::CONSTANT` resolves the trait directly there and is rejected at runtime.
+fn is_valid_trait_constant_access(origin: &ResolutionOrigin, inside_class_like_attribute: bool) -> bool {
+    if inside_class_like_attribute {
+        return false;
+    }
+
     matches!(
         origin,
         // self::CONSTANT
@@ -255,24 +263,33 @@ fn find_constant_in_class<'ctx, A>(
     class_span: Span,
     const_span: Span,
     resolution_origin: &ResolutionOrigin,
+    inside_class_like_attribute: bool,
 ) -> Option<ResolvedConstant>
 where
     A: Arena,
 {
-    if metadata.kind.is_trait() && !is_valid_trait_constant_access(resolution_origin) {
-        context.collector.report_with_code(
-            IssueCode::DirectTraitConstantAccess,
-            Issue::error(format!(
-                "Cannot access trait constant `{}::{}` directly.",
-                metadata.original_name, const_name
-            ))
-            .with_annotation(
-                Annotation::primary(class_span).with_message(format!("`{}` is a trait", metadata.original_name)),
-            )
-            .with_annotation(Annotation::secondary(const_span).with_message("Constant accessed here"))
-            .with_note("Trait constants can only be accessed through classes that use the trait, or via self, static, or $this within the trait.")
-            .with_help(format!("Access this constant through a class that uses `{}`, or use `self::{}`, `static::{}`, or `$this::{}` instead.", metadata.original_name, const_name, const_name, const_name)),
-        );
+    if metadata.kind.is_trait() && !is_valid_trait_constant_access(resolution_origin, inside_class_like_attribute) {
+        let trait_name = metadata.original_name;
+
+        let mut issue = Issue::error(format!("Cannot access trait constant `{trait_name}::{const_name}` directly."))
+            .with_annotation(Annotation::primary(class_span).with_message(format!("`{trait_name}` is a trait")))
+            .with_annotation(Annotation::secondary(const_span).with_message("Constant accessed here"));
+
+        issue = if inside_class_like_attribute {
+            issue
+                .with_note(
+                    "Attribute arguments are evaluated outside the trait body, so `self` resolves the trait directly here.",
+                )
+                .with_help(format!(
+                    "Spell out a class that uses `{trait_name}`, or inline the value of `{const_name}`."
+                ))
+        } else {
+            issue
+                .with_note("Trait constants can only be accessed through classes that use the trait, or via self, static, or $this within the trait.")
+                .with_help(format!("Access this constant through a class that uses `{trait_name}`, or use `self::{const_name}`, `static::{const_name}`, or `$this::{const_name}` instead."))
+        };
+
+        context.collector.report_with_code(IssueCode::DirectTraitConstantAccess, issue);
     }
 
     // Check for a defined constant

--- a/crates/analyzer/src/resolver/method.rs
+++ b/crates/analyzer/src/resolver/method.rs
@@ -512,7 +512,7 @@ where
     if let Some(function_like_metadata) = context.codebase.get_method_by_id(&method_id) {
         if !check_method_visibility(
             context,
-            block_context,
+            block_context.scope.get_class_like_name(),
             class_metadata.original_name.as_bytes(),
             method_name.as_bytes(),
             access_span,
@@ -642,7 +642,7 @@ where
             if let Some(function_like_metadata) = context.codebase.get_method_by_id(&mixin_method_id) {
                 if !check_method_visibility(
                     context,
-                    block_context,
+                    block_context.scope.get_class_like_name(),
                     mixin_metadata.original_name.as_bytes(),
                     method_name.as_bytes(),
                     access_span,

--- a/crates/analyzer/src/resolver/static_method.rs
+++ b/crates/analyzer/src/resolver/static_method.rs
@@ -388,7 +388,7 @@ where
     if let Some(result) = result
         && !check_method_visibility(
             context,
-            block_context,
+            block_context.scope.get_class_like_name(),
             method_id.get_class_name().as_bytes(),
             method_id.get_method_name().as_bytes(),
             access_span,
@@ -822,7 +822,7 @@ where
     // Check visibility
     if !check_method_visibility(
         context,
-        block_context,
+        block_context.scope.get_class_like_name(),
         method_id.get_class_name().as_bytes(),
         method_id.get_method_name().as_bytes(),
         access_span,

--- a/crates/analyzer/src/statement/attributes/mod.rs
+++ b/crates/analyzer/src/statement/attributes/mod.rs
@@ -3,6 +3,7 @@ use foldhash::fast::RandomState;
 use indexmap::IndexMap;
 use mago_allocator::Arena;
 
+use mago_codex::context::ScopeContext;
 use mago_codex::flags::attribute::AttributeFlags;
 use mago_codex::identifier::function_like::FunctionLikeIdentifier;
 use mago_codex::identifier::method::MethodIdentifier;
@@ -57,6 +58,34 @@ impl AttributeTarget {
             Self::Constant => "a constant",
         }
     }
+}
+
+/// Analyzes the attributes attached to a class-like declaration.
+///
+/// Attribute arguments on a class-like are evaluated in the scope of that
+/// class-like, so `self::` and `parent::` must resolve against it rather than
+/// against the enclosing scope.
+pub fn analyze_class_like_attributes<'ctx, 'arena, A>(
+    context: &mut Context<'ctx, 'arena, A>,
+    artifacts: &mut AnalysisArtifacts,
+    attribute_lists: &[AttributeList<'arena>],
+    class_like_metadata: &'ctx ClassLikeMetadata,
+) -> Result<(), AnalysisError>
+where
+    A: Arena,
+{
+    if attribute_lists.iter().all(|list| list.attributes.is_empty()) {
+        return Ok(());
+    }
+
+    let mut scope = ScopeContext::new();
+    scope.set_class_like(Some(class_like_metadata));
+    scope.set_static(true);
+
+    let mut block_context = BlockContext::new(scope, context.settings.register_super_globals);
+    block_context.flags.set_inside_class_like_attribute(true);
+
+    analyze_attributes(context, &mut block_context, artifacts, attribute_lists, AttributeTarget::ClassLike)
 }
 
 pub fn analyze_attributes<'ctx, 'arena, A>(
@@ -302,9 +331,11 @@ where
         &mut argument_types,
     )?;
 
+    // Attributes are instantiated by reflection, never from the annotated declaration, so
+    // the constructor must be reachable from the global scope.
     check_method_visibility(
         context,
-        block_context,
+        None,
         declaring_constructor_id.get_class_name().as_bytes(),
         declaring_constructor_id.get_method_name().as_bytes(),
         attribute.span(),

--- a/crates/analyzer/src/statement/class_like/mod.rs
+++ b/crates/analyzer/src/statement/class_like/mod.rs
@@ -59,8 +59,7 @@ use crate::context::Context;
 use crate::context::block::BlockContext;
 use crate::error::AnalysisError;
 use crate::plugin::context::HookContext;
-use crate::statement::attributes::AttributeTarget;
-use crate::statement::attributes::analyze_attributes;
+use crate::statement::attributes::analyze_class_like_attributes;
 use crate::statement::class_like::method_signature::SignatureCompatibilityIssue;
 use crate::statement::function_like::report_undefined_type_references;
 use crate::utils::missing_type_hints;
@@ -348,20 +347,14 @@ impl<'ast, 'arena> Analyzable<'ast, 'arena> for Class<'arena> {
     where
         A: Arena,
     {
-        analyze_attributes(
-            context,
-            block_context,
-            artifacts,
-            self.attribute_lists.as_slice(),
-            AttributeTarget::ClassLike,
-        )?;
-
         let name = context.resolved_names.get(&self.name);
         let Some(class_like_metadata) = context.codebase.get_class_like(name) else {
             tracing::warn!("Class {} not found in codebase", BytesDisplay(name));
 
             return Ok(());
         };
+
+        analyze_class_like_attributes(context, artifacts, self.attribute_lists.as_slice(), class_like_metadata)?;
 
         if class_like_metadata.span != self.span() {
             report_duplicate_definition(context, "Class", "class", name, self.span(), class_like_metadata.span);
@@ -490,20 +483,14 @@ impl<'ast, 'arena> Analyzable<'ast, 'arena> for Interface<'arena> {
     where
         A: Arena,
     {
-        analyze_attributes(
-            context,
-            block_context,
-            artifacts,
-            self.attribute_lists.as_slice(),
-            AttributeTarget::ClassLike,
-        )?;
-
         let name = context.resolved_names.get(&self.name);
         let Some(class_like_metadata) = context.codebase.get_class_like(name) else {
             tracing::warn!("Interface {} not found in codebase", BytesDisplay(name));
 
             return Ok(());
         };
+
+        analyze_class_like_attributes(context, artifacts, self.attribute_lists.as_slice(), class_like_metadata)?;
 
         if class_like_metadata.span != self.span() {
             report_duplicate_definition(context, "Interface", "interface", name, self.span(), class_like_metadata.span);
@@ -577,20 +564,14 @@ impl<'ast, 'arena> Analyzable<'ast, 'arena> for Trait<'arena> {
     where
         A: Arena,
     {
-        analyze_attributes(
-            context,
-            block_context,
-            artifacts,
-            self.attribute_lists.as_slice(),
-            AttributeTarget::ClassLike,
-        )?;
-
         let name = context.resolved_names.get(&self.name);
         let Some(class_like_metadata) = context.codebase.get_class_like(name) else {
             tracing::warn!("Trait {} not found in codebase", BytesDisplay(name));
 
             return Ok(());
         };
+
+        analyze_class_like_attributes(context, artifacts, self.attribute_lists.as_slice(), class_like_metadata)?;
 
         if class_like_metadata.span != self.span() {
             report_duplicate_definition(context, "Trait", "trait", name, self.span(), class_like_metadata.span);
@@ -664,20 +645,14 @@ impl<'ast, 'arena> Analyzable<'ast, 'arena> for Enum<'arena> {
     where
         A: Arena,
     {
-        analyze_attributes(
-            context,
-            block_context,
-            artifacts,
-            self.attribute_lists.as_slice(),
-            AttributeTarget::ClassLike,
-        )?;
-
         let name = context.resolved_names.get(&self.name);
         let Some(class_like_metadata) = context.codebase.get_class_like(name) else {
             tracing::warn!("Enum {} not found in codebase", BytesDisplay(name));
 
             return Ok(());
         };
+
+        analyze_class_like_attributes(context, artifacts, self.attribute_lists.as_slice(), class_like_metadata)?;
 
         if class_like_metadata.span != self.span() {
             report_duplicate_definition(context, "Enum", "enum", name, self.span(), class_like_metadata.span);

--- a/crates/analyzer/src/visibility/mod.rs
+++ b/crates/analyzer/src/visibility/mod.rs
@@ -23,7 +23,7 @@ use mago_bytes::BytesDisplay;
 /// # Arguments
 ///
 /// * `context` - The global analysis context.
-/// * `block_context` - The context of the current code block, providing scope information.
+/// * `calling_class` - The class the access occurs in, or `None` for the global scope.
 /// * `fqcn` - The fully-qualified class name on which the method is being called.
 /// * `method_name` - The method name.
 /// * `access_span` - The span of the entire method call/access expression (e.g., `$obj->method()`).
@@ -33,9 +33,9 @@ use mago_bytes::BytesDisplay;
 ///
 /// `true` if the method is visible, `false` otherwise. An error is reported to the
 /// context buffer if the method is not visible.
-pub fn check_method_visibility<'ctx, A>(
-    context: &mut Context<'ctx, '_, A>,
-    block_context: &BlockContext<'ctx>,
+pub fn check_method_visibility<A>(
+    context: &mut Context<'_, '_, A>,
+    calling_class: Option<Word>,
     fqcn: &[u8],
     method_name: &[u8],
     access_span: Span,
@@ -59,12 +59,7 @@ where
         return true;
     }
 
-    let is_visible = is_visible_from_scope(
-        context.codebase,
-        visibility,
-        declaring_class.as_bytes(),
-        block_context.scope.get_class_like_name(),
-    );
+    let is_visible = is_visible_from_scope(context.codebase, visibility, declaring_class.as_bytes(), calling_class);
     if !is_visible {
         let declaring_class_name = context
             .codebase
@@ -80,7 +75,7 @@ where
 
         report_visibility_issue(
             context,
-            block_context,
+            calling_class,
             IssueCode::InvalidMethodAccess,
             issue_title,
             visibility,
@@ -248,7 +243,7 @@ where
 
         report_visibility_issue(
             context,
-            block_context,
+            block_context.scope.get_class_like_name(),
             IssueCode::InvalidPropertyRead,
             issue_title,
             visibility,
@@ -348,7 +343,7 @@ where
 
         report_visibility_issue(
             context,
-            block_context,
+            block_context.scope.get_class_like_name(),
             IssueCode::InvalidPropertyWrite,
             issue_title,
             visibility,
@@ -421,9 +416,9 @@ fn is_visible_via_required_extends(
     false
 }
 
-fn report_visibility_issue<'ctx, A>(
-    context: &mut Context<'ctx, '_, A>,
-    block_context: &BlockContext<'ctx>,
+fn report_visibility_issue<A>(
+    context: &mut Context<'_, '_, A>,
+    calling_class: Option<Word>,
     code: IssueCode,
     title: String,
     visibility: Visibility,
@@ -434,7 +429,7 @@ fn report_visibility_issue<'ctx, A>(
 ) where
     A: Arena,
 {
-    let current_scope_str = if let Some(current_class) = block_context.scope.get_class_like_name() {
+    let current_scope_str = if let Some(current_class) = calling_class {
         format!("from within `{current_class}`")
     } else {
         "from the global scope".to_string()

--- a/crates/analyzer/tests/cases/attribute_self_scope.php
+++ b/crates/analyzer/tests/cases/attribute_self_scope.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+#[\Attribute(\Attribute::TARGET_ALL)]
+final class Named
+{
+    public function __construct(public readonly string $name) {}
+}
+
+#[Named(name: self::ROUTE_NAME)]
+final class HealthCheckController
+{
+    public const ROUTE_NAME = 'health-check';
+}
+
+#[Named(self::ROUTE_NAME)]
+interface NamedInterface
+{
+    public const ROUTE_NAME = 'interface';
+}
+
+// Attribute arguments are evaluated outside the trait body, so `self` resolves the
+// trait directly and PHP rejects the constant access at runtime.
+// @mago-expect analysis:direct-trait-constant-access
+#[Named(self::ROUTE_NAME)]
+trait NamedTrait
+{
+    public const ROUTE_NAME = 'trait';
+}
+
+trait SelfReferencingTrait
+{
+    public const ROUTE_NAME = 'trait-member';
+
+    #[Named(self::ROUTE_NAME)]
+    public function member(): void {}
+}
+
+#[Named(self::ROUTE_NAME)]
+enum NamedEnum: string
+{
+    public const ROUTE_NAME = 'enum';
+
+    case One = 'one';
+}
+
+abstract class BaseController
+{
+    public const ROUTE_NAME = 'base';
+}
+
+#[Named(parent::ROUTE_NAME)]
+final class InheritingController extends BaseController {}
+
+// @mago-expect analysis:invalid-argument
+#[Named(self::ROUTE_NAME)]
+final class WrongConstantType
+{
+    public const ROUTE_NAME = 1;
+}
+
+function make_anonymous(): object
+{
+    return new #[Named(self::ROUTE_NAME)] class {
+        public const ROUTE_NAME = 'anonymous';
+    };
+}
+
+// @mago-expect analysis:invalid-parent-type
+// @mago-expect analysis:no-value
+#[Named(parent::ROUTE_NAME)]
+final class ParentlessController {}
+
+// Attributes are instantiated by reflection, so a non-public constructor is unreachable
+// even when the annotated declaration is the attribute class itself.
+// @mago-expect analysis:invalid-method-access
+#[SelfAnnotating]
+#[\Attribute(\Attribute::TARGET_ALL)]
+final class SelfAnnotating
+{
+    private function __construct() {}
+}
+
+// The same holds for members of the attribute class, where the class scope is genuine
+// but still not the scope the attribute is instantiated from.
+#[\Attribute(\Attribute::TARGET_ALL)]
+final class PrivateMarker
+{
+    // @mago-expect analysis:invalid-method-access
+    #[PrivateMarker]
+    public const MARKED = 1;
+
+    // @mago-expect analysis:invalid-method-access
+    #[PrivateMarker]
+    public int $marked = 0;
+
+    private function __construct() {}
+
+    // @mago-expect analysis:invalid-method-access
+    #[PrivateMarker]
+    public function marked(
+        // @mago-expect analysis:invalid-method-access
+        #[PrivateMarker]
+        int $value = 0,
+    ): int {
+        return $value;
+    }
+}
+
+// @mago-expect analysis:self-outside-class-scope
+// @mago-expect analysis:no-value
+#[Named(self::ROUTE_NAME)]
+function standaloneFunction(): void {}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -253,6 +253,7 @@ test_case!(arrays_err_sort_int);
 test_case!(arrays_err_widen_array_to_list);
 test_case!(assert_concrete_to_template_type);
 test_case!(assert_generic_array_key_is_array_key);
+test_case!(attribute_self_scope);
 test_case!(bare_identifier_in_array_access);
 test_case!(bin2hex);
 test_case!(break_narrowing);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes false positives on `self::CONST` and `parent::CONST` inside
attribute arguments on a class, interface, trait, enum, or anonymous
class, and closes two false negatives that surface once those
references resolve.

## 🔍 Context & Motivation

PHP evaluates the arguments of an attribute on a class-like in the
scope of that class-like, so `#[Route(self::ROUTE_NAME)]` on a class
is valid. We analyze those arguments with the block context of the
enclosing scope, which has no class attached, so any file-level class
reports `self-outside-class-scope` and the argument degrades to
`never` — a hard error on correct code. Members are unaffected,
because the class-scoped context is built before descending into them;
only the attributes on the declaration itself are analyzed too early.

Attaching the class-like to that scope is necessary but not
sufficient, because the arguments are still evaluated *outside* its
body. Reflection instantiates the attribute from no class scope at
all, so a non-public `__construct` is unreachable even when the
annotated declaration is the attribute class itself; and `self::CONST`
on a trait resolves the trait directly, which PHP rejects at runtime.

Correcting the constructor case means visibility must be checkable
from deliberately-no-class, so `check_method_visibility` now takes the
calling class rather than a whole `BlockContext`. That also repairs a
pre-existing miss: an attribute with a non-public constructor used on
a *member* of its own class was silently accepted in every position
(class constant, property, method, parameter).

Regressions are pinned in both directions — `self::CONST` inside a
trait *method* body stays clean, and `static::` in attribute arguments
is still rejected by the semantics pass.

## 🛠️ Summary of Changes

- **Bug Fix:** Resolve `self`/`parent` in attribute arguments on
  class-likes against the annotated declaration, and report the
  non-public-constructor and direct-trait-constant accesses that
  become visible once they do.


## 📂 Affected Areas

- [x] Other (please specify): Analyzer

## 🔗 Related Issues or PRs

Fixes #2166.