### PR TITLE
fix(analyzer): report undefined types in class docblock tags

### DIFF
--- a/crates/analyzer/src/resolver/method.rs
+++ b/crates/analyzer/src/resolver/method.rs
@@ -5,6 +5,7 @@ use mago_codex::identifier::method::MethodIdentifier;
 use mago_codex::metadata::CodebaseMetadata;
 use mago_codex::metadata::class_like::ClassLikeMetadata;
 use mago_codex::metadata::function_like::FunctionLikeMetadata;
+use mago_codex::metadata::ttype::TypeMetadata;
 use mago_codex::misc::GenericParent;
 use mago_codex::ttype::TType;
 use mago_codex::ttype::atomic::TAtomic;
@@ -19,7 +20,6 @@ use mago_codex::ttype::get_mixed;
 use mago_codex::ttype::get_specialized_template_type;
 use mago_codex::ttype::template::GenericTemplate;
 use mago_codex::ttype::template::TemplateResult;
-use mago_codex::ttype::union::TUnion;
 use mago_reporting::Annotation;
 use mago_reporting::Issue;
 use mago_span::HasSpan;
@@ -1131,7 +1131,7 @@ fn collect_mixin_types(
     codebase: &CodebaseMetadata,
     class_metadata: &ClassLikeMetadata,
     outer_object: &TObject,
-    mixins: &[TUnion],
+    mixins: &[TypeMetadata],
 ) -> Vec<(Word, TObject)> {
     let mut results = Vec::new();
     let mut visited = HashSet::default();
@@ -1144,14 +1144,14 @@ fn collect_mixin_types_into(
     codebase: &CodebaseMetadata,
     class_metadata: &ClassLikeMetadata,
     outer_object: &TObject,
-    mixins: &[TUnion],
+    mixins: &[TypeMetadata],
     results: &mut Vec<(Word, TObject)>,
     visited: &mut HashSet<Word>,
 ) {
     let mut direct: Vec<(Word, &TObject)> = Vec::new();
 
     for mixin_type in mixins {
-        for mixin_atomic in mixin_type.types.as_ref() {
+        for mixin_atomic in mixin_type.type_union.types.as_ref() {
             match mixin_atomic {
                 TAtomic::Object(obj @ TObject::Named(named)) => {
                     direct.push((ascii_lowercase_word(named.name.as_bytes()), obj));

--- a/crates/analyzer/src/resolver/property.rs
+++ b/crates/analyzer/src/resolver/property.rs
@@ -1513,7 +1513,7 @@ fn find_property_in_mixins<A>(
     context: &Context<'_, '_, A>,
     class_metadata: &ClassLikeMetadata,
     outer_object: &TObject,
-    mixins: &[TUnion],
+    mixins: &[TypeMetadata],
     prop_name: Word,
     for_assignment: bool,
 ) -> Option<ResolvedProperty>
@@ -1521,7 +1521,7 @@ where
     A: Arena,
 {
     for mixin_type in mixins {
-        for mixin_atomic in mixin_type.types.as_ref() {
+        for mixin_atomic in mixin_type.type_union.types.as_ref() {
             match mixin_atomic {
                 TAtomic::Object(TObject::Named(named)) => {
                     if let Some(result) = find_property_in_single_mixin(context, named.name, prop_name, for_assignment)

--- a/crates/analyzer/src/resolver/static_method.rs
+++ b/crates/analyzer/src/resolver/static_method.rs
@@ -7,6 +7,7 @@ use mago_word::word;
 
 use mago_codex::identifier::method::MethodIdentifier;
 use mago_codex::metadata::class_like::ClassLikeMetadata;
+use mago_codex::metadata::ttype::TypeMetadata;
 use mago_codex::ttype::atomic::TAtomic;
 use mago_codex::ttype::atomic::generic::TGenericParameter;
 use mago_codex::ttype::atomic::object::TObject;
@@ -14,7 +15,6 @@ use mago_codex::ttype::atomic::object::r#enum::TEnum;
 use mago_codex::ttype::atomic::object::named::TNamedObject;
 use mago_codex::ttype::expander::StaticClassType;
 use mago_codex::ttype::get_specialized_template_type;
-use mago_codex::ttype::union::TUnion;
 use mago_codex::ttype::wrap_atomic;
 use mago_php_version::feature::Feature;
 use mago_reporting::Annotation;
@@ -729,7 +729,7 @@ fn report_non_existent_mixin_static_method<A>(
 fn find_static_method_in_mixins<'ctx, 'arena, A>(
     context: &mut Context<'ctx, 'arena, A>,
     block_context: &BlockContext<'ctx>,
-    mixins: &[TUnion],
+    mixins: &[TypeMetadata],
     method_name: Word,
     selector: &ClassLikeMemberSelector<'arena>,
     access_span: Span,
@@ -738,7 +738,7 @@ where
     A: Arena,
 {
     for mixin_type in mixins {
-        for mixin_atomic in mixin_type.types.as_ref() {
+        for mixin_atomic in mixin_type.type_union.types.as_ref() {
             match mixin_atomic {
                 TAtomic::Object(TObject::Named(named)) => {
                     if let Some(result) = find_static_method_in_single_mixin(

--- a/crates/analyzer/src/statement/class_like/mod.rs
+++ b/crates/analyzer/src/statement/class_like/mod.rs
@@ -38,6 +38,7 @@ use mago_reporting::Annotation;
 use mago_reporting::Issue;
 use mago_span::HasSpan;
 use mago_span::Span;
+use mago_syntax::comments::docblock::PrecedingDocblocks;
 use mago_syntax::cst::Class;
 use mago_syntax::cst::ClassLikeMember;
 use mago_syntax::cst::Enum;
@@ -1008,6 +1009,7 @@ where
 
     check_unused_template_parameters(context, class_like_metadata);
     check_class_like_properties(context, class_like_metadata);
+    check_docblock_declared_members(context, class_like_metadata, declaration_span);
 
     let mut scope = ScopeContext::new();
     scope.set_class_like(Some(class_like_metadata));
@@ -3009,6 +3011,60 @@ fn report_signature_compatibility_issue<'ctx, A>(
                     "Consider renaming the parameter to `{parent_param_name}` to match the parent method."
                 )),
             );
+        }
+    }
+}
+
+/// Reports undefined type references in the `@method`, `@property` and `@mixin`
+/// tags of a class-like docblock.
+///
+/// The members these tags declare have no AST of their own, so they are never
+/// visited by the analyzers that perform this check for real methods and
+/// properties.
+fn check_docblock_declared_members<A>(
+    context: &mut Context<'_, '_, A>,
+    class_like_metadata: &ClassLikeMetadata,
+    declaration_span: Span,
+) where
+    A: Arena,
+{
+    for pseudo_method_name in &class_like_metadata.pseudo_methods {
+        let Some(metadata) = context.codebase.function_likes.get(&(class_like_metadata.name, *pseudo_method_name))
+        else {
+            continue;
+        };
+
+        if let Some(return_type) = &metadata.return_type_metadata {
+            report_undefined_type_references(context, return_type);
+        }
+
+        for parameter in &metadata.parameters {
+            if let Some(parameter_type) = &parameter.type_declaration_metadata {
+                report_undefined_type_references(context, parameter_type);
+            }
+        }
+    }
+
+    for (property_name, property_metadata) in &class_like_metadata.magic_properties {
+        if class_like_metadata.magic_property_ids.get(property_name) != Some(&class_like_metadata.name) {
+            continue;
+        }
+
+        for type_metadata in
+            [&property_metadata.type_metadata, &property_metadata.write_type_metadata].into_iter().flatten()
+        {
+            report_undefined_type_references(context, type_metadata);
+        }
+    }
+
+    // Unlike the tags above, mixins are merged into every subclass, so report only
+    // the ones coming from this class-like's own docblock.
+    let docblocks: Vec<Span> =
+        PrecedingDocblocks::new(context.comments, declaration_span.start.offset).map(|trivia| trivia.span).collect();
+
+    for mixin in &class_like_metadata.mixins {
+        if docblocks.iter().any(|docblock| docblock.contains(&mixin.span)) {
+            report_undefined_type_references(context, mixin);
         }
     }
 }

--- a/crates/analyzer/tests/cases/docblock_declared_members_undefined_types.php
+++ b/crates/analyzer/tests/cases/docblock_declared_members_undefined_types.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+// The pragmas sit outside the docblocks: a pragma inside one would be scoped to
+// the class statement, which does not cover the docblock the issue points into.
+
+// @mago-expect analysis:non-existent-class-like
+/**
+ * @method NonExistentReturn method(string $id)
+ */
+class MethodReturn {}
+
+// @mago-expect analysis:non-existent-class-like
+/**
+ * @method ($id is 'a' ? NonExistentConditionalReturn : null) method(string $id)
+ */
+class ConditionalMethodReturn {}
+
+// @mago-expect analysis:non-existent-class-like
+/**
+ * @method null method(NonExistentParameter $value)
+ */
+class MethodParameter {}
+
+// @mago-expect analysis:non-existent-class-like
+/**
+ * @property NonExistentProperty $property
+ */
+class MagicProperty {}
+
+// @mago-expect analysis:non-existent-class-like
+/**
+ * @property-read NonExistentReadProperty $property
+ */
+class ReadOnlyMagicProperty {}
+
+// @mago-expect analysis:non-existent-class-like
+/**
+ * @property-write NonExistentWriteProperty $property
+ */
+class WriteOnlyMagicProperty {}
+
+// @mago-expect analysis:non-existent-class-like
+/**
+ * @mixin NonExistentMixin
+ */
+class Mixin {}
+
+/**
+ * @method self|null method(int $id)
+ * @property self $property
+ */
+class KnownTypes {}
+
+/**
+ * Pseudo-members are reported on the class-like that declares them, not again
+ * on the ones inheriting them.
+ */
+class InheritsMagic extends Mixin {}
+
+// @mago-expect analysis:non-existent-class-like
+/**
+ * @mixin NonExistentTraitMixin
+ */
+trait MixinTrait {}
+
+/** Trait mixins are reported on the trait, not on its users. */
+class UsesMixinTrait
+{
+    use MixinTrait;
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -627,6 +627,7 @@ test_case!(match_expression);
 test_case!(match_arm_reaching);
 test_case!(missing_constructor);
 test_case!(property_initialization);
+test_case!(docblock_declared_members_undefined_types);
 test_case!(parent_constructor_init);
 test_case!(parent_static_return);
 test_case!(property_hooks_initialization);

--- a/crates/codex/src/metadata/class_like.rs
+++ b/crates/codex/src/metadata/class_like.rs
@@ -107,7 +107,7 @@ pub struct ClassLikeMetadata {
     pub imported_type_aliases: WordMap<(Word, Word, Span)>,
     /// Mixin types from @mixin annotations - these types' methods/properties
     /// can be accessed via magic methods (__call, __get, __set, __callStatic)
-    pub mixins: Vec<TUnion>,
+    pub mixins: Vec<TypeMetadata>,
     pub version_constraint: VersionConstraint,
 }
 

--- a/crates/codex/src/populator/hierarchy.rs
+++ b/crates/codex/src/populator/hierarchy.rs
@@ -438,9 +438,9 @@ pub fn populate_class_like_types(
     }
 
     for mixin_type in &mut metadata.mixins {
-        if mixin_type.needs_population() || force_repopulation {
+        if mixin_type.type_union.needs_population() || force_repopulation {
             populate_union_type(
-                mixin_type,
+                &mut mixin_type.type_union,
                 codebase_symbols,
                 Some(&class_like_reference_source),
                 symbol_references,

--- a/crates/codex/src/scanner/class_like.rs
+++ b/crates/codex/src/scanner/class_like.rs
@@ -1040,7 +1040,7 @@ where
                 continue;
             };
 
-            match builder::get_union_from_type(mixin.r#type, scope, &type_context, Some(original_name)) {
+            match get_type_metadata_from_type(mixin.r#type, Some(original_name), &type_context, scope) {
                 Ok(mixin_type) => {
                     class_like_metadata.mixins.push(mixin_type);
                 }

--- a/crates/codex/src/ttype/expander.rs
+++ b/crates/codex/src/ttype/expander.rs
@@ -855,7 +855,7 @@ fn direct_mixins<'ctx>(
     metadata: &'ctx ClassLikeMetadata,
     codebase: &'ctx CodebaseMetadata,
 ) -> impl Iterator<Item = (Word, Option<&'ctx ClassLikeMetadata>)> {
-    metadata.mixins.iter().flat_map(|mixin| mixin.types.as_ref().iter()).flat_map(move |mixin_type| {
+    metadata.mixins.iter().flat_map(|mixin| mixin.type_union.types.as_ref().iter()).flat_map(move |mixin_type| {
         let atomics = match mixin_type {
             TAtomic::GenericParameter(TGenericParameter { constraint, .. }) => constraint.types.as_ref(),
             other => std::slice::from_ref(other),


### PR DESCRIPTION
## 📌 What Does This PR Do?

Reports `non-existent-class-like` for types named by `@method`,
`@property`, `@property-read`, `@property-write` and `@mixin`, which are
currently not checked for existence at all.

## 🔍 Context & Motivation

A typo in one of these tags silently produces an unresolved reference,
which later comparisons treat as compatible with anything — so the bad
type is not just unreported, it also weakens every check downstream. The
same type written in a `@return` or `@param` is caught, which makes the
gap easy to mistake for the tag being fine.

The members these tags declare have no AST of their own, so the
function-like and property analyzers that run this check never visit
them; the check has to run off the class-like metadata instead. Mixins
needed a preparatory change for that: they are stored as bare unions
with no span to point at, and they are merged into every subclass and
trait user, so a class-like's own mixins are indistinguishable from
inherited ones once the unions are pooled.

## 🛠️ Summary of Changes

- **Bug Fix:** Check the types of docblock-declared members for existence.
- **Refactor:** Keep the source span of `@mixin` types.

## 📂 Affected Areas

- [x] Other (please specify): Analyzer