### PR TITLE
test(analyzer): cover class probes with a dynamic class argument

### DIFF
--- a/crates/analyzer/tests/cases/class_probe_dynamic_class_argument.php
+++ b/crates/analyzer/tests/cases/class_probe_dynamic_class_argument.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+interface Probe {}
+
+/**
+ * @param class-string $class
+ */
+function narrows_through_a_dynamic_class_argument(object|string $value, string $class): void
+{
+    if (is_a($value, $class, true)) {
+        accepts_object_or_class_string($value);
+    }
+
+    if (is_subclass_of($value, $class, false)) {
+        accepts_object($value);
+    }
+}
+
+/**
+ * @param class-string<Probe> $class
+ */
+function keeps_the_template_of_a_dynamic_class_argument(object|string $value, string $class): void
+{
+    if (is_a($value, $class, true)) {
+        accepts_probe_or_probe_class_string($value);
+    }
+}
+
+function accepts_object(object $value): void
+{
+    echo $value::class;
+}
+
+/**
+ * @param object|class-string $value
+ */
+function accepts_object_or_class_string(object|string $value): void
+{
+    echo is_object($value) ? $value::class : $value;
+}
+
+/**
+ * @param Probe|class-string<Probe> $value
+ */
+function accepts_probe_or_probe_class_string(Probe|string $value): void
+{
+    echo is_object($value) ? $value::class : $value;
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -280,6 +280,7 @@ test_case!(by_reference_invalidation);
 test_case!(callable_template_inference);
 test_case!(class_like_constant_access);
 test_case!(class_probe_allow_string_result);
+test_case!(class_probe_dynamic_class_argument);
 test_case!(collection_types);
 test_case!(condition_is_too_complex);
 test_case!(conditional_if_else);


### PR DESCRIPTION
# 📌 What Does This PR Do?

Adds an analyzer test case for `is_a()`/`is_subclass_of()` narrowing when
the class argument is a `class-string` variable rather than a
`Foo::class` literal.

## 🔍 Context & Motivation

Every existing test for these probes passes a `Foo::class` literal, so
the branch that resolves a `class-string` variable is unguarded — as is
the fact that it carries a `class-string<T>` template through to the
narrowed subject. That narrowing lives in the dedicated handling in
`scrape_special_function_call_assertions()`, which is silently bypassed
whenever the prelude declares a docblock assertion on the same function,
so it is easy to lose without noticing.

## 🛠️ Summary of Changes

- **Tests:** Cover `is_a()`/`is_subclass_of()` narrowing through a
  dynamic class argument, including template propagation and the
  `allow_string: false` case.

## 📂 Affected Areas

- [x] Other: analyzer test suite