### PR TITLE
fix(analyzer): narrow types through error-suppressed conditions

### DIFF
--- a/crates/analyzer/src/utils/misc.rs
+++ b/crates/analyzer/src/utils/misc.rs
@@ -11,6 +11,8 @@ use mago_reporting::Annotation;
 use mago_reporting::Issue;
 use mago_span::Span;
 use mago_syntax::cst::Expression;
+use mago_syntax::cst::UnaryPrefix;
+use mago_syntax::cst::UnaryPrefixOperator;
 
 use crate::code::IssueCode;
 
@@ -148,6 +150,10 @@ fn report_paradoxical_condition<A>(
 pub const fn unwrap_expression<'ast, 'arena>(expression: &'ast Expression<'arena>) -> &'ast Expression<'arena> {
     match expression {
         Expression::Parenthesized(parenthesized) => unwrap_expression(parenthesized.expression),
+        // `@` only suppresses diagnostics; it yields the operand's value unchanged.
+        Expression::UnaryPrefix(UnaryPrefix { operator: UnaryPrefixOperator::ErrorControl(_), operand }) => {
+            unwrap_expression(operand)
+        }
         _ => expression,
     }
 }

--- a/crates/analyzer/tests/cases/error_suppressed_condition_narrowing.php
+++ b/crates/analyzer/tests/cases/error_suppressed_condition_narrowing.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @param array<array-key, mixed> $values
+ */
+function suppressed_class_exists(array $values): void
+{
+    foreach ($values as $name => $_value) {
+        if (!is_string($name)) {
+            continue;
+        }
+
+        if (@class_exists($name)) {
+            takes_class_string($name);
+        }
+    }
+}
+
+function suppressed_is_string(mixed $value): string
+{
+    if (@is_string($value)) {
+        return $value;
+    }
+
+    return '';
+}
+
+function suppressed_negated_is_string(mixed $value): string
+{
+    if (!@is_string($value)) {
+        return '';
+    }
+
+    return $value;
+}
+
+/**
+ * @param class-string $class
+ */
+function takes_class_string(string $class): void
+{
+    echo $class;
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -577,6 +577,7 @@ test_case!(conditional_with_assignment);
 test_case!(conditional_nested);
 test_case!(elvis_operator_with_null);
 test_case!(elvis_operator_with_falsy_string);
+test_case!(error_suppressed_condition_narrowing);
 test_case!(short_ternary_with_truthy);
 test_case!(short_ternary_with_falsy);
 test_case!(conditional_type_narrowing);


### PR DESCRIPTION
fix(analyzer): narrow types through error-suppressed conditions

## 📌 What Does This PR Do?

Conditions wrapped in the error-suppression operator now narrow types
the same way unsuppressed ones do.

## 🔍 Context & Motivation

`@class_exists($name)` and friends currently contribute no assertions
at all, so the guarded value keeps its original type and every use of
it inside the branch is reported as an error. The operator only
silences diagnostics and yields its operand's value unchanged, so it
should be transparent here.

## 🛠️ Summary of Changes

- Type narrowing from a condition such as `if (@class_exists($name))`
  or `if (@is_string($value))` now applies inside the branch instead
  of being silently dropped.

## 📂 Affected Areas

- [x] Other (please specify): Analyzer