### PR TITLE
fix(analyzer): reject non-class-strings where `class-string` is expected

### DIFF
--- a/crates/analyzer/tests/cases/bare_class_string_containment.php
+++ b/crates/analyzer/tests/cases/bare_class_string_containment.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @param class-string $class
+ */
+function takes_class_string(string $class): void
+{
+    echo $class;
+}
+
+/**
+ * @param interface-string $interface
+ */
+function takes_interface_string(string $interface): void
+{
+    echo $interface;
+}
+
+function rejects_non_strings(int $i, bool $b): void
+{
+    /** @mago-expect analysis:invalid-argument */
+    takes_class_string($i);
+
+    /** @mago-expect analysis:invalid-argument */
+    takes_class_string($b);
+}
+
+function coerces_plain_string(string $s): void
+{
+    /** @mago-expect analysis:possibly-invalid-argument */
+    takes_class_string($s);
+}
+
+function accepts_class_strings(): void
+{
+    takes_class_string(Throwable::class);
+    takes_class_string(Exception::class);
+    takes_interface_string(Throwable::class);
+}
+
+/**
+ * @param class-string $class
+ * @param class-string<Throwable> $throwable
+ */
+function accepts_narrower_class_strings(string $class, string $throwable): void
+{
+    takes_class_string($class);
+    takes_class_string($throwable);
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -72,6 +72,7 @@ test_case!(array_append_overflow_conditionally_assigned_max_key);
 test_case!(array_append_overflow_explicit_max_key);
 test_case!(array_append_overflow_optional_max_key);
 test_case!(array_list_reconciliation);
+test_case!(bare_class_string_containment);
 test_case!(boundary_widen_generic_never_to_int);
 test_case!(boundary_widen_generic_property_assignment);
 test_case!(boundary_widen_generic_static_property);

--- a/crates/codex/src/ttype/comparator/class_string_comparator.rs
+++ b/crates/codex/src/ttype/comparator/class_string_comparator.rs
@@ -23,9 +23,7 @@ pub fn is_contained_by(
     atomic_comparison_result: &mut ComparisonResult,
 ) -> bool {
     let fake_container_type = match container_class_string {
-        TClassLikeString::Any { .. } => {
-            return true;
-        }
+        TClassLikeString::Any { .. } => Cow::Owned(TAtomic::Object(TObject::Any)),
         TClassLikeString::Literal { value } => {
             if let Some(str_value) = input_scalar.get_known_literal_string_value()
                 && is_valid_class_string(str_value)


### PR DESCRIPTION
## 📌 What Does This PR Do?

Makes the unparameterized `class-string` (and `interface-string`,
`enum-string`, ...) type actually check its input during containment.

## 🔍 Context & Motivation

A bare `class-string` container short-circuits containment to true
before it looks at the input at all, so every scalar is considered
assignable to it: passing an `int`, a `bool` or a plain `string` to a
`class-string` parameter goes unreported. The same short-circuit makes
`array-key` and `class-string` mutually contained, so a
`@var class-string` annotation is flagged as redundant instead of
narrowing the value.

Only `class-string<T>` behaves correctly, because it builds a fake
object type from its constraint and defers to the atomic comparator.
The bare form has no constraint to build from, but comparing against
`object` gives it the right semantics, and the input side already
rejects scalars that are not class-like strings.

## 📂 Affected Areas

- [x] Other: Codex