### PR TITLE
fix(analyzer): resolve parent constructor to declaration

### DIFF
--- a/crates/analyzer/src/statement/class_like/initialization.rs
+++ b/crates/analyzer/src/statement/class_like/initialization.rs
@@ -385,9 +385,16 @@ where
             && let Some(class_meta) = context.codebase.get_class_like(current_class.as_bytes())
             && let Some(parent_name) = &class_meta.direct_parent_class
             && let Some(parent_meta) = context.codebase.get_class_like(parent_name.as_bytes())
-            && parent_meta.declaring_method_ids.contains_key(&word("__construct"))
+            && let Some(method_id) = parent_meta.declaring_method_ids.get(&word("__construct"))
         {
-            work_queue.push((*parent_name, word("__construct"), parent_meta.flags.is_final(), false, origin_class));
+            // Find closest constructor-declaring ancestor
+            let declaring_class_name = method_id.get_class_name();
+            let declaring_class_is_final = context
+                .codebase
+                .get_class_like(declaring_class_name.as_bytes())
+                .is_some_and(|declaring_meta| declaring_meta.flags.is_final());
+
+            work_queue.push((declaring_class_name, word("__construct"), declaring_class_is_final, false, origin_class));
         }
 
         if let Some(parent_initializer_name) = artifacts.method_calls_parent_initializer.get(&method_key)

--- a/crates/analyzer/tests/cases/parent_constructor_init.php
+++ b/crates/analyzer/tests/cases/parent_constructor_init.php
@@ -250,3 +250,55 @@ class Level3 extends Level2
         $this->l3 = 'level3';
     }
 }
+
+abstract class ParentDeclaringConstructor
+{
+    public string $declared;
+
+    public function __construct()
+    {
+        $this->declared = 'declared';
+    }
+}
+
+// Declares no constructor, so `parent::__construct()` in subclasses resolves past it
+class MiddleWithoutConstructor extends ParentDeclaringConstructor
+{
+}
+
+class ChildCallsConstructorFromAncestor extends MiddleWithoutConstructor
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+}
+
+trait TraitDeclaringProperty
+{
+    public string $fromTrait;
+}
+
+// Concrete, but the property comes from a trait so it still needs initializing here
+class ParentUsingTrait
+{
+    use TraitDeclaringProperty;
+
+    public function __construct()
+    {
+        $this->fromTrait = 'trait';
+    }
+}
+
+// Declares no constructor, so `parent::__construct()` in subclasses resolves past it
+class TraitMiddleWithoutConstructor extends ParentUsingTrait
+{
+}
+
+class ChildCallsConstructorFromTraitAncestor extends TraitMiddleWithoutConstructor
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+}


### PR DESCRIPTION
## 📌 What Does This PR Do?

Ensures `parent::__construct()` calls are internally resolved to the ancestor which actually declares the constructor, rather than solely the direct parent. This is resolved through all intermediary ancestor classes to the closest declared constructor.

## 🔍 Context & Motivation

When checking property initialisation, a `parent::__construct()` call looks at the direct parent class. If that parent is itself a subclass but does not declare a constructor of its own then the actual ancestor constructor is never credited for initialisation so its properties are reported as uninitialised if that ancestor is abstract:

```php
abstract class Base
{
    protected bool $value;

    public function __construct(bool $value)
    {
        $this->value = $value;
    }
}

// This correctly does not trigger any error
final class DirectChild extends Base
{
}

abstract class Middle extends Base
{
}

// This currently incorrectly triggers 'Property `$value` is not initialized in the constructor of class `Grandchild`.'
final class Grandchild extends Middle
{
    public function __construct()
    {
        parent::__construct(true);
    }
}
```

_Requires `check-property-initialization = true`._

[(Playground)](https://mago.carthage.software/1.47.4/en/playground/#01a043cc-3931-c8c1-7941-883b5e05341b)

This bug also impacts properties declared in a trait and initialised in an ancestor's constructor. Note properties declared and initialised directly in concrete ancestor classes are correctly detected as initialised – only abstract class properties and trait properties are impacted.

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed `parent::__construct()` not being resolved past constructor-less intermediary classes.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Analyzer

## 🔗 Related Issues or PRs

N/A

## 📝 Notes for Reviewers

Test coverage added. The queued class's own `final` flag is also now used instead of the direct parent's, since that determines whether methods called by the constructor are trusted not to be overridden – the two only differ when a final class is extended, which is already rejected by PHP itself and reported via Mago's `extend-final-class`.