### PR TITLE
fix(analyzer): report missing property types on items without a default

### DIFF
--- a/crates/analyzer/src/utils/missing_type_hints.rs
+++ b/crates/analyzer/src/utils/missing_type_hints.rs
@@ -14,7 +14,6 @@ use mago_syntax::cst::FunctionLikeParameter;
 use mago_syntax::cst::FunctionLikeReturnTypeHint;
 use mago_syntax::cst::Hint;
 use mago_syntax::cst::Property;
-use mago_syntax::cst::PropertyItem;
 
 use crate::code::IssueCode;
 use crate::context::Context;
@@ -75,33 +74,12 @@ pub fn check_property_type_hint<'arena, A>(
         return;
     }
 
-    let hint = match property {
-        Property::Plain(plain) => plain.hint.as_ref(),
-        Property::Hooked(hooked) => hooked.hint.as_ref(),
-    };
-
     // If it already has a type hint, nothing to check
-    if hint.is_some() {
+    if property.hint().is_some() {
         return;
     }
 
-    let variables = match property {
-        Property::Plain(plain) => plain
-            .items
-            .iter()
-            .filter_map(
-                |item| {
-                    if let PropertyItem::Concrete(concrete) = item { Some(&concrete.variable) } else { None }
-                },
-            )
-            .collect::<Vec<_>>(),
-        Property::Hooked(hooked) => match &hooked.item {
-            PropertyItem::Concrete(concrete) => vec![&concrete.variable],
-            PropertyItem::Abstract(_) => vec![],
-        },
-    };
-
-    for variable in variables {
+    for variable in property.variables() {
         // Skip variables prefixed with `$_`
         if variable.name.starts_with(b"$_") {
             continue;
@@ -345,12 +323,7 @@ pub fn check_imprecise_property_type_hint<'arena, A>(
         return;
     }
 
-    let hint = match property {
-        Property::Plain(plain) => plain.hint.as_ref(),
-        Property::Hooked(hooked) => hooked.hint.as_ref(),
-    };
-
-    let Some(hint) = hint else {
+    let Some(hint) = property.hint() else {
         return;
     };
 
@@ -361,25 +334,13 @@ pub fn check_imprecise_property_type_hint<'arena, A>(
         return;
     }
 
-    let variables = match property {
-        Property::Plain(plain) => plain
-            .items
-            .iter()
-            .filter_map(|item| if let PropertyItem::Concrete(c) = item { Some(c.variable.name) } else { None })
-            .collect::<Vec<_>>(),
-        Property::Hooked(hooked) => match &hooked.item {
-            PropertyItem::Concrete(c) => vec![c.variable.name],
-            PropertyItem::Abstract(_) => vec![],
-        },
-    };
-
     let imprecise = collect_imprecise_hints(hint);
     if imprecise.is_empty() {
         return;
     }
 
-    for variable_name in variables {
-        let variable_name = BytesDisplay(variable_name);
+    for variable in property.variables() {
+        let variable_name = BytesDisplay(variable.name);
         for &(type_name, span) in &imprecise {
             report_imprecise_type(context, type_name, span, &format!("property `{variable_name}`"));
         }

--- a/crates/analyzer/tests/cases/missing_property_type.php
+++ b/crates/analyzer/tests/cases/missing_property_type.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Fixture;
+
+class MissingPropertyType
+{
+    /** @mago-expect analysis:missing-property-type */
+    public $withoutDefault;
+
+    /** @mago-expect analysis:missing-property-type */
+    protected $withoutDefaultProtected;
+
+    /** @mago-expect analysis:missing-property-type */
+    public $withDefault = 1;
+
+    /**
+     * Reported once per declared item, defaulted or not.
+     *
+     * @mago-expect analysis:missing-property-type(2)
+     */
+    public $firstItem, $secondItem = 2;
+
+    // Hooked properties never carry a default, so they only report via the
+    // `Property::Hooked` arm.
+    /** @mago-expect analysis:missing-property-type */
+    public $hooked {
+        get => 1;
+    }
+
+    // A docblock `@var` does not satisfy the check; a native hint is required,
+    // matching how `@param` and `@return` are treated by
+    // `missing-parameter-type` and `missing-return-type`.
+    /**
+     * @var int
+     *
+     * @mago-expect analysis:missing-property-type
+     */
+    public $docblockOnly;
+
+    // `imprecise-type` on properties has the same per-item behavior
+    /** @mago-expect analysis:imprecise-type */
+    public array $impreciseWithoutDefault;
+
+    // Natively typed properties are never reported, defaulted or not
+    public int $typedWithDefault = 1;
+    protected ?string $typedWithoutDefault = null;
+
+    // Properties prefixed with `$_` stay ignored by convention
+    public $_ignored;
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -626,6 +626,7 @@ test_case!(match_not_exhaustive);
 test_case!(match_expression);
 test_case!(match_arm_reaching);
 test_case!(missing_constructor);
+test_case!(missing_property_type, crate::framework::check_missing_type_hints_settings());
 test_case!(property_initialization);
 test_case!(docblock_declared_members_undefined_types);
 test_case!(parent_constructor_init);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Hello! I was attempting to migrate from phpstan to mago on our large closed-source codebase and I ran into a small issue with the analyzer. It seems `missing-property-type` fires only on properties that carry a default value.  `public $foo;` is never reported; `public $foo = 1;` is.

Here's a reproduction:

```php
<?php

class PropProbe
{
    public $pubNoDefault;           // not reported
    public $pubDefault = 1;         // reported
    protected $protNoDefault;       // not reported
    protected $protDefault = 1;     // reported
    private $privNoDefault;         // not reported
    private $privDefault = 1;       // reported
    public static $statNoDefault;   // not reported
    public static $statDefault = 1; // reported
    public $multiA, $multiB = 2;    // only $multiB reported
    var $legacyVar;                 // not reported

    public array $impreciseNoDefault;      // no imprecise-type
    public array $impreciseDefault = [];   // imprecise-type
}
```

This PR reports `missing-property-type` on properties without a default value.

## 🔍 Context & Motivation

I was doing some research, and it seems mago used to have a linter rule to catch this, but the linter rule was "promoted" to an analyzer rule in https://github.com/carthage-software/mago/commit/4caaa2d5a due to https://github.com/carthage-software/mago/issues/374. Makes sense -- the analyzer can apply semantic analysis to catch things like parent-class typing.

It seems though that the "promotion" from a linter rule to an analyzer rule created the possibility of false negatives on properties without defaults. This PR changes the code to use the existing `Property::variables()` helper, which already returns the variable of every item regardless of whether it has a default value.

## 🛠️ Summary of Changes

- **Bug Fix:** correctly reports `missing-property-type` on properties without a default

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): analyzer

## 📝 Notes for Reviewers

This will add warnings on lines that previously passed without being flagged.