### PR TITLE
fix(formatter): avoid wrapping expandable arrow binary bodies

### DIFF
--- a/crates/formatter/src/internal/format/return_value.rs
+++ b/crates/formatter/src/internal/format/return_value.rs
@@ -2,6 +2,7 @@ use mago_allocator::Arena;
 use mago_allocator::vec_in;
 use mago_span::HasSpan;
 use mago_syntax::cst::Expression;
+use mago_syntax::cst::Node;
 
 use crate::document::Document;
 use crate::document::Group;
@@ -102,6 +103,13 @@ where
 {
     match value {
         Expression::Binary(binary) => {
+            if matches!(f.current_node(), Node::ArrowFunction(_))
+                && is_expandable_expression(binary.lhs, false)
+                && is_expandable_expression(binary.rhs, true)
+            {
+                return false;
+            }
+
             if is_simple_expression_or_binary(f, binary.lhs) && is_expandable_expression(binary.rhs, true) {
                 return false;
             }

--- a/crates/formatter/tests/cases/arrow_function_binary_array_body/after.php
+++ b/crates/formatter/tests/cases/arrow_function_binary_array_body/after.php
@@ -1,0 +1,10 @@
+<?php
+
+usort(
+    $records,
+    static fn(array $a, array $b): int => [
+        $a['x'],
+    ] <=> [
+        $b['x'],
+    ],
+);

--- a/crates/formatter/tests/cases/arrow_function_binary_array_body/before.php
+++ b/crates/formatter/tests/cases/arrow_function_binary_array_body/before.php
@@ -1,0 +1,7 @@
+<?php
+
+usort($records, static fn (array $a, array $b): int => [
+    $a['x'],
+] <=> [
+    $b['x'],
+]);

--- a/crates/formatter/tests/cases/arrow_function_binary_array_body/settings.inc
+++ b/crates/formatter/tests/cases/arrow_function_binary_array_body/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings::default()

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -181,6 +181,7 @@ test_case!(next_line_chain_property_receiver_unchanged);
 test_case!(return_wrapping);
 test_case!(shebang);
 test_case!(arrow_return);
+test_case!(arrow_function_binary_array_body);
 test_case!(match_breaking);
 test_case!(array_alignment);
 test_case!(align_parameters);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes broken binary expressions in arrow-function bodies being wrapped in redundant parentheses when both operands are expandable expressions, such as array literals.

Array comparison body:

```diff
 usort(
     $records,
-    static fn(array $a, array $b): int => (
-        [
-            $a['x'],
-        ] <=> [
-            $b['x'],
-        ]
-    ),
+    static fn(array $a, array $b): int => [
+        $a['x'],
+    ] <=> [
+        $b['x'],
+    ],
 );
```

The binary expression keeps its natural multi-line layout without an extra `(...)` layer. Return statements, conditional arrow-function bodies, and binary bodies without two expandable operands keep their existing behavior.

## 🔍 Context & Motivation

`format_return_value()` formats both `return` values and arrow-function bodies. Its binary-expression heuristic already avoids wrapping when one operand is expandable and the other is simple, but two expandable operands fell through to the wrapping path. Because both array documents contain hard line breaks, the surrounding `IfBreak` group always emitted parentheses.

Arrow functions already delimit their body after `=>`, and two independently expandable operands provide their own stable multi-line structure. The outer parentheses add indentation and diff noise without clarifying the expression.

## 🛠️ Summary of Changes

- **Formatter:** `should_wrap_return_value()` now detects arrow-function context and skips conditional wrapping when both binary operands are expandable (`crates/formatter/src/internal/format/return_value.rs`).
- **Tests:** new `arrow_function_binary_array_body` fixture covers the original array-literal comparison and verifies idempotency through the formatter harness.
- No setting or documentation change: this narrows an existing wrapping heuristic only for expandable binary arrow-function bodies.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Related to #843/#2243, which control wrapping for `return` statements. Distinct from #2244, which fixes dangling semicolons on embedded method chains.

## 📝 Notes for Reviewers

- Existing wrapping for complex logical arrow-function bodies remains covered by `arrow_return` and is unchanged.
- `mago-formatter` suite green (505 tests); `cargo fmt --check` and `cargo clippy -p mago-formatter --all-targets` clean.
- Verified end-to-end with `mago format --stdin-input` on the original reproducer.
