### PR TITLE
fix(analyzer): resolve callable strings with a leading backslash

### DIFF
--- a/crates/analyzer/tests/cases/callable_string_leading_backslash.php
+++ b/crates/analyzer/tests/cases/callable_string_leading_backslash.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Callables;
+
+function shout(string $value): string
+{
+    return $value . '!';
+}
+
+final class Formatter
+{
+    public static function format(string $value): string
+    {
+        return $value;
+    }
+}
+
+function accept(?callable $callback): void
+{
+    if (null !== $callback) {
+        $callback('x');
+    }
+}
+
+/** @param callable(string): string $callback */
+function apply(callable $callback, string $input): string
+{
+    return $callback($input);
+}
+
+function takes_int(int $_i): void {}
+
+// A fully qualified callable string resolves like its unqualified form.
+accept('trim');
+accept('\trim');
+accept('Fixtures\Callables\shout');
+accept('\Fixtures\Callables\shout');
+accept('Fixtures\Callables\Formatter::format');
+accept('\Fixtures\Callables\Formatter::format');
+accept(['Fixtures\Callables\Formatter', 'format']);
+accept(['\Fixtures\Callables\Formatter', 'format']);
+
+echo apply('\strtoupper', 'a');
+echo apply('\Fixtures\Callables\shout', 'a');
+echo apply('\Fixtures\Callables\Formatter::format', 'a');
+echo apply(['\Fixtures\Callables\Formatter', 'format'], 'a');
+
+// The alias is truly resolved, so the return type is known.
+function test_return_type_of_qualified_callable_string(): void
+{
+    $fn = '\strtoupper';
+
+    /** @mago-expect analysis:invalid-argument */
+    takes_int($fn('a'));
+}
+
+function test_invalid_callable_string(): void
+{
+    $fn = '\strouper';
+
+    /** @mago-expect analysis:mixed-argument,non-existent-function */
+    takes_int($fn('a'));
+}
+
+function test_empty_callable_string(): void
+{
+    $fn = '';
+
+    /** @mago-expect analysis:mixed-argument,non-existent-function */
+    takes_int($fn('a'));
+}
+
+function test_empty_qualified_callable_string(): void
+{
+    $fn = '\\';
+
+    /** @mago-expect analysis:mixed-argument,non-existent-function */
+    takes_int($fn('a'));
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -956,6 +956,7 @@ test_case!(parent_static_call_template_resolution);
 test_case!(bitwise_shift_bounds);
 test_case!(isset_after_loop_break);
 test_case!(callable_string);
+test_case!(callable_string_leading_backslash);
 test_case!(session_set_save_handler);
 test_case!(session_set_cookie_params);
 test_case!(psl_math);

--- a/crates/codex/src/ttype/cast.rs
+++ b/crates/codex/src/ttype/cast.rs
@@ -47,6 +47,8 @@ pub fn cast_atomic_to_callable<'atomic>(
     }
 
     if let Some(literal_string) = atomic.get_literal_string_value() {
+        let literal_string = strip_root_separator(literal_string);
+
         // Check if this is a static method callable in the format "ClassName::methodName"
         if let Some(idx) = memchr::memmem::find(literal_string, b"::") {
             let (class_part, rest) = literal_string.split_at(idx);
@@ -111,6 +113,12 @@ pub fn cast_atomic_to_callable<'atomic>(
     None
 }
 
+/// Strips the leading root namespace separator PHP allows in callable strings,
+/// which always name a fully qualified function-like or class.
+fn strip_root_separator(name: &[u8]) -> &[u8] {
+    name.strip_prefix(b"\\").unwrap_or(name)
+}
+
 fn handle_array_callable(
     known_elements: &BTreeMap<usize, (bool, TUnion)>,
     codebase: &CodebaseMetadata,
@@ -131,7 +139,10 @@ fn handle_array_callable(
 
     // Check if the first element is a literal string (e.g., 'ClassName')
     if let Some(class_name) = class_or_object.get_literal_string_value() {
-        return Some(Cow::Owned(TCallable::Alias(FunctionLikeIdentifier::Method(word(class_name), method_name))));
+        return Some(Cow::Owned(TCallable::Alias(FunctionLikeIdentifier::Method(
+            word(strip_root_separator(class_name)),
+            method_name,
+        ))));
     }
 
     // Check if the first element is a class-string literal (e.g., ClassName::class)


### PR DESCRIPTION
## 📌 What Does This PR Do?

Makes a callable string spelled with the root namespace separator
(`'\trim'`, `'\Psl\Str\trim'`, `['\Foo\Bar', 'method']`) resolve to the
same function-like as the form without it.

## 🔍 Context & Motivation

A callable string is never namespace-relative, so PHP treats both
spellings identically. We keep the separator when building the
identifier, the lookup misses, and the value stays an unresolved
`callable` — reported as a false `possibly-invalid-argument` wherever a
more specific callable is expected. Attribute argument validation in
1.46.0 made this widespread: one `#[NotBlank(normalizer: '\Psl\Str\trim')]`
pattern produced 78 errors across 34 files in a Symfony codebase.

## 🛠️ Summary of Changes

- **Bug Fix:** Strip the root separator before resolving a callable
  string or an array callable's class name.

## 📂 Affected Areas

- [x] Other (please specify): Codex / Analyzer

## 🔗 Related Issues or PRs

Fixes #2274