### PR TITLE
fix(composer): unbreak self-analysis of the availability markers

### DIFF
--- a/composer/src/AvailableSince.php
+++ b/composer/src/AvailableSince.php
@@ -24,6 +24,8 @@ use Attribute;
     | Attribute::TARGET_METHOD
     | Attribute::TARGET_PROPERTY
     | Attribute::TARGET_CLASS_CONSTANT
+    // Only read by Mago itself, never reflected at runtime, so the 8.5 floor does not apply.
+    // @mago-ignore analysis:unavailable-class-constant
     | Attribute::TARGET_CONSTANT
     | Attribute::TARGET_PARAMETER
     | Attribute::IS_REPEATABLE,

--- a/composer/src/AvailableUntil.php
+++ b/composer/src/AvailableUntil.php
@@ -22,6 +22,8 @@ use Attribute;
     | Attribute::TARGET_METHOD
     | Attribute::TARGET_PROPERTY
     | Attribute::TARGET_CLASS_CONSTANT
+    // Only read by Mago itself, never reflected at runtime, so the 8.5 floor does not apply.
+    // @mago-ignore analysis:unavailable-class-constant
     | Attribute::TARGET_CONSTANT
     | Attribute::TARGET_PARAMETER
     | Attribute::IS_REPEATABLE,


### PR DESCRIPTION
Restores a green `analyze` step in CI, which currently fails on our own
`composer/` sources.

## 🔍 Context & Motivation

9bef3027a `"fix(prelude): add Attribute TARGET_CONSTANT"` added
`Attribute::TARGET_CONSTANT` to the prelude carrying an
`#[AvailableSince(80500)]` annotation. `AvailableSince` and
`AvailableUntil` already list that constant among their own targets, and
`mago.toml` pins `php-version = "8.1"` to match the `~8.1` floor in
`composer.json`, so analyzing the package reports the constant as
unavailable.

Dropping the flag is not an option — the prelude annotates global
constants and needs `TARGET_CONSTANT` to stay a legal target — and
raising `php-version` would contradict `composer.json`. Mago reads
these markers statically and never calls `newInstance()`, so the 8.5
requirement never materializes; say so at the use site.

## 🛠️ Summary of Changes

- **Bug Fix:** Suppress `unavailable-class-constant` on the
  `Attribute::TARGET_CONSTANT` target in both availability markers,
  with a comment recording why the version floor does not bite.

## 📂 Affected Areas

- [x] Other (please specify): composer integration / tests