### PR TITLE
fix(analyzer): credit cross-file parent ctors with property initialization

### DIFF
--- a/cases/uninitialized_property_parent_constructor/analyzer.baseline.toml
+++ b/cases/uninitialized_property_parent_constructor/analyzer.baseline.toml
@@ -1,0 +1,3 @@
+variant = "strict"
+
+[entries]

--- a/cases/uninitialized_property_parent_constructor/linter.baseline.toml
+++ b/cases/uninitialized_property_parent_constructor/linter.baseline.toml
@@ -1,0 +1,3 @@
+variant = "strict"
+
+[entries]

--- a/cases/uninitialized_property_parent_constructor/mago.toml
+++ b/cases/uninitialized_property_parent_constructor/mago.toml
@@ -1,0 +1,13 @@
+extends = "../defaults.toml"
+
+php-version = "8.4"
+
+[source]
+paths = ["src"]
+includes = []
+
+[analyzer]
+check-property-initialization = true
+
+[linter.rules]
+file-name = { enabled = false }

--- a/cases/uninitialized_property_parent_constructor/src/Base.php
+++ b/cases/uninitialized_property_parent_constructor/src/Base.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UninitializedPropertyParentConstructor;
+
+abstract class Base
+{
+    protected bool $flag;
+
+    public function __construct(bool $flag)
+    {
+        $this->flag = $flag;
+    }
+}

--- a/cases/uninitialized_property_parent_constructor/src/InheritChild.php
+++ b/cases/uninitialized_property_parent_constructor/src/InheritChild.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UninitializedPropertyParentConstructor;
+
+/**
+ * Inherits the parent constructor unchanged.
+ */
+final class InheritChild extends Base {}

--- a/cases/uninitialized_property_parent_constructor/src/PassthroughChild.php
+++ b/cases/uninitialized_property_parent_constructor/src/PassthroughChild.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UninitializedPropertyParentConstructor;
+
+/**
+ * Declares a constructor that passes its own argument through to the parent constructor.
+ */
+final class PassthroughChild extends Base
+{
+    public function __construct(bool $flag)
+    {
+        parent::__construct($flag);
+    }
+}

--- a/cases/uninitialized_property_parent_constructor/src/SpecifyChild.php
+++ b/cases/uninitialized_property_parent_constructor/src/SpecifyChild.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UninitializedPropertyParentConstructor;
+
+/**
+ * Declares a constructor that supplies the parent constructor argument itself.
+ */
+final class SpecifyChild extends Base
+{
+    public function __construct()
+    {
+        parent::__construct(true);
+    }
+}

--- a/crates/analyzer/src/statement/class_like/initialization.rs
+++ b/crates/analyzer/src/statement/class_like/initialization.rs
@@ -363,6 +363,25 @@ where
                         }
                     }
                 }
+            } else if method == word("__construct")
+                && current_class != origin_class
+                && !context.codebase.method_is_abstract(current_class.as_bytes(), b"__construct")
+            {
+                // The constructor's body is in another file, so nothing was recorded for it here.
+                // Defer responsibility for initializing its class's properties to that constructor.
+                // A class that only inherits a constructor initializes nothing itself.
+                if let Some(current_meta) = context.codebase.get_class_like(current_class.as_bytes())
+                    && current_meta
+                        .declaring_method_ids
+                        .get(&word("__construct"))
+                        .is_some_and(|method_id| method_id.get_class_name() == current_class)
+                {
+                    for (prop_name, declaring_class) in &current_meta.declaring_property_ids {
+                        if *declaring_class == current_class {
+                            all_initialized.insert(*prop_name);
+                        }
+                    }
+                }
             }
 
             if let Some(called_methods) = artifacts.method_calls_this_methods.get(&method_key) {


### PR DESCRIPTION
## 📌 What Does This PR Do?

Credits a parent constructor declared in a different file with initialising the properties its own class declares.

## 🔍 Context & Motivation

A subclass that defines an overridden constructor which then calls its parent's constructor – where the parent is declared in a different file – will incorrectly trigger uninitialised property errors if the parent constructor initialises its own properties:

_(No Playground link can be provided as this reproduction requires multiple files.)_

```php
/* Base.php */

abstract class Base
{
    protected bool $value;

    public function __construct(bool $value)
    {
        $this->value = $value;
    }
}
```

```php
/* Child.php */

// This currently incorrectly triggers 'Property `$value` is not initialized in the constructor of class `Child`.'
final class Child extends Base
{
    public function __construct()
    {
        parent::__construct(true);
    }
}
```

_Requires `check-property-initialization = true`._

This is due to analysis artifacts currently being built per file, so a parent defined in a different file whose constructor initialises properties is considered equivalent to one that initialises nothing.

If both classes are in the same file the false positive is not triggered. Similarly if a subclass does not override the constructor then the issue is not triggered – in this instance [the analyser already "trusts" any unseen parent constructor when the subclass declares no constructor of its own](https://github.com/carthage-software/mago/blob/7ba104a272b980a892c5330d02e5cc446f784bbc/crates/analyzer/src/statement/class_like/initialization.rs#L569-L572). Only a subclass in a different file with an overridden constructor causes the issue, so this PR brings that same parent constructor trust to explicit `parent::__construct()` calls.

As the `uninitialized-property` issue is reported at the property declaration in the parent class, if the parent class is from a Composer package the issue is reported within `vendor/` so cannot be suppressed with `@mago-expect`, making it particularly frustrating.

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed inherited properties being reported as uninitialised when the initialising parent constructor is declared in another file.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): Analyzer

## 🔗 Related Issues or PRs

N/A

## 📝 Notes for Reviewers

Test coverage added – it is a multi-file integration case since this cannot be reproduced in the single-file analyser tests.

### Notable Caveat

This trades a common false positive for an obscure – but not impossible – false negative. By trusting the parent constructor without actually reviewing it then an abstract parent class whose own constructor leaves one of its own properties unset would not be detected when the subclass is in a separate file, declares its own constructor, and does not initialise the parent property.

All five of these conditions need to be met together for this false negative to occur:

1. The parent class declares a property but does not initialise it (if it initialises it then there is nothing to report).
2. The parent class is abstract (if concrete the issue will be triggered directly on it).
3. The parent and child classes are in separate files (if in the same file the parent class is analysed directly).
4. The subclass defines its own constructor (if not the pre-existing trusting takes place so while the issue is not detected that is the existing behaviour).
5. The subclass explicitly calls `parent::__construct(...)` in its constructor (if it does not call the parent's constructor then the issue is correctly triggered).

In all cases a subclass's own uninitialised properties are still correctly detected.

Fixing this edge case would require a much more fundamental and disruptive change, and would not be able to apply to Composer dependencies as vendor files are scanned but not analysed.

Note properties declared in traits are not impacted either way by this change – a trait property initialised by a parent constructor in a different file to the subclass is still falsely reported as uninitialised as [Mago attributes the property to the trait rather than the class using it](https://github.com/carthage-software/mago/blob/7ba104a272b980a892c5330d02e5cc446f784bbc/crates/codex/src/populator/properties.rs#L37-L52). That is a pre-existing issue out of scope for this PR.

<details>
<summary>Reproduction of the false negative</summary>

```php
/* Base.php */

abstract class Base
{
    protected bool $unset;

    public function __construct()
    {
        // Never assigns $unset.
    }
}
```

```php
/* Child.php */

final class Child extends Base
{
    public function __construct()
    {
        parent::__construct();
    }
}
```

**Before this PR:** `Base.php:_:_: error[uninitialized-property]: Property `$unset` is not initialized in the constructor of class 'Child'.`

**After this PR:** No issue reported. `Child::$unset` is never assigned, so reading it throws an `Error` at runtime.

Any of the following restores detection:
- Making `Base` non-abstract
- Moving both classes into the same file
- Removing `Child`'s constructor
- Removing the `parent::__construct()` call
</details>