### PR TITLE
refactor(analyzer): extract effective_write_visibility()

### DIFF
--- a/crates/analyzer/src/resolver/property.rs
+++ b/crates/analyzer/src/resolver/property.rs
@@ -24,8 +24,6 @@ use mago_codex::ttype::get_mixed;
 use mago_codex::ttype::template::TemplateResult;
 use mago_codex::ttype::template::inferred_type_replacer;
 use mago_codex::ttype::union::TUnion;
-use mago_codex::visibility::Visibility;
-use mago_php_version::feature::Feature;
 use mago_reporting::Annotation;
 use mago_reporting::Issue;
 use mago_span::HasSpan;
@@ -51,6 +49,7 @@ use crate::utils::names::display_class_like_name;
 use crate::utils::template::get_template_types_for_class_member;
 use crate::visibility::check_resolved_property_read_visibility;
 use crate::visibility::check_resolved_property_write_visibility;
+use crate::visibility::effective_write_visibility;
 use crate::visibility::is_visible_from_scope;
 
 /// Represents a successfully resolved instance property.
@@ -1147,18 +1146,7 @@ where
             return false;
         }
 
-        let visibility = if property.flags.is_readonly() {
-            if context.settings.version.is_supported(Feature::AsymmetricVisibility) {
-                match property.write_visibility {
-                    Visibility::Public => Visibility::Protected,
-                    visibility => visibility,
-                }
-            } else {
-                Visibility::Private
-            }
-        } else {
-            property.write_visibility
-        };
+        let visibility = effective_write_visibility(property, context.settings.version);
 
         return is_visible_from_scope(
             context.codebase,

--- a/crates/analyzer/src/visibility/mod.rs
+++ b/crates/analyzer/src/visibility/mod.rs
@@ -3,7 +3,9 @@ use mago_word::Word;
 use mago_word::word;
 
 use mago_codex::metadata::CodebaseMetadata;
+use mago_codex::metadata::property::PropertyMetadata;
 use mago_codex::visibility::Visibility;
+use mago_php_version::PHPVersion;
 use mago_php_version::feature::Feature;
 use mago_reporting::Annotation;
 use mago_reporting::Issue;
@@ -312,18 +314,7 @@ where
         return false;
     }
 
-    let visibility = if property_metadata.flags.is_readonly() {
-        if context.settings.version.is_supported(Feature::AsymmetricVisibility) {
-            match property_metadata.write_visibility {
-                Visibility::Public => Visibility::Protected,
-                visibility => visibility,
-            }
-        } else {
-            Visibility::Private
-        }
-    } else {
-        property_metadata.write_visibility
-    };
+    let visibility = effective_write_visibility(property_metadata, context.settings.version);
 
     let is_visible = is_visible_from_scope(
         context.codebase,
@@ -355,6 +346,23 @@ where
     }
 
     is_visible
+}
+
+/// The visibility that governs writes to `property`, which is narrower than the
+/// declared write visibility for `readonly` properties.
+pub(crate) fn effective_write_visibility(property: &PropertyMetadata, version: PHPVersion) -> Visibility {
+    if !property.flags.is_readonly() {
+        return property.write_visibility;
+    }
+
+    if !version.is_supported(Feature::AsymmetricVisibility) {
+        return Visibility::Private;
+    }
+
+    match property.write_visibility {
+        Visibility::Public => Visibility::Protected,
+        visibility => visibility,
+    }
 }
 
 pub(crate) fn is_visible_from_scope(


### PR DESCRIPTION
# 📌 What Does This PR Do?

Deduplicates the `readonly` write-visibility rule into a single shared
helper.

## 🔍 Context & Motivation

The narrower write scope that `readonly` imposes on a property is
computed identically in the property write visibility check and in the
descendant property accessibility check, so any change to the rule has to
be mirrored in both places. Pull that computation into one function both
call sites use. No behavioral change.

## 📂 Affected Areas

- [x] Other (please specify): Analyzer