### PR TITLE
fix(analyzer): stop unreachable coalesce rhs terminating control flow

### DIFF
--- a/crates/analyzer/src/expression/binary/null_coalesce.rs
+++ b/crates/analyzer/src/expression/binary/null_coalesce.rs
@@ -127,7 +127,12 @@ where
         );
 
         result_type = (**lhs_type).clone();
-        binary.rhs.analyze(context, block_context, artifacts)?;
+
+        // Analyze the unreachable right-hand side in a separate disposable context
+        // Prevents its terminating control flow and recorded thrown exceptions from affecting the remainder of the block
+        let mut dead_rhs_context = block_context.clone();
+        dead_rhs_context.flags.set_has_returned(true);
+        binary.rhs.analyze(context, &mut dead_rhs_context, artifacts)?;
     } else {
         let non_null_lhs_type = lhs_type.to_non_nullable();
         let has_returned = block_context.flags.has_returned();

--- a/crates/analyzer/tests/cases/flow_throw_in_redundant_coalesce.php
+++ b/crates/analyzer/tests/cases/flow_throw_in_redundant_coalesce.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+function flow_throw_in_redundant_coalesce(): string
+{
+    // @mago-expect analysis:redundant-null-coalesce
+    $checked = 'value' ?? throw new \OutOfBoundsException('missing');
+
+    return $checked;
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -1503,6 +1503,7 @@ test_case!(flow_try_multi_catch_pipe);
 test_case!(flow_try_finally_no_catch);
 test_case!(flow_throw_in_ternary);
 test_case!(flow_throw_in_coalesce);
+test_case!(flow_throw_in_redundant_coalesce);
 test_case!(flow_assert_narrow);
 test_case!(flow_assert_false_unreachable);
 test_case!(flow_eq_literal_string);


### PR DESCRIPTION
## 📌 What Does This PR Do?

Ensures code after a redundant null-coalesce whose right-hand side terminates is still analysed.

## 🔍 Context & Motivation

A redundant `??` whose right-hand side never returns incorrectly marks the rest of the enclosing block unreachable, producing false reports from that point on:

```php
// This correctly triggers `help[redundant-null-coalesce]: Redundant null coalesce: left-hand side can never be `null` or undefined.`
$value = 'value' ?? throw new RuntimeException('missing');

// This currently *incorrectly* triggers `help[unevaluated-code]: Unreachable code detected.`
echo $value;
```

[(Playground)](https://mago.carthage.software/1.47.4/en/playground/#01a043b9-7c0c-3717-fc22-2f6f79c10fcc)

This also means references to variables assigned in an unreachable right-hand side are now correctly detected as undefined since the unreachable right-hand side's assignment is discarded:

```php
// Correctly triggers `help[redundant-null-coalesce]`
$a = 'defined' ?? ($b = 'undefined');
// Currently raises no issues; will now correctly trigger `error[mixed-argument],error[undefined-variable]`
echo $b;
```

[(Playground)](https://mago.carthage.software/1.47.4/en/playground/#01a043b9-e7a5-08cc-8111-5cf26f972734)

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed analysis not continuing after a terminating unreachable null coalesce right-hand side.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Analyzer

## 🔗 Related Issues or PRs

N/A

## 📝 Notes for Reviewers

Test coverage added. The bug currently suppresses all analysis of statements after the coalesce, so merging this will start (correctly) flagging any previously-hidden issues in the affected code, like the undefined variable example above.