### PR TITLE
feat(init): detect Drupal projects and configure Mago for them

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -217,7 +217,7 @@ php-version = "{php_version}"
 workspace = "."
 paths = [{paths}]
 includes = [{includes}]
-excludes = [{excludes}]
+excludes = [{excludes}]{source_extensions}
 
 [source.glob]
 literal-separator = true
@@ -346,6 +346,7 @@ impl InitCommand {
             .replace("{paths}", &quote_format_strings(&paths))
             .replace("{includes}", &quote_format_strings(&includes))
             .replace("{excludes}", &quote_format_strings(&excludes))
+            .replace("{source_extensions}", &build_source_extensions_string(&integrations))
             .replace(
                 "{integrations}",
                 &quote_format_strings(&integrations.iter().map(|i| i.to_string().to_lowercase()).collect::<Vec<_>>()),
@@ -820,6 +821,10 @@ fn detect_integrations_from_composer(composer: &ComposerPackage) -> Vec<Integrat
         integrations.push(Integration::Laravel);
     }
 
+    if has_package_prefix(composer, "drupal/") {
+        integrations.push(Integration::Drupal);
+    }
+
     if has_package(composer, "phpunit/phpunit") {
         integrations.push(Integration::PHPUnit);
     }
@@ -947,6 +952,22 @@ fn quote_format_strings(items: &[String]) -> String {
     items.iter().map(|p| format!("\"{}\"", p)).collect::<Vec<_>>().join(", ")
 }
 
+/// Builds the `extensions` line for the `[source]` section, leading newline included, or an empty string
+/// when Drupal is not detected. The template appends it to the `excludes` line so nothing is left behind
+/// when the line is not needed.
+///
+/// Drupal classes live in `.php` files, but hooks, update functions, and other procedural code sit in
+/// legacy `.module`, `.install`, and `.theme` files that the default `php`-only list skips. The list matches the
+/// `extensions` argument in Drupal core's own `phpcs.xml.dist`, minus the non-PHP entries.
+fn build_source_extensions_string(integrations: &[Integration]) -> String {
+    if !integrations.contains(&Integration::Drupal) {
+        return String::new();
+    }
+
+    "\nextensions = [\"php\", \"engine\", \"inc\", \"install\", \"module\", \"profile\", \"test\", \"theme\"]"
+        .to_string()
+}
+
 fn build_analyzer_settings_string(settings: &InitializationAnalyzerSettings) -> String {
     let mut lines = Vec::new();
 
@@ -1012,6 +1033,7 @@ mod tests {
             .replace("{paths}", &quote_format_strings(paths))
             .replace("{includes}", &quote_format_strings(includes))
             .replace("{excludes}", &quote_format_strings(excludes))
+            .replace("{source_extensions}", &build_source_extensions_string(integrations))
             .replace(
                 "{integrations}",
                 &quote_format_strings(&integrations.iter().map(|i| i.to_string().to_lowercase()).collect::<Vec<_>>()),
@@ -1111,6 +1133,8 @@ mod tests {
             &create_default_analyzer_settings(),
         );
 
+        assert!(!content.contains("extensions ="), "Drupal extensions should not leak into other projects");
+
         let result: Result<Configuration, _> = toml::from_str(&content);
         assert!(result.is_ok(), "Generated config should parse. Error: {:?}\n\nConfig:\n{}", result.err(), content);
     }
@@ -1202,5 +1226,39 @@ mod tests {
 
         let result: Result<Configuration, _> = toml::from_str(&content);
         assert!(result.is_ok(), "Generated config should parse. Error: {:?}\n\nConfig:\n{}", result.err(), content);
+    }
+    #[test]
+    fn test_generated_config_adds_drupal_extensions() {
+        let content = generate_config_content(
+            "8.3",
+            &["web/modules/custom".to_string()],
+            &["vendor".to_string()],
+            &[],
+            &[Integration::Drupal],
+            "[formatter]\npreset = \"drupal\"",
+            &create_default_analyzer_settings(),
+        );
+
+        let configuration: Configuration = toml::from_str(&content).expect("generated config should parse");
+        for extension in ["php", "engine", "inc", "install", "module", "profile", "test", "theme"] {
+            assert!(configuration.source.extensions.iter().any(|e| e == extension), "missing `{extension}`");
+        }
+    }
+
+    #[test]
+    fn test_detect_integrations_from_composer_detects_drupal() {
+        let composer = ComposerPackage::from_str(
+            r#"{"require": {"drupal/core-recommended": "^11.0", "symfony/console": "^7.0"}}"#,
+        )
+        .expect("composer.json should parse");
+
+        let integrations = detect_integrations_from_composer(&composer);
+        assert!(integrations.contains(&Integration::Drupal));
+
+        let composer =
+            ComposerPackage::from_str(r#"{"require": {"laravel/framework": "^11.0"}}"#).expect("should parse");
+
+        let integrations = detect_integrations_from_composer(&composer);
+        assert!(!integrations.contains(&Integration::Drupal));
     }
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -228,9 +228,7 @@ literal-separator = true
 integrations = [{integrations}]
 
 [linter.rules]
-ambiguous-function-call = { enabled = false }
-literal-named-argument = { enabled = false }
-halstead = { effort-threshold = 7000 }
+{linter_rules}
 
 [analyzer]
 plugins = [{analyzer_plugins}]
@@ -336,27 +334,19 @@ impl InitCommand {
         let InitializationProjectSettings { php_version, paths, includes, excludes } = setup_project(&theme)?;
 
         let integrations = setup_linter(&theme)?;
-        let formatter_config = setup_formatter(&theme)?;
+        let formatter_config = setup_formatter(&theme, &integrations)?;
         let analyzer_settings = setup_analyzer(&theme)?;
 
         print_step_header(5, "Review & Confirm");
-        let config_content = CONFIGURATION_TEMPLATE
-            .replace("{mago_version}", env!("CARGO_PKG_VERSION"))
-            .replace("{php_version}", &php_version)
-            .replace("{paths}", &quote_format_strings(&paths))
-            .replace("{includes}", &quote_format_strings(&includes))
-            .replace("{excludes}", &quote_format_strings(&excludes))
-            .replace("{source_extensions}", &build_source_extensions_string(&integrations))
-            .replace(
-                "{integrations}",
-                &quote_format_strings(&integrations.iter().map(|i| i.to_string().to_lowercase()).collect::<Vec<_>>()),
-            )
-            .replace("{formatter_config}", &formatter_config)
-            .replace(
-                "{analyzer_plugins}",
-                &quote_format_strings(&analyzer_settings.plugins.iter().map(|p| p.to_string()).collect::<Vec<_>>()),
-            )
-            .replace("{analyzer_settings}", &build_analyzer_settings_string(&analyzer_settings));
+        let config_content = generate_config_content(
+            &php_version,
+            &paths,
+            &includes,
+            &excludes,
+            &integrations,
+            &formatter_config,
+            &analyzer_settings,
+        );
 
         if write_configuration_if_confirmed(&theme, &configuration_file, &config_content)? {
             print_final_summary();
@@ -522,23 +512,38 @@ fn setup_linter(theme: &ColorfulTheme) -> Result<Vec<Integration>, Error> {
     }
 }
 
-fn setup_formatter(theme: &ColorfulTheme) -> Result<String, Error> {
+fn setup_formatter(theme: &ColorfulTheme, integrations: &[Integration]) -> Result<String, Error> {
     print_step_header(3, "Formatter Configuration");
     println!("  │  {}", "The Formatter automatically rewrites your files to a consistent style.".bright_black());
     println!("  │  {}", "This ends debates about spacing and helps you focus on the code.".bright_black());
     println!("  │");
 
+    let suggested_preset = preset_for_integrations(integrations);
+    if let Some(preset) = suggested_preset {
+        println!(
+            "  │  {}",
+            format!("The `{}` preset matches this project's coding standard.", preset.name()).bright_black()
+        );
+        println!("  │");
+    }
+
     let base_config = if Confirm::with_theme(theme)
         .with_prompt(" │  Do you want to use a preset formatter configuration?")
-        .default(false)
+        .default(suggested_preset.is_some())
         .interact()?
     {
         println!("  │");
 
         let preset_values = FormatterPreset::all();
         let preset_items = preset_values.iter().map(|p| p.description()).collect::<Vec<_>>();
-        let selection =
-            Select::with_theme(theme).with_prompt(" │  Select a preset").items(&preset_items).default(0).interact()?;
+        let default_selection = suggested_preset
+            .and_then(|preset| preset_values.iter().position(|candidate| *candidate == preset))
+            .unwrap_or(0);
+        let selection = Select::with_theme(theme)
+            .with_prompt(" │  Select a preset")
+            .items(&preset_items)
+            .default(default_selection)
+            .interact()?;
 
         let selected_preset = preset_values[selection];
 
@@ -821,7 +826,7 @@ fn detect_integrations_from_composer(composer: &ComposerPackage) -> Vec<Integrat
         integrations.push(Integration::Laravel);
     }
 
-    if has_package_prefix(composer, "drupal/") {
+    if is_drupal_project(composer) {
         integrations.push(Integration::Drupal);
     }
 
@@ -838,6 +843,17 @@ fn detect_integrations_from_composer(composer: &ComposerPackage) -> Vec<Integrat
     }
 
     integrations
+}
+
+/// Checks whether the composer metadata points at a Drupal site, module, theme, or profile.
+fn is_drupal_project(composer: &ComposerPackage) -> bool {
+    has_package_prefix(composer, "drupal/")
+        || composer.r#type.as_ref().is_some_and(|package_type| package_type.0.starts_with("drupal-"))
+}
+
+/// Returns the formatter preset that matches a detected integration's coding standard.
+fn preset_for_integrations(integrations: &[Integration]) -> Option<FormatterPreset> {
+    integrations.contains(&Integration::Drupal).then_some(FormatterPreset::Drupal)
 }
 
 fn detect_analyzer_plugins_from_composer(composer: &ComposerPackage) -> Vec<AnalyzerPlugin> {
@@ -968,6 +984,61 @@ fn build_source_extensions_string(integrations: &[Integration]) -> String {
         .to_string()
 }
 
+/// Linter rules every generated configuration sets.
+const BASE_LINTER_RULES: &str = "ambiguous-function-call = { enabled = false }
+literal-named-argument = { enabled = false }
+halstead = { effort-threshold = 7000 }";
+
+/// Linter rules matching the Drupal coding standards.
+const DRUPAL_LINTER_RULES: &str = "# Drupal coding standards.
+interface-name = { psr = true }
+trait-name = { psr = true }
+method-name = { enabled = true }
+property-name = { enabled = true }
+variable-name = { enabled = true }";
+
+/// Builds the body of the `[linter.rules]` section for the detected integrations.
+fn build_linter_rules_string(integrations: &[Integration]) -> String {
+    let mut blocks = vec![BASE_LINTER_RULES];
+
+    if integrations.contains(&Integration::Drupal) {
+        blocks.push(DRUPAL_LINTER_RULES);
+    }
+
+    blocks.join("\n\n")
+}
+
+/// Fills the configuration template with the values collected during initialization.
+#[allow(clippy::too_many_arguments)]
+fn generate_config_content(
+    php_version: &str,
+    paths: &[String],
+    includes: &[String],
+    excludes: &[String],
+    integrations: &[Integration],
+    formatter_config: &str,
+    analyzer_settings: &InitializationAnalyzerSettings,
+) -> String {
+    CONFIGURATION_TEMPLATE
+        .replace("{mago_version}", env!("CARGO_PKG_VERSION"))
+        .replace("{php_version}", php_version)
+        .replace("{paths}", &quote_format_strings(paths))
+        .replace("{includes}", &quote_format_strings(includes))
+        .replace("{excludes}", &quote_format_strings(excludes))
+        .replace("{source_extensions}", &build_source_extensions_string(integrations))
+        .replace(
+            "{integrations}",
+            &quote_format_strings(&integrations.iter().map(|i| i.to_string().to_lowercase()).collect::<Vec<_>>()),
+        )
+        .replace("{linter_rules}", &build_linter_rules_string(integrations))
+        .replace("{formatter_config}", formatter_config)
+        .replace(
+            "{analyzer_plugins}",
+            &quote_format_strings(&analyzer_settings.plugins.iter().map(|p| p.to_string()).collect::<Vec<_>>()),
+        )
+        .replace("{analyzer_settings}", &build_analyzer_settings_string(analyzer_settings))
+}
+
 fn build_analyzer_settings_string(settings: &InitializationAnalyzerSettings) -> String {
     let mut lines = Vec::new();
 
@@ -1015,35 +1086,6 @@ mod tests {
             check_missing_type_hints: false,
             register_super_globals: true,
         }
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn generate_config_content(
-        php_version: &str,
-        paths: &[String],
-        includes: &[String],
-        excludes: &[String],
-        integrations: &[Integration],
-        formatter_config: &str,
-        analyzer_settings: &InitializationAnalyzerSettings,
-    ) -> String {
-        CONFIGURATION_TEMPLATE
-            .replace("{mago_version}", env!("CARGO_PKG_VERSION"))
-            .replace("{php_version}", php_version)
-            .replace("{paths}", &quote_format_strings(paths))
-            .replace("{includes}", &quote_format_strings(includes))
-            .replace("{excludes}", &quote_format_strings(excludes))
-            .replace("{source_extensions}", &build_source_extensions_string(integrations))
-            .replace(
-                "{integrations}",
-                &quote_format_strings(&integrations.iter().map(|i| i.to_string().to_lowercase()).collect::<Vec<_>>()),
-            )
-            .replace("{formatter_config}", formatter_config)
-            .replace(
-                "{analyzer_plugins}",
-                &quote_format_strings(&analyzer_settings.plugins.iter().map(|p| p.to_string()).collect::<Vec<_>>()),
-            )
-            .replace("{analyzer_settings}", &build_analyzer_settings_string(analyzer_settings))
     }
 
     #[test]
@@ -1134,6 +1176,7 @@ mod tests {
         );
 
         assert!(!content.contains("extensions ="), "Drupal extensions should not leak into other projects");
+        assert!(!content.contains("interface-name"), "Drupal rules should not leak into other projects");
 
         let result: Result<Configuration, _> = toml::from_str(&content);
         assert!(result.is_ok(), "Generated config should parse. Error: {:?}\n\nConfig:\n{}", result.err(), content);
@@ -1202,6 +1245,43 @@ mod tests {
         assert_eq!(AnalyzerPlugin::Psl.to_string(), "psl");
         assert_eq!(AnalyzerPlugin::FlowPhp.to_string(), "flow-php");
         assert_eq!(AnalyzerPlugin::PsrContainer.to_string(), "psr-container");
+    }
+
+    #[test]
+    fn test_generated_config_for_drupal() {
+        let content = generate_config_content(
+            "8.3",
+            &["web/modules/custom".to_string()],
+            &["vendor".to_string()],
+            &[],
+            &[Integration::Drupal],
+            "[formatter]\npreset = \"drupal\"",
+            &create_default_analyzer_settings(),
+        );
+
+        assert!(content.contains(r#"integrations = ["drupal"]"#));
+        assert!(content.contains("interface-name = { psr = true }"));
+        assert!(content.contains("trait-name = { psr = true }"));
+        assert!(content.contains("method-name = { enabled = true }"));
+        assert!(content.contains("property-name = { enabled = true }"));
+        assert!(content.contains("variable-name = { enabled = true }"));
+
+        let result: Result<Configuration, _> = toml::from_str(&content);
+        assert!(result.is_ok(), "Generated config should parse. Error: {:?}\n\nConfig:\n{}", result.err(), content);
+    }
+
+    #[test]
+    fn test_detect_integrations_from_composer_detects_drupal_by_package_type() {
+        let composer = ComposerPackage::from_str(r#"{"type": "drupal-module"}"#).expect("composer.json should parse");
+
+        let integrations = detect_integrations_from_composer(&composer);
+        assert!(integrations.contains(&Integration::Drupal));
+    }
+
+    #[test]
+    fn test_preset_for_integrations() {
+        assert_eq!(preset_for_integrations(&[Integration::Drupal]), Some(FormatterPreset::Drupal));
+        assert_eq!(preset_for_integrations(&[Integration::Symfony]), None);
     }
 
     #[test]


### PR DESCRIPTION
## 📌 What Does This PR Do?

Teaches `mago init` to recognize a Drupal project from `composer.json` and generate a
configuration that fits it: Drupal's PHP file extensions, the `drupal` integration, the
`drupal` formatter preset, and the linter rules matching Drupal's naming conventions.

## 🔍 Context & Motivation

Running `mago init` in a Drupal project today produces a config that misses part of the
codebase and flags idiomatic code:

- Drupal classes live in `.php`, but hooks, update functions, and other procedural code sit
  in legacy `.module`, `.install`, and `.theme` files. Mago scans `.php` only, so none of
  that code is parsed.
- The `drupal` integration exists — `lowercase-keyword` already uses it to allow
  `TRUE`/`FALSE`/`NULL` — but nothing ever detects it.
- The `drupal` formatter preset exists, but the preset prompt defaults to "no".
- Drupal requires the `Interface` and `Trait` suffixes and camelCase members, while
  `method-name`, `property-name`, and `variable-name` are all disabled by default.

## 🛠️ Summary of Changes

- **Feature:** detect Drupal from a `drupal/*` requirement or a `drupal-*` composer `type`,
  which covers both site installs and contrib modules that require nothing from `drupal/*`.
- **Feature:** the generated `[source]` gets the extra Drupal extensions, matching the list
  in Drupal core's own `phpcs.xml.dist` minus the non-PHP entries.
- **Feature:** the formatter step defaults to yes and preselects the `drupal` preset.
- **Feature:** the generated `[linter.rules]` gets a Drupal block.
- **Refactor:** one `generate_config_content`, shared by `execute` and the tests, which each
  had their own copy of the same replace chain.

What a detected Drupal project now gets:

```toml
[source]
extensions = ["php", "engine", "inc", "install", "module", "profile", "test", "theme"]

[formatter]
preset = "drupal"

[linter]
integrations = ["drupal"]

[linter.rules]
# Drupal coding standards.
interface-name = { psr = true }
trait-name = { psr = true }
method-name = { enabled = true }
property-name = { enabled = true }
variable-name = { enabled = true }
```

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [x] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

None.

## 📝 Notes for Reviewers

- Nothing changes for non-Drupal projects. The existing multi-integration generation test now
  also asserts that neither the extensions line nor the Drupal rules leak into other configs.
- On the rule picks: `psr` on `interface-name`/`trait-name` is Drupal's suffix requirement;
  `method-name` and `property-name` default to camelCase but ship disabled; `variable-name`'s
  default `either` accepts snake_case procedural variables alongside camelCase members.
  `class-name.psr` is deliberately not set — it requires an `Abstract` prefix, while Drupal
  uses a `...Base` suffix. `function-name` is left alone, since its default already requires
  snake_case.
- Alternative considered for the extensions: adding them during config load whenever the
  `drupal` integration is set, which would also cover hand-written configs. I kept it in
  `init` so the behavior stays visible in the user's own file, but happy to switch.
