### PR TITLE
Show versions in reverse: from new to old ones

### DIFF
--- a/docs/static/js/versions.js
+++ b/docs/static/js/versions.js
@@ -59,10 +59,13 @@
     const entries = data.versions.filter((v) => v && typeof v.id === "string");
     if (entries.length === 0) return;
 
+    const mainArr = entries.filter((v) => v.label === "main");
+    const latestMain = mainArr.length > 0 ? mainArr[0] : null;
+
     const stable = entries
       .filter((v) => v.stable === true)
-      .sort((a, b) => compareSemver(a.id, b.id));
-    const latestStable = stable.length > 0 ? stable[stable.length - 1] : null;
+      .sort((a, b) => -compareSemver(a.id, b.id));
+    const latestStable = stable.length > 0 ? stable[0] : null;
 
     const items = [];
     if (latestStable) {
@@ -73,7 +76,15 @@
         active: false,
       });
     }
-    for (const version of entries) {
+    if (latestMain) {
+      items.push({
+        id: latestMain.id,
+        label: latestMain.label,
+        url: buildUrl("main"),
+        active: false,
+      });
+    }
+    for (const version of stable) {
       items.push({
         id: version.id,
         label: typeof version.label === "string" ? version.label : version.id,


### PR DESCRIPTION
## 📌 What Does This PR Do?

| Before | After |
|--------|--------|
| <img alt="Versions list: before" src="https://github.com/user-attachments/assets/d0e6fc97-0dda-4c83-b247-a68d26c9d27d" /> | <img alt="Versions list: after" src="https://github.com/user-attachments/assets/c995eb8e-c254-4c78-ab03-14ab58b49783" /> |

## 🔍 Context & Motivation

I think it’s better UX to show the new versions on top of the old ones.

## 🛠️ Summary of Changes

- **Docs:** Updated versions list for better UX.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [x] Documentation
- [ ] Other (please specify):
