### PR TITLE
fix(formatter): honor method-chain-semicolon-on-next-line for embedded chains

### DIFF
--- a/crates/formatter/src/internal/format/member_access.rs
+++ b/crates/formatter/src/internal/format/member_access.rs
@@ -27,6 +27,7 @@ use crate::document::Group;
 use crate::document::IndentIfBreak;
 use crate::document::Line;
 use crate::internal::FormatterState;
+use crate::internal::MemberAccessChainContext;
 use crate::internal::format::Format;
 use crate::internal::format::call_arguments::print_argument_list;
 use crate::internal::format::call_arguments::promote_argument_list_to_partial;
@@ -922,8 +923,8 @@ where
         parts.push(Document::BreakParent);
     }
 
-    if matches!(f.parent_node(), Node::ExpressionStatement(_) | Node::Assignment(_) | Node::Return(_)) {
-        f.set_member_access_chain_group_id(group_id);
+    if f.terminates_statement_from_parent() {
+        f.set_member_access_chain_context(MemberAccessChainContext { group_id, must_break });
     }
 
     // Wrap everything in a group to manage line breaking

--- a/crates/formatter/src/internal/format/mod.rs
+++ b/crates/formatter/src/internal/format/mod.rs
@@ -1213,19 +1213,21 @@ where
             let expression = self.expression.format(f);
             let terminator = self.terminator.format(f);
 
-            if let Some(chain_group_id) = f.take_member_access_chain_group_id()
+            if let Some(chain) = f.take_member_access_chain_context()
                 && f.settings.method_chain_semicolon_on_next_line
             {
+                let semicolon = Document::Array(vec_in![f.arena;
+                    Document::Line(Line::hard()),
+                    Document::String(b";"),
+                ]);
+
                 return Document::Array(vec_in![f.arena;
                     expression,
-                    Document::IfBreak(
-                        IfBreak::new(
-                            f.arena,
-                            Document::Array(vec_in![f.arena; Document::Line(Line::hard()), Document::String(b";")]),
-                            terminator,
-                        )
-                        .with_id(chain_group_id),
-                    ),
+                    if chain.must_break {
+                        semicolon
+                    } else {
+                        Document::IfBreak(IfBreak::new(f.arena, semicolon, terminator).with_id(chain.group_id))
+                    },
                 ]);
             }
 
@@ -1437,19 +1439,21 @@ where
 
             let terminator = self.terminator.format(f);
 
-            if let Some(chain_group_id) = f.take_member_access_chain_group_id()
+            if let Some(chain) = f.take_member_access_chain_context()
                 && f.settings.method_chain_semicolon_on_next_line
             {
-                contents.push(Document::IfBreak(
-                    IfBreak::new(
-                        f.arena,
-                        Document::Array(vec_in![f.arena; Document::Line(Line::hard()), Document::String(b";")]),
-                        terminator,
-                    )
-                    .with_id(chain_group_id),
-                ));
+                let semicolon = Document::Array(vec_in![f.arena;
+                    Document::Line(Line::hard()),
+                    Document::String(b";"),
+                ]);
 
-                return Document::Group(Group::new(contents).with_id(chain_group_id));
+                contents.push(if chain.must_break {
+                    semicolon
+                } else {
+                    Document::IfBreak(IfBreak::new(f.arena, semicolon, terminator).with_id(chain.group_id))
+                });
+
+                return Document::Group(Group::new(contents).with_id(chain.group_id));
             }
 
             contents.push(terminator);

--- a/crates/formatter/src/internal/mod.rs
+++ b/crates/formatter/src/internal/mod.rs
@@ -104,6 +104,16 @@ where
     (regions.leak(), next_markers.leak())
 }
 
+/// Context about a formatted member access chain that terminates an expression statement,
+/// an assignment or a return statement.
+#[derive(Debug, Clone, Copy)]
+pub struct MemberAccessChainContext {
+    /// The identifier of the group wrapping the chain, for `IfBreak` resolution.
+    pub(crate) group_id: GroupIdentifier,
+    /// Whether the chain is guaranteed to be printed across multiple lines.
+    pub(crate) must_break: bool,
+}
+
 #[derive(Debug)]
 pub struct FormatterState<'ctx, 'arena, A>
 where
@@ -133,7 +143,7 @@ where
     is_in_aligned_assignment_rhs: bool,
     halted_compilation: bool,
     alignment_context: Option<AssignmentAlignment>,
-    member_access_chain_group_id: Option<GroupIdentifier>,
+    member_access_chain_context: Option<MemberAccessChainContext>,
 }
 
 impl<'ctx, 'arena, A> FormatterState<'ctx, 'arena, A>
@@ -185,7 +195,7 @@ where
             halted_compilation: false,
             in_script_terminating_statement: false,
             alignment_context: None,
-            member_access_chain_group_id: None,
+            member_access_chain_context: None,
         }
     }
 
@@ -219,16 +229,16 @@ where
         self.all_comments
     }
 
-    /// Take the member access chain group ID, resetting it to None.
+    /// Take the member access chain context, resetting it to `None`.
     #[inline]
-    pub(crate) fn take_member_access_chain_group_id(&mut self) -> Option<GroupIdentifier> {
-        self.member_access_chain_group_id.take()
+    pub(crate) fn take_member_access_chain_context(&mut self) -> Option<MemberAccessChainContext> {
+        self.member_access_chain_context.take()
     }
 
-    /// Set the member access chain group ID.
+    /// Set the member access chain context.
     #[inline]
-    pub(crate) fn set_member_access_chain_group_id(&mut self, id: GroupIdentifier) {
-        self.member_access_chain_group_id = Some(id);
+    pub(crate) fn set_member_access_chain_context(&mut self, context: MemberAccessChainContext) {
+        self.member_access_chain_context = Some(context);
     }
 
     fn next_id(&mut self) -> GroupIdentifier {
@@ -274,6 +284,29 @@ where
         let len = self.stack.len();
 
         (len > n).then(|| self.stack[len - n - 1])
+    }
+
+    /// Walks up from the immediate parent through expression nodes that never own a
+    /// statement terminator (parentheses, unary operators/casts, binary operations) to
+    /// determine whether this node terminates an expression statement, an assignment
+    /// or a return statement.
+    ///
+    /// For example, in `return $this->foo()->bar() > 0;` the member access chain does
+    /// not have the return statement as its direct parent, but this still returns
+    /// `true`.
+    #[inline]
+    pub(crate) fn terminates_statement_from_parent(&self) -> bool {
+        let len = self.stack.len();
+
+        for i in (0..len.saturating_sub(1)).rev() {
+            match &self.stack[i] {
+                Node::ExpressionStatement(_) | Node::Assignment(_) | Node::Return(_) => return true,
+                Node::Expression(_) | Node::Binary(_) | Node::Parenthesized(_) | Node::UnaryPrefix(_) => {}
+                _ => return false,
+            }
+        }
+
+        false
     }
 
     #[inline]

--- a/crates/formatter/tests/cases/method_chain_semicolon_embedded_expression/after.php
+++ b/crates/formatter/tests/cases/method_chain_semicolon_embedded_expression/after.php
@@ -1,0 +1,22 @@
+<?php
+
+class C
+{
+    public function hasGames(array $team): bool
+    {
+        return $this->getEntityManager()
+            ->getRepository(Game::class)
+            ->createQueryBuilder('game')
+            ->select('COUNT(game.id)')
+            ->getQuery()
+            ->getSingleScalarResult() > 0
+        ;
+    }
+
+    public function slug(string $value): string
+    {
+        return (string) new AsciiSlugger()->slug($value ?? '')
+            ->lower()
+        ;
+    }
+}

--- a/crates/formatter/tests/cases/method_chain_semicolon_embedded_expression/before.php
+++ b/crates/formatter/tests/cases/method_chain_semicolon_embedded_expression/before.php
@@ -1,0 +1,21 @@
+<?php
+
+class C
+{
+    public function hasGames(array $team): bool
+    {
+        return $this->getEntityManager()->getRepository(Game::class)
+            ->createQueryBuilder('game')
+            ->select('COUNT(game.id)')
+            ->getQuery()
+            ->getSingleScalarResult() > 0
+        ;
+    }
+
+    public function slug(string $value): string
+    {
+        return (string) new AsciiSlugger()->slug($value ?? '')
+            ->lower()
+        ;
+    }
+}

--- a/crates/formatter/tests/cases/method_chain_semicolon_embedded_expression/settings.inc
+++ b/crates/formatter/tests/cases/method_chain_semicolon_embedded_expression/settings.inc
@@ -1,0 +1,6 @@
+FormatSettings {
+    method_chain_breaking_style: MethodChainBreakingStyle::SameLine,
+    first_method_chain_on_new_line: false,
+    method_chain_semicolon_on_next_line: true,
+    ..Default::default()
+}

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -193,6 +193,7 @@ test_case!(binary_alignment_before_op);
 test_case!(chain_comments);
 test_case!(literal_concat_parens);
 test_case!(method_chain_semicolon_group_scope);
+test_case!(method_chain_semicolon_embedded_expression);
 test_case!(method_chain_semicolon_group_scope_same_line_first_break);
 test_case!(preserve_breaking_member_access_chain);
 test_case!(preserve_breaking_member_access_chain_same_line_first_break);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes `method-chain-semicolon-on-next-line = true` being ignored when the broken method chain is embedded in a larger expression — comparison operand, cast + `new` receiver, parentheses. A *pure* chain statement (`return $chain->a()->b();`) already worked; the option silently fell back to a glued semicolon as soon as something wrapped the chain.

### Comparison operand

Input:

```php
return $this->getEntityManager()->getRepository(Game::class)
    ->createQueryBuilder('game')
    ->select('COUNT(game.id)')
    ->getQuery()
    ->getSingleScalarResult() > 0
;
```

On `main` with the option enabled, the chain is re-broken after its first access (`->getRepository(Game::class)` moves down — that is the regular chain-breaking rule of one inlined access, untouched by this PR), but the semicolon stays glued to the last line:

```php
return $this->getEntityManager()
    ->getRepository(Game::class)
    ->createQueryBuilder('game')
    ->select('COUNT(game.id)')
    ->getQuery()
    ->getSingleScalarResult() > 0;   // glued, option ignored
```

With this PR:

```php
return $this->getEntityManager()
    ->getRepository(Game::class)
    ->createQueryBuilder('game')
    ->select('COUNT(game.id)')
    ->getQuery()
    ->getSingleScalarResult() > 0
;                                      // dangling, as configured
```

### Cast + `new` receiver

Input:

```php
return (string) new AsciiSlugger()->toto()->slug($value ?? '')->lower();
```

On `main`, same story: the regular chain-breaking rule already moves everything after the first access (`->slug(...)` and `->lower()`) onto their own lines, but the semicolon stays glued:

```php
return (string) new AsciiSlugger()->toto()
    ->slug($value ?? '')
    ->lower();   // glued, option ignored
```

With this PR:

```php
return (string) new AsciiSlugger()->toto()
    ->slug($value ?? '')
    ->lower()
;   // dangling, as configured
```

Chains that fit on a single line still collapse with a glued semicolon; only chains that remain multi-line are affected.

## 🔍 Context & Motivation

The dangling-semicolon document is emitted by `ExpressionStatement`/`Return` from a chain context registered in `print_member_access_chain()`. That context was only set when the chain's **direct** parent was an expression statement, assignment or `return`, so any chain wrapped in e.g. a `Binary` (`... > 0`) or a cast (`(string) new X()->slug()->lower()`) silently fell back to the glued semicolon.

A second coupling: for chains wrapped in a binary expression, `BreakParent` propagation is deliberately suppressed, so the printer can record the chain group's mode as flat even when the chain prints across multiple lines (hard lines). An `IfBreak` bound to the chain group id therefore cannot fire reliably for those chains.

## 🛠️ Summary of Changes

- **Formatter:** new `FormatterState::terminates_statement_from_parent()` (`crates/formatter/src/internal/mod.rs`) that walks up the ancestor stack through expression nodes that never own a terminator (`Expression`, `Binary`, `Parenthesized`, `UnaryPrefix`) to detect that the chain terminates an expression statement / assignment / return.
- **Formatter:** the chain context now also records whether the chain is guaranteed to break (`must_break`). When it is, the statement emits the dangling semicolon unconditionally instead of relying on `IfBreak`; fits-driven chains keep the existing `IfBreak` behavior unchanged (`crates/formatter/src/internal/format/member_access.rs`, `mod.rs`).
- **Tests:** new fixture `method_chain_semicolon_embedded_expression` covering both reproducers (comparison operand and cast + `new` receiver); the harness also re-formats the output to assert idempotency.
- No setting, preset or documentation change: this only makes the existing option work as documented.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Distinct from #2150/#2237 and #843/#2243 (same family of php-cs-fixer alignment gaps, different mechanism).

## 📝 Notes for Reviewers

- Default settings and all other option combinations are unaffected: no layout changes outside `method-chain-semicolon-on-next-line = true`.
- Full `mago-formatter` suite green (452 + 53 tests), verified end-to-end with `mago format` on the original reproducers; `cargo fmt --check` and `cargo clippy -p mago-formatter --all-targets` clean.