### PR TITLE
fix(formatter): keep node stack balanced when method-chain-semicolon-on-next-line is enabled

### DIFF
--- a/crates/formatter/src/internal/format/mod.rs
+++ b/crates/formatter/src/internal/format/mod.rs
@@ -1212,11 +1212,10 @@ where
         wrap!(f, self, ExpressionStatement, {
             let expression = self.expression.format(f);
             let terminator = self.terminator.format(f);
-
             if let Some(chain_group_id) = f.take_member_access_chain_group_id()
                 && f.settings.method_chain_semicolon_on_next_line
             {
-                return Document::Array(vec_in![f.arena;
+                Document::Array(vec_in![f.arena;
                     expression,
                     Document::IfBreak(
                         IfBreak::new(
@@ -1226,10 +1225,10 @@ where
                         )
                         .with_id(chain_group_id),
                     ),
-                ]);
+                ])
+            } else {
+                Document::Array(vec_in![f.arena; expression, terminator])
             }
-
-            Document::Array(vec_in![f.arena; expression, terminator])
         })
     }
 }
@@ -1449,12 +1448,12 @@ where
                     .with_id(chain_group_id),
                 ));
 
-                return Document::Group(Group::new(contents).with_id(chain_group_id));
+                Document::Group(Group::new(contents).with_id(chain_group_id))
+            } else {
+                contents.push(terminator);
+
+                Document::Group(Group::new(contents))
             }
-
-            contents.push(terminator);
-
-            Document::Group(Group::new(contents))
         })
     }
 }

--- a/crates/formatter/tests/cases/issue_2150/after.php
+++ b/crates/formatter/tests/cases/issue_2150/after.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+class Foo
+{
+    public function printSomething(bool $bool): void
+    {
+        if ($bool) {
+            $bar = new Bar()
+                ->setTest1('test1')
+                ->setTest2('test2')
+            ;
+
+            echo $bar->getTest1();
+        } else {
+            $bar = new Bar()
+                ->setTest1('test1')
+                ->setTest2('test2')
+            ;
+
+            echo $bar->getTest2();
+        }
+    }
+
+    public function other(int $b): void
+    {
+        if ($b === 1) {
+            $x = new Bar()
+                ->setTest1('a')
+                ->setTest2('b')
+            ;
+        } elseif ($b === 2) {
+            $x = new Bar()->setTest1('c');
+        } else {
+            $x = new Bar()->setTest2('d');
+        }
+    }
+}

--- a/crates/formatter/tests/cases/issue_2150/before.php
+++ b/crates/formatter/tests/cases/issue_2150/before.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+class Foo
+{
+    public function printSomething(bool $bool): void
+    {
+        if ($bool) {
+            $bar = (new Bar())
+                ->setTest1('test1')
+                ->setTest2('test2')
+            ;
+
+            echo $bar->getTest1();
+        } else {
+            $bar = (new Bar())
+                ->setTest1('test1')
+                ->setTest2('test2')
+            ;
+
+            echo $bar->getTest2();
+        }
+    }
+
+    public function other(int $b): void
+    {
+        if ($b === 1) {
+            $x = (new Bar())
+                ->setTest1('a')
+                ->setTest2('b')
+            ;
+        } elseif ($b === 2) {
+            $x = (new Bar())
+                ->setTest1('c')
+            ;
+        } else {
+            $x = (new Bar())
+                ->setTest2('d')
+            ;
+        }
+    }
+}

--- a/crates/formatter/tests/cases/issue_2150/settings.inc
+++ b/crates/formatter/tests/cases/issue_2150/settings.inc
@@ -1,0 +1,4 @@
+FormatSettings {
+    method_chain_semicolon_on_next_line: true,
+    ..Default::default()
+}

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -477,6 +477,7 @@ test_case!(member_access_chain_keeps_breaks_with_comments);
 test_case!(issue_1562);
 test_case!(bare_cr_line_endings);
 test_case!(table_style_tiny_print_width);
+test_case!(issue_2150);
 
 // PHP identifiers may contain non-UTF-8 bytes; the formatter must round-trip
 // `before.php`/`after.php` byte-for-byte without lossy decoding.


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes #2150.

When `method-chain-semicolon-on-next-line = true`, `mago fmt` removed the space between the closing `}` of an `if`/`elseif` body and the following `else`/`elseif` keyword whenever the body contained a multi-line method chain:

```diff
-        }else {
+        } else {
```

## 🔍 Context & Motivation

The `wrap!` macro pushes the current node onto the formatter's node stack on entry and pops it via `leave_node()` at the end. Both `ExpressionStatement::format()` and `Return::format()` used an early `return Document::…` **inside** their `wrap!` block for the `method_chain_semicolon_on_next_line` branch. An early return exits the function before the macro tail runs, so `leave_node()` was skipped and the node leaked onto the stack.

The stack stayed shifted for the rest of the file, so every later `f.current_node()` call saw the wrong node. In particular, `adjust_clause()` (`misc.rs`) relies on `current_node() == IfStatementBody` to detect a trailing `else`/`elseif` clause and emit the separating space; with the corrupted stack it concluded there was no trailing clause and dropped the space.

## 🛠️ Summary of Changes

- **Fix:** replaced both early returns with plain `if/else` expressions so that `wrap!`'s `leave_node()` always executes — in `ExpressionStatement::format()` and `Return::format()` (`crates/formatter/src/internal/format/mod.rs`).
- **Regression test:** new `issue_2150` fixture (`crates/formatter/tests/cases/issue_2150/`) covering an `if`/`else` whose bodies contain broken method chains with a trailing semicolon line.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Fixes #2150.

## 📝 Notes for Reviewers

- The bug only manifests with `method-chain-semicolon-on-next-line = true`; default settings are unaffected, which is why no existing fixture caught it.
- The leaked node shifted the formatter's node stack until the end of the file, so the visible symptom (missing space before `else`) can appear far away from the chain statement that triggered it.
- Full formatter suite green (452 tests) and whole-workspace test suite green; `cargo fmt --check` and `cargo clippy -p mago-formatter --all-targets` clean.