### PR TITLE
chore: collapse guard clauses flagged by nightly clippy

### DIFF
--- a/crates/analyzer/src/statement/class_like/initialization.rs
+++ b/crates/analyzer/src/statement/class_like/initialization.rs
@@ -560,11 +560,7 @@ where
         return true;
     }
 
-    if context.codebase.method_is_final(class_name.as_bytes(), method_name.as_bytes()) {
-        return true;
-    }
-
-    false
+    context.codebase.method_is_final(class_name.as_bytes(), method_name.as_bytes())
 }
 
 /// Check if parent class constructor initializes the required properties.

--- a/crates/codex/src/ttype/atomic/array/mod.rs
+++ b/crates/codex/src/ttype/atomic/array/mod.rs
@@ -256,13 +256,7 @@ impl TArray {
 
                 !keyed_array.non_empty
             }
-            Self::List(list) => {
-                if list.known_elements.is_none() && list.element_type.is_never() && !list.non_empty {
-                    return true;
-                }
-
-                false
-            }
+            Self::List(list) => list.known_elements.is_none() && list.element_type.is_never() && !list.non_empty,
         }
     }
 

--- a/crates/codex/src/ttype/comparator/array_comparator.rs
+++ b/crates/codex/src/ttype/comparator/array_comparator.rs
@@ -183,8 +183,8 @@ pub(crate) fn is_array_contained_by_array(
         return false;
     }
 
-    if !input_value_type.is_never()
-        && !union_comparator::is_contained_by(
+    input_value_type.is_never()
+        || union_comparator::is_contained_by(
             codebase,
             &input_value_type,
             &container_value_type,
@@ -193,11 +193,6 @@ pub(crate) fn is_array_contained_by_array(
             inside_assertion,
             atomic_comparison_result,
         )
-    {
-        return false;
-    }
-
-    true
 }
 
 #[cfg(test)]

--- a/crates/codex/src/ttype/comparator/atomic_comparator.rs
+++ b/crates/codex/src/ttype/comparator/atomic_comparator.rs
@@ -784,18 +784,14 @@ pub(crate) fn can_be_identical(
         };
     }
 
-    if matches!(
+    matches!(
         (first_part, second_part),
         (TAtomic::Object(_), TAtomic::Reference(TReference::Symbol { .. }))
             | (
                 TAtomic::Reference(TReference::Symbol { .. }),
                 TAtomic::Object(_) | TAtomic::Reference(TReference::Symbol { .. })
             )
-    ) {
-        return true;
-    }
-
-    false
+    )
 }
 
 /// Checks whether two string types can share at least one concrete value.

--- a/crates/collector/src/lib.rs
+++ b/crates/collector/src/lib.rs
@@ -639,11 +639,7 @@ where
                 return true;
             }
         }
-        if cursor < inner.len() && check_non_pragma_line(&inner[cursor..]) {
-            return true;
-        }
-
-        false
+        cursor < inner.len() && check_non_pragma_line(&inner[cursor..])
     }
 
     /// Computes a `TextEdit` to delete a single pragma directive line from within a multi-line comment.

--- a/crates/linter/src/rule/utils/security.rs
+++ b/crates/linter/src/rule/utils/security.rs
@@ -196,14 +196,9 @@ pub fn is_password(mut str: &[u8]) -> bool {
 
     let lower = str.to_ascii_lowercase();
 
-    if lower.ends_with(b"password")
+    lower.ends_with(b"password")
         || lower.ends_with(b"token")
         || lower.ends_with(b"secret")
         || lower.ends_with(b"apikey")
         || lower.ends_with(b"api_key")
-    {
-        return true;
-    }
-
-    false
 }


### PR DESCRIPTION
# 📌 What Does This PR Do?

Makes `cargo +nightly clippy` run clean again.

## 🔍 Context & Motivation

Nightly clippy's `needless_bool` now also fires on a trailing guard
clause whose body returns a bool literal and that is followed by the
opposite literal, which we have in six places across the analyzer,
codex, collector, and linter. Collapse each of them into its guard
condition.

## 🛠️ Summary of Changes

- **Refactor:** No user-visible change; internal lint cleanup only.

## 📂 Affected Areas

- [x] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): analyzer, codex, collector