### PR TITLE
docs(reporting): clarify that --sort is a no-op for some formats

### DIFF
--- a/src/commands/args/reporting.rs
+++ b/src/commands/args/reporting.rs
@@ -59,6 +59,9 @@ pub struct ReportingArgs {
     ///
     /// By default, issues are reported in the order they appear in files.
     /// This option provides a more organized view for reviewing large numbers of issues.
+    ///
+    /// No-op for aggregate-formats (count, code-count) and formats where the consumer handles
+    /// ordering (github, gitlab, sarif, checkstyle, emacs), they are always unordered.
     #[arg(long)]
     pub sort: bool,
 


### PR DESCRIPTION
## 📌 What Does This PR Do?

Documents that `--sort` has no effect for a subset of reporting
formats.

## 🔍 Context & Motivation

`--sort` is advertised as a general reporting option, but it only
applies to formats where Mago itself lays out the issue list.
Aggregate formats have no per-issue output to order, and machine
formats hand ordering off to whatever consumes them. Users
reasonably expect the flag to work everywhere and are left
wondering why nothing changes.

Rather than making the flag error or warn for those formats — which
would break existing invocations that pass `--sort` unconditionally
— state the limitation in the help text.

## 🛠️ Summary of Changes

- **Docs:** Note in the `--sort` help text which formats ignore it.

## 📂 Affected Areas

- [x] CLI
- [x] Documentation

## 🔗 Related Issues or PRs

Fixes #2173