### PR TITLE
fix(analyzer): 'is_scalar($x) && is_numeric($x)' narrowing $x to never

### DIFF
--- a/crates/analyzer/src/reconciler/simple_assertion_reconciler.rs
+++ b/crates/analyzer/src/reconciler/simple_assertion_reconciler.rs
@@ -959,6 +959,9 @@ where
             TAtomic::Mixed(_) | TAtomic::Scalar(TScalar::Generic) => {
                 return get_numeric();
             }
+            TAtomic::Scalar(TScalar::Numeric) => {
+                acceptable_types.push(TAtomic::Scalar(TScalar::Numeric));
+            }
             TAtomic::Scalar(TScalar::Float(float)) => {
                 acceptable_types.push(TAtomic::Scalar(TScalar::Float(*float)));
             }

--- a/crates/analyzer/tests/cases/narrowing_to_numeric_is_idempotent.php
+++ b/crates/analyzer/tests/cases/narrowing_to_numeric_is_idempotent.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+function mixed_to_int_or_mixed(mixed $value): mixed
+{
+    if (!\is_scalar($value) || !\is_numeric($value)) {
+        return $value;
+    }
+
+    if ((string) (int) $value !== (string) $value) {
+        return $value;
+    }
+
+    return (int) $value;
+}
+
+/**
+ * @param numeric $value
+ */
+function takes_numeric(mixed $value): void
+{
+}
+
+function narrow_to_numeric(mixed $value): void
+{
+    if (!\is_scalar($value) || !\is_numeric($value)) {
+        return;
+    }
+
+    takes_numeric($value);
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -402,6 +402,7 @@ test_case!(non_utf8_class_names);
 test_case!(non_utf8_function_names);
 test_case!(non_utf8_property_names);
 test_case!(numeric_reconciliation);
+test_case!(narrowing_to_numeric_is_idempotent);
 test_case!(priority_queue_implementation);
 test_case!(psl_integration);
 test_case!(psl_int_range);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes `is_scalar($x) && is_numeric($x)` collapsing `$x` to `never`
instead of narrowing it to `numeric`.

## 🔍 Context & Motivation

Code of this shape reports `never-return` (or unreachable-code) errors
on every use of `$value` after the guard:

```php
if (!is_scalar($value) || !is_numeric($value)) {
    return $value;
}
```

intersect_numeric has never had an arm for an existing numeric
atomic, so intersecting numeric with numeric yields never. That
stayed latent while each conjunct was reconciled exactly once, because
nothing narrowed a variable to bare numeric before the numeric
assertion was applied.

🛠️ Summary of Changes

- Bug Fix: intersect_numeric keeps an existing numeric atomic rather than discarding it, making narrowing to numeric idempotent.

📂 Affected Areas

- [x] Other (please specify): Analyzer

## 🔗 Related Issues or PRs

Fixes #2179