### PR TITLE
fix(analyzer): honor `@var` docblocks on `global` statements

### DIFF
--- a/crates/analyzer/src/statement/global.rs
+++ b/crates/analyzer/src/statement/global.rs
@@ -17,6 +17,7 @@ use crate::context::block::BlockContext;
 use crate::context::block::ReferenceConstraint;
 use crate::context::block::ReferenceConstraintSource;
 use crate::error::AnalysisError;
+use crate::utils::docblock::get_type_from_var_docblock;
 use crate::utils::expression::get_variable_id;
 
 impl<'ast, 'arena> Analyzable<'ast, 'arena> for Global<'arena> {
@@ -24,7 +25,7 @@ impl<'ast, 'arena> Analyzable<'ast, 'arena> for Global<'arena> {
         &'ast self,
         context: &mut Context<'ctx, 'arena, A>,
         block_context: &mut BlockContext<'ctx>,
-        _artifacts: &mut AnalysisArtifacts,
+        artifacts: &mut AnalysisArtifacts,
     ) -> Result<(), AnalysisError>
     where
         A: Arena,
@@ -52,15 +53,33 @@ impl<'ast, 'arena> Analyzable<'ast, 'arena> for Global<'arena> {
 
             let var_id_atom = mago_word::word(var_id);
             let is_argc_or_argv = var_id == b"$argc" || var_id == b"$argv";
-            let global_type = get_global_variable_type(var_id).unwrap_or_else(|| Rc::new(get_mixed()));
+            let known_type = get_global_variable_type(var_id);
+            let docblock_type =
+                get_type_from_var_docblock(context, block_context, artifacts, Some(var_id), self.variables.len() == 1)
+                    .map(|(docblock_type, docblock_type_span)| (Rc::new(docblock_type), docblock_type_span));
 
-            block_context.locals.insert(var_id_atom, global_type);
+            // Incompatibilities between the docblock and a known superglobal type are already
+            // reported by the generic `@var` pass, which sees them in scope before this point.
+            let variable_type = match (&docblock_type, known_type) {
+                (Some((docblock_type, _)), _) => Rc::clone(docblock_type),
+                (None, Some(known_type)) => known_type,
+                (None, None) => Rc::new(get_mixed()),
+            };
+
+            block_context.locals.insert(var_id_atom, variable_type);
 
             if !is_argc_or_argv {
                 block_context.variables_possibly_in_scope.insert(var_id_atom);
                 block_context.by_reference_constraints.insert(
                     var_id_atom,
-                    ReferenceConstraint::new(variable.span(), ReferenceConstraintSource::Global, None),
+                    match &docblock_type {
+                        Some((docblock_type, docblock_type_span)) => ReferenceConstraint::new(
+                            *docblock_type_span,
+                            ReferenceConstraintSource::Global,
+                            Some(Rc::clone(docblock_type)),
+                        ),
+                        None => ReferenceConstraint::new(variable.span(), ReferenceConstraintSource::Global, None),
+                    },
                 );
             }
 

--- a/crates/analyzer/tests/cases/var_docblock_on_global.php
+++ b/crates/analyzer/tests/cases/var_docblock_on_global.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+class GlobalValue
+{
+    public function value(): string
+    {
+        return '';
+    }
+}
+
+function named_var(): string
+{
+    /** @var GlobalValue $value */
+    global $value;
+
+    return $value->value();
+}
+
+function unnamed_var(): string
+{
+    /** @var GlobalValue */
+    global $value;
+
+    return $value->value();
+}
+
+function multiple_vars(): string
+{
+    /**
+     * @var GlobalValue $first
+     * @var GlobalValue $second
+     */
+    global $first, $second;
+
+    return $first->value() . $second->value();
+}
+
+function constrains_assignments(): void
+{
+    /** @var GlobalValue $value */
+    global $value;
+
+    /** @mago-expect analysis:reference-constraint-violation */
+    $value = 'not an object';
+}
+
+function narrows_superglobal(): string
+{
+    /** @var array<string, string> $_SERVER */
+    global $_SERVER;
+
+    return $_SERVER['REQUEST_URI'] ?? '';
+}
+
+function without_var(): string
+{
+    global $value;
+
+    /**
+     * @mago-expect analysis:mixed-method-access
+     * @mago-expect analysis:mixed-return-statement
+     */
+    return $value->value();
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -676,6 +676,7 @@ test_case!(optional_object_with_properties);
 test_case!(unsealed_array_overlap);
 test_case!(echo_tag);
 test_case!(var_docblock);
+test_case!(var_docblock_on_global);
 test_case!(redundant_var_docblock);
 test_case!(magic_method_trait);
 test_case!(real_pseudo_method);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Makes `/** @var Foo $foo */` apply to the `global $foo;` statement it
precedes, instead of being silently discarded.

## 🔍 Context & Motivation

An imported global always ends up as `mixed` (or the built-in
superglobal type), so any method call on it reports
`mixed-method-access`. The annotation is parsed and put in scope, then
overwritten. The only workaround is a redundant `$foo = $foo;`
self-assignment carrying the annotation.

## 🛠️ Summary of Changes

- **Bug Fix:** `@var` on a `global` statement now types the imported
  variable, and constrains later assignments to it like other typed
  globals.

## 📂 Affected Areas

- [x] Other (please specify): Analyzer

## 🔗 Related Issues or PRs

Fixes #2181