### PR TITLE
fix(analyzer): return StructureType from flow-php's type_structure() provider

### DIFF
--- a/crates/analyzer/src/plugin/libraries/flow_php/type_structure.rs
+++ b/crates/analyzer/src/plugin/libraries/flow_php/type_structure.rs
@@ -117,7 +117,7 @@ impl FunctionReturnTypeProvider for TypeStructureProvider {
         }
 
         Some(TUnion::from_atomic(TAtomic::Object(TObject::Named(TNamedObject::new_with_type_parameters(
-            word("Flow\\Types\\Type"),
+            word("Flow\\Types\\Type\\Logical\\StructureType"),
             Some(vec![TUnion::from_atomic(TAtomic::Array(TArray::Keyed(TKeyedArray {
                 parameters: if allows_extra_fields {
                     Some((Arc::new(get_arraykey()), Arc::new(get_mixed())))

--- a/crates/analyzer/tests/cases/flow_php_integration.php
+++ b/crates/analyzer/tests/cases/flow_php_integration.php
@@ -16,18 +16,76 @@ namespace Flow\Types {
     }
 }
 
+namespace Flow\Types\Type\Logical {
+    use Flow\Types\Type;
+
+    /**
+     * @template-covariant T of array<array-key, mixed>
+     *
+     * @implements Type<T>
+     */
+    final class StructureType implements Type
+    {
+        /**
+         * @param array<array-key, Type<value-of<T>>> $elements
+         * @param array<array-key, Type<value-of<T>>> $optionalElements
+         */
+        public function __construct(
+            private array $elements = [],
+            private array $optionalElements = [],
+            private bool $allowExtra = false,
+        ) {}
+
+        public function allowsExtra(): bool
+        {
+            return $this->allowExtra;
+        }
+
+        /**
+         * @param mixed $value
+         *
+         * @return T
+         */
+        public function assert($value): mixed
+        {
+            /** @var T $value */
+            return $value;
+        }
+
+        /**
+         * @return array<array-key, Type<mixed>>
+         */
+        public function elements(): array
+        {
+            return $this->elements;
+        }
+
+        /**
+         * @return array<array-key, Type<mixed>>
+         */
+        public function optionalElements(): array
+        {
+            return $this->optionalElements;
+        }
+    }
+}
+
 namespace Flow\Types\DSL {
     use Flow\Types\Type;
+    use Flow\Types\Type\Logical\StructureType;
 
     /**
      * @template T
      *
      * @param array<string, Type<T>> $elements
      *
-     * @return Type<array<string, T>>
+     * @return StructureType<array<string, T>>
      */
-    function type_structure(array $elements = [], array $optional_elements = [], bool $allow_extra = false): Type
-    {
+    function type_structure(
+        array $elements = [],
+        array $optional_elements = [],
+        bool $allow_extra = false,
+    ): StructureType {
         return type_structure($elements, $optional_elements, $allow_extra);
     }
 
@@ -49,6 +107,8 @@ namespace Flow\Types\DSL {
 }
 
 namespace {
+    use Flow\Types\Type\Logical\StructureType;
+
     function get_mixed(): mixed
     {
         return 1;
@@ -62,6 +122,24 @@ namespace {
     function i_take_int(int $value): void
     {
         echo "Received int: $value\n";
+    }
+
+    function i_take_bool(bool $value): void
+    {
+        echo "Received bool: $value\n";
+    }
+
+    /**
+     * The structural accessors consumers introspect with are declared on the concrete class, not on `Type`,
+     * so the provider has to return `StructureType` for this parameter to be satisfiable from the DSL.
+     *
+     * @param StructureType<array<array-key, mixed>> $type
+     */
+    function i_take_structure_type(StructureType $type): void
+    {
+        i_take_int(count($type->elements()));
+        i_take_int(count($type->optionalElements()));
+        i_take_bool($type->allowsExtra());
     }
 
     /**
@@ -104,4 +182,8 @@ namespace {
 
     i_take_flexible_array($flexible);
     i_take_string($flexible['required_field']);
+
+    // The inferred shape must remain assignable to the concrete class it is built from.
+    i_take_structure_type($array_type);
+    i_take_structure_type($flexible_type);
 }


### PR DESCRIPTION
## 📌 What Does This PR Do?

Changed behavior of flow-php plugin for analyzer. 

The `flow-php` plugin's `type_structure()` provider infers the structure's shape correctly but reports it as the `Flow\Types\Type` interface rather than the concrete `Flow\Types\Type\Logical\StructureType` the call actually returns.

Which works in case of PSL but not Flow. 
Flow logical types like Structure comes with additional methods, like `StructureType::elements()` or `MapType::keys()` 

Thats why can't return `Type<T>`, but `StructureType` so those extra methods are recognized when they are used like this `type_structure(...)->elements()` without mago reporting that method elements doesnt exists. 

## 🔍 Context & Motivation

<!-- Why is this change needed? Is it fixing a bug, adding a feature, or refactoring? -->

## 🛠️ Summary of Changes

- **Bug Fix:** return StructureType from flow-php's type_structure() provider


## 📂 Affected Areas

- [x] Analyzer
- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

<!-- Fixes #__, related to #__ -->

## 📝 Notes for Reviewers

<!-- Any extra context, concerns, or breaking changes? -->
