### PR TITLE
fix(formatter): match Drupal's style for single value arguments and logical parentheses

### DIFF
--- a/crates/formatter/src/presets.rs
+++ b/crates/formatter/src/presets.rs
@@ -307,6 +307,7 @@ const DRUPAL_PRESET: FormatSettings = FormatSettings {
     inline_empty_method_braces: false,
     preserve_breaking_member_access_chain: true,
     preserve_breaking_argument_list: true,
+    inline_single_breaking_value_argument: true,
     preserve_breaking_parameter_list: true,
     preserve_breaking_attribute_list: true,
     preserve_breaking_conditional_expression: true,

--- a/crates/formatter/src/presets.rs
+++ b/crates/formatter/src/presets.rs
@@ -312,6 +312,7 @@ const DRUPAL_PRESET: FormatSettings = FormatSettings {
     preserve_breaking_attribute_list: true,
     preserve_breaking_conditional_expression: true,
     preserve_breaking_condition_expression: true,
+    preserve_redundant_logical_binary_expression_parentheses: true,
     array_table_style_alignment: false,
     space_before_arrow_function_parameter_list_parenthesis: true,
     empty_line_after_class_like_open: true,

--- a/crates/formatter/tests/cases/drupal_preset/after.php
+++ b/crates/formatter/tests/cases/drupal_preset/after.php
@@ -306,9 +306,7 @@ $derivatives["entity:$entity_type_id"] =
       'alias' => ContextDefinition::create('string')
         ->setLabel(t('Path alias'))
         ->setRequired(TRUE)
-        ->setDescription(t(
-          "Specify an alternative path by which the content can be accessed. For example, 'about' for an about page. Use a relative path and do not add a trailing slash.",
-        )),
+        ->setDescription(t("Specify an alternative path by which the content can be accessed. For example, 'about' for an about page. Use a relative path and do not add a trailing slash.")),
     ],
     'provides' => [],
   ] + $base_plugin_definition;
@@ -328,9 +326,7 @@ $derivatives["entity:$entity_type_id"] =
       'alias' => ContextDefinition::create('string')
         ->setLabel(t('Path alias'))
         ->setRequired(TRUE)
-        ->setDescription(t(
-          "Specify an alternative path by which the content can be accessed. For example, 'about' for an about page. Use a relative path and do not add a trailing slash.",
-        )),
+        ->setDescription(t("Specify an alternative path by which the content can be accessed. For example, 'about' for an about page. Use a relative path and do not add a trailing slash.")),
     ],
     'provides' => [],
   ] + $base_plugin_definition;
@@ -1263,9 +1259,11 @@ $x = new class() {
 
 // Test mago compatibility with single array value over multiple lines.
 $response = new AjaxResponse();
-$response->addCommand(new InvokeCommand('#edit-field-job-expiration-date-0-value-date', 'val', [$end_value->format(
-  'Y-m-d',
-)]));
+$response->addCommand(new InvokeCommand(
+  '#edit-field-job-expiration-date-0-value-date',
+  'val',
+  [$end_value->format('Y-m-d')],
+));
 
 foreach ($result['subscriptions'] as $subscription) {
   $group = $subscription->organization->entity;
@@ -1311,9 +1309,7 @@ $form['account']['notify_message'] = [
   '#type' => 'container',
   '#markup' =>
     '<div class="messages messages--warning">'
-      . t(
-        "By turning this off, no welcome or verification emails will be sent to the account that's being created.",
-      )
+      . t("By turning this off, no welcome or verification emails will be sent to the account that's being created.")
       . '</div>',
   '#states' => [
     'visible' => [

--- a/crates/formatter/tests/cases/drupal_preset_logical_parentheses/after.php
+++ b/crates/formatter/tests/cases/drupal_preset_logical_parentheses/after.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\Core\Access;
+
+class AccessCheck {
+
+  public function isAllowed($account, $entity, $operation) {
+    if ($account->isAnonymous() || ($entity->isPublished() && $operation === 'view')) {
+      return TRUE;
+    }
+
+    if (
+      $this->token === NULL
+      || ($this->lookahead !== NULL
+      && ($this->lookahead->position - $this->token->position) === strlen($this->token->value))
+    ) {
+      return FALSE;
+    }
+
+    return (
+      $account->hasPermission('bypass access')
+      || ($entity->getOwnerId() === $account->id() && $operation !== 'delete')
+    );
+  }
+
+}

--- a/crates/formatter/tests/cases/drupal_preset_logical_parentheses/before.php
+++ b/crates/formatter/tests/cases/drupal_preset_logical_parentheses/before.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\Core\Access;
+
+class AccessCheck {
+
+  public function isAllowed($account, $entity, $operation) {
+    if ($account->isAnonymous() || ($entity->isPublished() && $operation === 'view')) {
+      return TRUE;
+    }
+
+    if (
+      $this->token === NULL
+      || ($this->lookahead !== NULL && ($this->lookahead->position - $this->token->position) === strlen($this->token->value))
+    ) {
+      return FALSE;
+    }
+
+    return $account->hasPermission('bypass access') || ($entity->getOwnerId() === $account->id() && $operation !== 'delete');
+  }
+
+}

--- a/crates/formatter/tests/cases/drupal_preset_logical_parentheses/settings.inc
+++ b/crates/formatter/tests/cases/drupal_preset_logical_parentheses/settings.inc
@@ -1,0 +1,1 @@
+mago_formatter::presets::FormatterPreset::Drupal.settings()

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -319,6 +319,7 @@ test_case!(match_idempotency);
 test_case!(heredoc_indentation);
 test_case!(heredoc_indentation_disabled);
 test_case!(drupal_preset);
+test_case!(drupal_preset_logical_parentheses);
 test_case!(redundant_grouping_parens);
 test_case!(preserve_logical_grouping_parens);
 test_case!(preserve_logical_grouping_parens_disabled);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Flips two settings in `DRUPAL_PRESET` so its output matches what Drupal code actually looks like: long single-argument calls stay on one line, and grouping parentheses in logical expressions survive formatting.

## 🔍 Context & Motivation

Both defaults are reasonable for PER-CS but wrong for Drupal, and both fire constantly in a Drupal codebase.

`t()` wrapping a long translatable string is everywhere in Drupal. Breaking the parentheses around it costs two lines and shortens nothing:

```php
// before
->setDescription(t(
  "Specify an alternative path by which the content can be accessed. For example, 'about' for an about page.",
)),

// after
->setDescription(t("Specify an alternative path by which the content can be accessed. For example, 'about' for an about page.")),
```

And the formatter removed parentheses that PHP's precedence rules already imply, rewriting
grouping the author added on purpose. Drupal's standards keep them:

```php
// before
if ($account->isAnonymous() || $entity->isPublished() && $operation === 'view') {

// after
if ($account->isAnonymous() || ($entity->isPublished() && $operation === 'view')) {
```

## 🛠️ Summary of Changes

- **Fix:** `inline_single_breaking_value_argument: true` in the Drupal preset. Applies only to a lone positional value-shaped argument with no surrounding comments, so multi-argument calls keep breaking normally — visible in the `drupal_preset` fixture, where an `addCommand(...)` call goes from a break *inside* a nested `format()` call to a clean one-argument-per-line list.
- **Fix:** `preserve_redundant_logical_binary_expression_parentheses: true` in the Drupal preset, with a new `drupal_preset_logical_parentheses` case covering inline conditions, an already-broken multi-line condition, and a `return` that has to break.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Same Drupal push as #2215, which teaches `mago init` to select this preset.

## 📝 Notes for Reviewers

- Both settings are preset-scoped; no other preset and no default changes.
- The `drupal_preset` fixture diff is the visible proof of the first change: three call sites collapse back onto one line and one multi-argument call formats better than before.
