### PR TITLE
fix(analyzer): accept class-strings of specialized generic classes

### DIFF
--- a/crates/analyzer/src/invocation/template_inference.rs
+++ b/crates/analyzer/src/invocation/template_inference.rs
@@ -94,6 +94,47 @@ fn expand_template_constraint<'ty>(
     Cow::Owned(expanded)
 }
 
+/// Whether `input_object` is the very class the container is parameterizing, without carrying
+/// type parameters of its own — in which case it cannot specialize anything.
+fn names_the_same_unspecialized_class(container_constraint: &TAtomic, input_object: &TAtomic) -> bool {
+    let (TAtomic::Object(TObject::Named(container)), TAtomic::Object(TObject::Named(input))) =
+        (container_constraint, input_object)
+    else {
+        return false;
+    };
+
+    input.type_parameters.is_none() && container.name == input.name
+}
+
+/// Turns the class-string-ish members of `input_type` into the object types they name.
+fn collect_class_string_object_types<A>(context: &Context<'_, '_, A>, input_type: &TUnion) -> Vec<TAtomic>
+where
+    A: Arena,
+{
+    let mut input_objects = vec![];
+    for input_atomic in input_type.types.iter() {
+        match input_atomic {
+            TAtomic::Scalar(TScalar::ClassLikeString(class_string)) => {
+                input_objects.push(class_string.get_object_type(context.codebase));
+            }
+            TAtomic::Scalar(TScalar::String(string)) => {
+                // A literal `'Foo'` argument passed where `class-string<T>` is expected
+                // should bind `T = Foo`, mirroring how Psalm/PHPStan coerce literal
+                // strings that name a real class. Only do this when the literal really
+                // names a class-like in the codebase, otherwise leave inference alone.
+                if let Some(literal) = string.get_known_literal_value()
+                    && context.codebase.class_like_exists(literal)
+                {
+                    input_objects.push(TClassLikeString::literal(word(literal)).get_object_type(context.codebase));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    input_objects
+}
+
 fn infer_templates_from_input_and_container_types<A>(
     context: &Context<'_, '_, A>,
     container_type: &TUnion,
@@ -751,6 +792,37 @@ fn infer_templates_from_input_and_container_types<A>(
                     }
                 }
             }
+            // `class-string<Repo<T>>`: the templates live inside the constraint, not in the
+            // class-string itself, so unwrap both sides to objects and let the regular object
+            // inference specialize `T` through the argument's `@extends`.
+            TAtomic::Scalar(TScalar::ClassLikeString(TClassLikeString::OfType { constraint, .. })) => {
+                let container_object_type = wrap_atomic(constraint.as_ref().clone());
+                if !container_object_type.has_template_types() {
+                    continue;
+                }
+
+                // Only a name that actually specializes the container's parameters tells us
+                // anything. `class-string<It>` against `class-string<It<K, V>>` would otherwise
+                // bind `K` and `V` to their bare constraints and wipe out the bounds that other
+                // arguments already pinned.
+                let input_objects = collect_class_string_object_types(context, &residual_input_type)
+                    .into_iter()
+                    .filter(|input_object| !names_the_same_unspecialized_class(constraint, input_object))
+                    .collect::<Vec<_>>();
+
+                if input_objects.is_empty() {
+                    continue;
+                }
+
+                infer_templates_from_input_and_container_types(
+                    context,
+                    &container_object_type,
+                    &TUnion::from_vec(input_objects),
+                    template_result,
+                    options,
+                    violations,
+                );
+            }
             TAtomic::Scalar(TScalar::ClassLikeString(TClassLikeString::Generic {
                 parameter_name,
                 defining_entity,
@@ -764,28 +836,7 @@ fn infer_templates_from_input_and_container_types<A>(
                         .and_then(|map| map.get(defining_entity))
                         .is_none_or(std::vec::Vec::is_empty);
 
-                let mut input_objects = vec![];
-                for input_atomic in residual_input_type.types.iter() {
-                    match input_atomic {
-                        TAtomic::Scalar(TScalar::ClassLikeString(class_string)) => {
-                            input_objects.push(class_string.get_object_type(context.codebase));
-                        }
-                        TAtomic::Scalar(TScalar::String(string)) => {
-                            // A literal `'Foo'` argument passed where `class-string<T>` is expected
-                            // should bind `T = Foo`, mirroring how Psalm/PHPStan coerce literal
-                            // strings that name a real class. Only do this when the literal really
-                            // names a class-like in the codebase, otherwise leave inference alone.
-                            if let Some(literal) = string.get_known_literal_value()
-                                && context.codebase.class_like_exists(literal)
-                            {
-                                input_objects
-                                    .push(TClassLikeString::literal(word(literal)).get_object_type(context.codebase));
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-
+                let input_objects = collect_class_string_object_types(context, &residual_input_type);
                 if input_objects.is_empty() || !should_add_bound {
                     continue;
                 }

--- a/crates/analyzer/tests/cases/class_string_of_generic_object_inference.php
+++ b/crates/analyzer/tests/cases/class_string_of_generic_object_inference.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @template TEntity of object
+ */
+class EntityRepository
+{
+    /**
+     * @var TEntity|null
+     */
+    public ?object $entity = null;
+}
+
+final class UserEntity {}
+
+/**
+ * @extends EntityRepository<UserEntity>
+ */
+final class UserRepository extends EntityRepository {}
+
+/**
+ * @template TEntity of object
+ *
+ * @param class-string<EntityRepository<TEntity>>|null $repositoryClass
+ *
+ * @return TEntity
+ *
+ * @throws RuntimeException
+ */
+function configureEntity(?string $repositoryClass): object
+{
+    throw new RuntimeException($repositoryClass ?? '');
+}
+
+function takeUserEntity(UserEntity $entity): void
+{
+    unset($entity);
+}
+
+configureEntity(null);
+
+// `UserRepository` specializes `TEntity` through its `@extends`, so the argument is
+// valid and the return type is `UserEntity`.
+takeUserEntity(configureEntity(UserRepository::class));
+
+/**
+ * @template TKey of array-key
+ * @template TValue
+ */
+final class Collection
+{
+    /**
+     * @param array<TKey, TValue> $items
+     * @param class-string<Collection<TKey, TValue>> $collectionClass
+     */
+    public function __construct(
+        public array $items,
+        public string $collectionClass = Collection::class,
+    ) {}
+
+    /**
+     * @return TValue
+     *
+     * @throws RuntimeException
+     */
+    public function first(): mixed
+    {
+        foreach ($this->items as $item) {
+            return $item;
+        }
+
+        throw new RuntimeException('empty');
+    }
+}
+
+function takeInt(int $value): void
+{
+    unset($value);
+}
+
+// Naming the very class being parameterized carries no specialization, so it must not
+// widen the parameters that `$items` already pinned.
+$collection = new Collection(['a' => 1]);
+
+takeInt($collection->first());

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -804,6 +804,7 @@ test_case!(interface_assertion);
 test_case!(nullsafe_chain_bug);
 test_case!(class_string_instantiation);
 test_case!(class_string_comparison);
+test_case!(class_string_of_generic_object_inference);
 test_case!(static_var_lazy_init);
 test_case!(static_var_coalesce);
 test_case!(array_coalesce_assign_check);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Passing a class name to a parameter typed `class-string<SomeGeneric<T>>`
no longer reports a bogus argument mismatch, and `T` is resolved from
however that class specializes `SomeGeneric`.

## 🔍 Context & Motivation

Templates nested inside a `class-string` constraint — as in `@param
class-string<EntityRepository<TEntity>>` — are never inferred, because
inference only understands `class-string<T>`, where the template is the
class-string's own parameter. Every argument is therefore compared
against a type that still mentions the unresolved `TEntity` and gets
rejected, and any `@return TEntity` stays unusable. The equivalent
object parameter (`EntityRepository<TEntity>`) already works, so the gap
is specific to the class-string wrapper.

Unwrap both sides to the object types they name and let the existing
object inference read the specialization off the argument, no matter
where it comes from — `@extends`, `@implements`, `@use`, an ancestor, or
type parameters the argument's own type already carries. One subtlety:
a bare name of the parameterized class itself carries none of that, and
inferring from it binds the parameters to their bare constraints,
discarding what other arguments already pinned — visible with
`ArrayObject`, whose `$iterator_class` defaults to `ArrayIterator::class`
and would wipe out the key/value types taken from `$input`. Those
arguments are skipped.

## 🛠️ Summary of Changes

- **Bug Fix:** Templates nested in a `class-string<...>` parameter are
  inferred from the argument's class, instead of being left unresolved
  and reported as an argument type mismatch.

## 📂 Affected Areas

- [x] Other (please specify): Analyzer

## 🔗 Related Issues or PRs

Fixes #2167