### PR TITLE
fix(phpdoc): stop a trailing hyphen from swallowing the next byte

### DIFF
--- a/crates/phpdoc-syntax/src/lexer/mod.rs
+++ b/crates/phpdoc-syntax/src/lexer/mod.rs
@@ -230,7 +230,9 @@ impl<'arena> DocblockLexer<'arena> {
                 consumed_hyphen = true;
             }
 
-            if !consumed_hyphen {
+            // `scan_identifier` skips its first byte, trusting the caller to have validated it,
+            // so re-entering it after a trailing hyphen would swallow whatever follows.
+            if !consumed_hyphen || !remaining.get(length).is_some_and(is_part_of_identifier) {
                 break;
             }
         }
@@ -461,6 +463,18 @@ mod tests {
             TokenKind::Identifier,
             TokenKind::Whitespace,
             TokenKind::ThisVariable,
+        ]
+    );
+
+    test!(
+        lexes_trailing_hyphen_without_consuming_what_follows,
+        b"`foo-` UTF-8",
+        vec![
+            TokenKind::Backtick,
+            TokenKind::Identifier,
+            TokenKind::Backtick,
+            TokenKind::Whitespace,
+            TokenKind::Identifier,
         ]
     );
 

--- a/crates/phpdoc-syntax/src/lexer/mod.rs
+++ b/crates/phpdoc-syntax/src/lexer/mod.rs
@@ -230,8 +230,6 @@ impl<'arena> DocblockLexer<'arena> {
                 consumed_hyphen = true;
             }
 
-            // `scan_identifier` skips its first byte, trusting the caller to have validated it,
-            // so re-entering it after a trailing hyphen would swallow whatever follows.
             if !consumed_hyphen || !remaining.get(length).is_some_and(is_part_of_identifier) {
                 break;
             }

--- a/crates/phpdoc-syntax/tests/corpus.rs
+++ b/crates/phpdoc-syntax/tests/corpus.rs
@@ -299,6 +299,22 @@ fn inline_code_with_unbalanced_apostrophe_is_closed() {
 }
 
 #[test]
+fn inline_code_ending_with_a_hyphen_is_closed() {
+    let arena = LocalArena::new();
+    let source = b"/**\n * `foo-` is the prefix.\n */";
+    let document = parse(&arena, source);
+
+    assert!(document.errors.is_empty(), "expected no errors, got {:?}", document.errors);
+
+    let texts = texts(&document);
+    let [TextSegment::InlineCode(inline), TextSegment::PlainText(rest)] = texts[0].segments else {
+        panic!("expected inline-code then plain-text, got {:?}", texts[0].segments);
+    };
+    assert_eq!(inline.value, b"foo-");
+    assert_eq!(rest.value, b" is the prefix.");
+}
+
+#[test]
 fn utf8_paragraph_text_is_kept_verbatim() {
     let arena = LocalArena::new();
     let source = "/**\n * 中文段落\n */".as_bytes();


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes the docblock lexer swallowing the byte that follows an identifier ending in a hyphen, which made inline code spans like `` `foo-` `` parse as unclosed.

## 🔍 Context & Motivation

Reported in #2194. Reproduces on `main`:

```rust
PHPDocParser::parse(&arena, FileId::zero(), b"/**\n * `foo-` is the prefix.\n */");
// errors: [UnclosedInlineCode(Span { start: 7, end: 28 })]
```

`` `foo-bar` `` and `` `-` `` are fine, so the trigger is specifically a hyphen at the *end* of an identifier.

`read_identifier` walks segments in a loop: `scan_identifier`, then any run of `-`, and it loops back if it consumed a hyphen. But `scan_identifier` starts at `pos = start + 1`, deliberately skipping its first byte because the caller is supposed to have validated it. On re-entry after a trailing hyphen nothing validated that byte, so it was consumed whatever it was. `` `foo-` `` lexed as `` Backtick, Identifier("foo-`") ``, the closing backtick disappeared into the identifier, and `parse_code_span` ran to the end of the docblock and reported `UnclosedInlineCode`.

The same swallow hits anything that follows a trailing hyphen, not just backticks: `foo- bar` took the space, and `foo-` at end of line took the `\n`, which also defeats the `starts_line` checks and the inline-code reset in `advance`.

## 🛠️ Summary of Changes

- **Bug Fix:** `read_identifier` now only continues past a hyphen run when the next byte is one `scan_identifier` would have consumed anyway (`is_part_of_identifier`).

`is_part_of_identifier` rather than the local `is_identifier_start` on purpose: it is exactly the table `scan_identifier` applies to its own continuation bytes, so digits keep working and `UTF-8` and `array{a-1: int}` lex as they did before. Using the start table there would have split them.

One boundary does change: `foo-\Bar` was previously one token and is now `foo-` plus `\Bar`. That token only existed because of this bug, and a hyphen before a namespace separator has no meaning in a type.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): PHPDoc lexer (`crates/phpdoc-syntax`)

## 🔗 Related Issues or PRs

Fixes #2194.

## 📝 Notes for Reviewers

Two tests, at the two levels that can regress independently:

- `lexes_trailing_hyphen_without_consuming_what_follows` pins the token boundaries, including `UTF-8`, so a later tightening of the predicate to the start table would fail rather than silently re-splitting identifiers.
- `inline_code_ending_with_a_hyphen_is_closed` is the acceptance test for the reported case.

Both fail without the change. `cargo test --workspace --locked --all-targets`, `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets --all-features -- -D warnings` are clean locally.

`!consumed_hyphen` is arguably redundant now, since a non-identifier byte is the only way the hyphen loop can exit without having consumed one. I kept it because dropping it means relying on an invariant that lives in another crate, and the flag says what the loop means. Happy to remove it if you prefer.

I used an AI assistant while working on this: to help trace the bug back to the `scan_identifier` contract and to review the patch, which is how the `UTF-8` predicate issue got caught. The diagnosis, the fix and the tests are mine and I have verified them.