### PR TITLE
fix(prelude): model how class probes treat string subjects

### DIFF
--- a/crates/analyzer/tests/cases/class_probe_allow_string_result.php
+++ b/crates/analyzer/tests/cases/class_probe_allow_string_result.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+interface ProbeTarget {}
+
+function accepts_plain_strings(string $s): void
+{
+    if (is_a($s, ProbeTarget::class, true)) {
+        echo 'a';
+    }
+
+    if (is_subclass_of($s, ProbeTarget::class)) {
+        echo 'b';
+    }
+
+    if (method_exists($s, 'probe')) {
+        echo 'c';
+    }
+}
+
+function knows_the_result_when_strings_are_disallowed(string $s): void
+{
+    /** @mago-expect analysis:impossible-condition */
+    if (is_a($s, ProbeTarget::class)) {
+        echo 'a';
+    }
+
+    /** @mago-expect analysis:impossible-condition */
+    if (is_subclass_of($s, ProbeTarget::class, false)) {
+        echo 'b';
+    }
+}
+
+function keeps_objects_undecided(object $o): void
+{
+    if (is_a($o, ProbeTarget::class)) {
+        echo 'a';
+    }
+
+    if (is_subclass_of($o, ProbeTarget::class, false)) {
+        echo 'b';
+    }
+}
+
+function keeps_unions_and_unknown_flags_undecided(object|string $os, bool $allow): void
+{
+    if (is_a($os, ProbeTarget::class)) {
+        echo 'a';
+    }
+
+    if (is_a($os, ProbeTarget::class, $allow)) {
+        echo 'b';
+    }
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -278,6 +278,7 @@ test_case!(break_narrowing);
 test_case!(by_reference_invalidation);
 test_case!(callable_template_inference);
 test_case!(class_like_constant_access);
+test_case!(class_probe_allow_string_result);
 test_case!(collection_types);
 test_case!(condition_is_too_complex);
 test_case!(conditional_if_else);

--- a/crates/prelude/assets/extensions/core.php
+++ b/crates/prelude/assets/extensions/core.php
@@ -819,7 +819,7 @@ function get_called_class(): string {}
 function get_parent_class(object|string $object_or_class): string|false {}
 
 /**
- * @param object|class-string $object_or_class
+ * @param object|string $object_or_class
  *
  * @pure
  */
@@ -900,16 +900,20 @@ function get_included_files(): array {}
 function get_required_files(): array {}
 
 /**
- * @param object|class-string $object_or_class
+ * @param object|string $object_or_class
  * @param class-string $class
+ *
+ * @return ($allow_string is false ? ($object_or_class is object ? bool : false) : bool)
  *
  * @pure
  */
 function is_subclass_of(mixed $object_or_class, string $class, bool $allow_string = true): bool {}
 
 /**
- * @param object|class-string $object_or_class
+ * @param object|string $object_or_class
  * @param class-string $class
+ *
+ * @return ($allow_string is false ? ($object_or_class is object ? bool : false) : bool)
  *
  * @pure
  */


### PR DESCRIPTION
## 📌 What Does This PR Do?

Corrects the `is_a()`, `is_subclass_of()` and `method_exists()` stubs so
that probing an untrusted string for a class is no longer reported as an
error, and so that a probe which can only ever fail is recognized as
such.

## 🔍 Context & Motivation

These functions declare their subject as `object|class-string`, which
inverts the idiom: they are how you establish that a string names a
class, so demanding a `class-string` going in requires the very fact the
call is meant to determine. Reflection code that checks a string before
using it as a class name is flagged for passing a too-general argument.

The `$allow_string` flag is the part that does constrain the subject,
and it is unmodelled. With the flag off, a string subject makes the call
return false unconditionally, but we infer a plain `bool` and the dead
branch that follows goes unnoticed.

## 🛠️ Summary of Changes

- **Bug Fix:** Widened the probe subject to `object|string` and encoded
  `$allow_string` in a conditional `@return`.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other (please specify): prelude