### PR TITLE
fix(formatter): keep comments inside parentheses

### DIFF
--- a/crates/formatter/src/internal/comment/format.rs
+++ b/crates/formatter/src/internal/comment/format.rs
@@ -526,6 +526,11 @@ where
                 continue;
             }
 
+            // Block comments already placed as leading are left for the node they were placed on.
+            if comment.is_block && self.placed_comments.is_placed_leading(self.next_comment_index) {
+                break;
+            }
+
             let is_between = comment.start >= after.end_offset() && comment.end <= before.start_offset();
             let gap_is_ok =
                 after.end_offset() == comment.start || self.is_insignificant(after.end_offset(), comment.start);
@@ -749,11 +754,16 @@ where
 
             parts.push(self.print_comment(comment));
 
-            if !trivia.kind.is_block_comment() {
+            if !comment.is_block || !comment.is_single_line {
+                // Line comments and multi-line block comments always end the line.
                 parts.push(Document::BreakParent);
                 parts.push(Document::Line(Line::hard()));
-            } else {
+            } else if self.has_newline(comment.end, /* backwards */ false) {
+                // A line break followed the comment in the source, so allow one here.
                 parts.push(Document::Line(Line::default()));
+            } else {
+                // The comment shared a line with what followed it, so keep them together.
+                parts.push(Document::Space(Space::soft()));
             }
         }
 
@@ -821,7 +831,17 @@ where
         span: Span,
         document: Document<'arena, A>,
     ) -> Document<'arena, A> {
+        // Wrapper nodes such as `Expression` share a span with the node they hold.
+        // Leave the comments to the outer node, so any parentheses added to it enclose them too.
+        if self.nth_parent_kind(1).is_some_and(|parent| parent.span() == span) {
+            return document;
+        }
+
         match self.take_placed_leading(span) {
+            // Separate comments from preceding prefix operators.
+            Some(placed) if matches!(self.nth_parent_kind(1), Some(Node::UnaryPrefix(_))) => {
+                Document::Array(vec_in![self.arena; Document::Space(Space::soft()), placed, document])
+            }
             Some(placed) => Document::Array(vec_in![self.arena; placed, document]),
             None => document,
         }

--- a/crates/formatter/src/internal/comment/placement.rs
+++ b/crates/formatter/src/internal/comment/placement.rs
@@ -171,7 +171,8 @@ fn collect_node_comments<'ast, 'arena>(
     let can_reattribute = !is_binary_like(node);
     let mut prev_child: Option<Node<'ast, 'arena>> = None;
     for child in children.iter() {
-        let child = unwrap_parenthesized_node(*child);
+        let parenthesized_child = *child;
+        let child = unwrap_parenthesized_node(parenthesized_child);
         let child_start = child.span().start.offset;
 
         while *cursor < total {
@@ -181,7 +182,10 @@ fn collect_node_comments<'ast, 'arena>(
                 break;
             }
 
-            let enclosing = if can_reattribute
+            let enclosing = if comment_start > parenthesized_child.span().start.offset {
+                // The comment is within the child's parentheses, so belongs to it.
+                parenthesized_child
+            } else if can_reattribute
                 && let Some(prev) = prev_child.filter(|p| comment_start >= p.span().end.offset && is_binary_like(*p))
             {
                 prev
@@ -274,6 +278,13 @@ fn unwrap_parenthesized_node<'ast, 'arena>(node: Node<'ast, 'arena>) -> Node<'as
 
 fn place_comment<'ast, 'arena>(comment: DecoratedComment<'ast, 'arena>) -> CommentPlacement<'ast, 'arena> {
     let enclosing = match comment.enclosing {
+        // A comment inside parentheses belongs to the whole expression, so this is checked first.
+        Node::Parenthesized(parenthesized) | Node::Expression(Expression::Parenthesized(parenthesized)) => {
+            return CommentPlacement::Leading {
+                node: Node::Expression(unwrap_parenthesized(parenthesized.expression)),
+                comment_index: comment.comment_index,
+            };
+        }
         Node::Expression(expr) => match unwrap_parenthesized(expr) {
             Expression::Binary(binary) => Node::Binary(binary),
             Expression::Conditional(cond) => Node::Conditional(cond),

--- a/crates/formatter/src/internal/format/expression.rs
+++ b/crates/formatter/src/internal/format/expression.rs
@@ -287,8 +287,7 @@ where
     fn format(&'arena self, f: &mut FormatterState<'_, 'arena, A>) -> Document<'arena, A> {
         wrap!(f, self, UnaryPrefix, {
             // Prevent block comments between operator and operand running straight into the operand.
-            let operand = unwrap_parenthesized(self.operand);
-            let separator = if f.has_comment(operand.span(), CommentFlags::LEADING | CommentFlags::BLOCK) {
+            let separator = if f.has_comment(self.operand.span(), CommentFlags::LEADING | CommentFlags::BLOCK) {
                 Document::soft_space()
             } else {
                 Document::empty()

--- a/crates/formatter/src/internal/macros.rs
+++ b/crates/formatter/src/internal/macros.rs
@@ -11,13 +11,13 @@ macro_rules! wrap {
         let doc = $block;
         let trailing = $f.print_trailing_comments_for_node(node);
         let has_leading_comments = leading.is_some();
-        let doc = $f.print_comments(leading, doc, trailing);
         let doc = if needed_to_wrap_in_parens {
+            let doc = $f.print_comments(leading, doc, trailing);
             $f.add_parens_with_placed_leading(doc, node, has_leading_comments)
         } else {
-            doc
+            let doc = $f.prepend_unclaimed_placed_leading(node.span(), doc);
+            $f.print_comments(leading, doc, trailing)
         };
-        let doc = $f.prepend_unclaimed_placed_leading(node.span(), doc);
         $f.leave_node();
         $f.is_wrapped_in_parens = was_wrapped_in_parens;
         doc

--- a/crates/formatter/tests/cases/comment_placement_grouping_parens/after.php
+++ b/crates/formatter/tests/cases/comment_placement_grouping_parens/after.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/** @param numeric-string $value */
+function requires_numeric(string $value): string
+{
+    return $value;
+}
+
+// Mandatory parentheses around pipe arrow functions
+$single = '1' |> (/** @param numeric-string $x */ static fn(string $x): string => requires_numeric($x));
+
+// Forced multiline pipe
+$chained = '1'
+    |> trim(...)
+    |> (/** @param numeric-string $x */ static fn(string $x): string => requires_numeric($x))
+    |> strrev(...)
+    |> strlen(...);
+
+// Multiline docblocks within parentheses
+$documented = '1'
+    |> (
+        /**
+         * @param numeric-string $x
+         *
+         * @return numeric-string
+         */
+        static fn(string $x): string => requires_numeric($x)
+    );
+
+// Line comments within parentheses
+$annotated = '1'
+    |> (
+        // Only ever called with numeric strings.
+        static fn(string $x): string => requires_numeric($x)
+    );
+
+// Comment outside parentheses
+$outside = '1' |> /** not attached to the closure */ (static fn(string $x): string => requires_numeric($x));
+
+// Closure syntax does not require parentheses
+$via_closure = '1'
+    |> /** @param numeric-string $x */ static function (string $x): string {
+        return requires_numeric($x);
+    };
+
+// Immediately invoked closure
+$eager = (
+    /** @return numeric-string */ static function (): string {
+        return '1';
+    }
+)();
+
+// Immediately invoked arrow function
+$applied = (/** @param numeric-string $x */ static fn(string $x): string => requires_numeric($x))('1');
+
+// Closure invoked via method
+$bound = (
+    /** @param numeric-string $x */ function (string $x): string {
+        return $this->format($x);
+    }
+)->call($formatter, '1');
+
+// First-class callable created from a documented closure
+$callable = (/** @param numeric-string $x */ static fn(string $x): string => requires_numeric($x))(...);
+
+// Inline `@var` on a class constant used as an instantiation target
+$handler = new (/** @var class-string<HandlerInterface> */ self::HANDLER)();
+
+// Inline `@var` on a piped `require` expression
+$names = (/** @var list<string> */ require __DIR__ . '/names.php') |> array_values(...);
+
+// Inline `@var` on a piped conditional
+$count = (/** @var int $n */ $n > 0 ? $n : 0) |> strval(...);
+
+// Inline `@var` on a pipe used as a unary operand
+$magnitude = -(/** @var int $offset */ $offset |> abs(...));
+
+// Inline `@var` on a loop condition assignment
+while ((/** @var Row|false $row */ $row = $statement->fetch()) !== false) {
+    handle($row);
+}

--- a/crates/formatter/tests/cases/comment_placement_grouping_parens/before.php
+++ b/crates/formatter/tests/cases/comment_placement_grouping_parens/before.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/** @param numeric-string $value */
+function requires_numeric(string $value): string
+{
+    return $value;
+}
+
+// Mandatory parentheses around pipe arrow functions
+$single = '1' |> (/** @param numeric-string $x */ static fn(string $x): string => requires_numeric($x));
+
+// Forced multiline pipe
+$chained = '1'
+    |> trim(...)
+    |> (/** @param numeric-string $x */ static fn(string $x): string => requires_numeric($x))
+    |> strrev(...)
+    |> strlen(...);
+
+// Multiline docblocks within parentheses
+$documented = '1'
+    |> (
+        /**
+         * @param numeric-string $x
+         *
+         * @return numeric-string
+         */
+        static fn(string $x): string => requires_numeric($x)
+    );
+
+// Line comments within parentheses
+$annotated = '1'
+    |> (
+        // Only ever called with numeric strings.
+        static fn(string $x): string => requires_numeric($x)
+    );
+
+// Comment outside parentheses
+$outside = '1' |> /** not attached to the closure */ (static fn(string $x): string => requires_numeric($x));
+
+// Closure syntax does not require parentheses
+$via_closure = '1'
+    |> /** @param numeric-string $x */ static function (string $x): string {
+        return requires_numeric($x);
+    };
+
+// Immediately invoked closure
+$eager = (
+    /** @return numeric-string */ static function (): string {
+        return '1';
+    }
+)();
+
+// Immediately invoked arrow function
+$applied = (/** @param numeric-string $x */ static fn(string $x): string => requires_numeric($x))('1');
+
+// Closure invoked via method
+$bound = (
+    /** @param numeric-string $x */ function (string $x): string {
+        return $this->format($x);
+    }
+)->call($formatter, '1');
+
+// First-class callable created from a documented closure
+$callable = (/** @param numeric-string $x */ static fn(string $x): string => requires_numeric($x))(...);
+
+// Inline `@var` on a class constant used as an instantiation target
+$handler = new (/** @var class-string<HandlerInterface> */ self::HANDLER)();
+
+// Inline `@var` on a piped `require` expression
+$names = (/** @var list<string> */ require __DIR__ . '/names.php') |> array_values(...);
+
+// Inline `@var` on a piped conditional
+$count = (/** @var int $n */ $n > 0 ? $n : 0) |> strval(...);
+
+// Inline `@var` on a pipe used as a unary operand
+$magnitude = -(/** @var int $offset */ $offset |> abs(...));
+
+// Inline `@var` on a loop condition assignment
+while ((/** @var Row|false $row */ $row = $statement->fetch()) !== false) {
+    handle($row);
+}

--- a/crates/formatter/tests/cases/comment_placement_grouping_parens/settings.inc
+++ b/crates/formatter/tests/cases/comment_placement_grouping_parens/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings::default()

--- a/crates/formatter/tests/cases/unary_prefix_block_comment/after.php
+++ b/crates/formatter/tests/cases/unary_prefix_block_comment/after.php
@@ -10,7 +10,7 @@ $b = (int) /* c */ $s;
 $c = (bool) /* c */ ($x && $y);
 
 // Comment inside parentheses that are kept
-$d = ! /* c */ ($x && $y);
+$d = !(/* c */ $x && $y);
 
 // Every spacing possibility around the comment
 $e = - /* c */ $n;

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -331,6 +331,7 @@ test_case!(comment_placement_binary);
 test_case!(comment_placement_conditional);
 test_case!(comment_placement_conditional_preserve);
 test_case!(unary_prefix_block_comment);
+test_case!(comment_placement_grouping_parens, PHPVersion::PHP85);
 test_case!(fits_line_suffix);
 
 // A special test case for regressions in the Psl codebase


### PR DESCRIPTION
## 📌 What Does This PR Do?

Ensures the formatter keeps comments within parentheses.

## 🔍 Context & Motivation

Some values, like arrow functions, must be placed in parentheses when used in a PHP 8.5 `|>` pipe. Adding a docblock to e.g. specify `fn (string $argument)` as `@param non-empty-string $argument` is required to satisfy Mago's analyser, however the formatter currently moves those comments outside the parentheses, disassociating them from the closure:

```
$value = 'hello world'
  |> (/** @param non-empty-string $arg */ static fn (string $arg): string => needs_non_empty_string(123, $arg))
  |> // ...
```

has no analysis issues, but after formatting becomes:

```
$value = 'hello world'
  |> /** @param non-empty-string $arg */ (static fn (string $arg): string => needs_non_empty_string(123, $arg))
  |> // ...
```

which raises a `possibly-invalid-argument` analysis issue.

[(Playground)](https://mago.carthage.software/1.47.4/en/playground/#01a0629c-6724-f4a0-d94d-716492c87bf6) - click 'Format' to see the issue

There are other places where this can be an issue, such as immediately invoked closures, includes, etc.

This PR updates the formatter to keep comments within parentheses.

## 🛠️ Summary of Changes

- **Bug Fix:** Kept comments within parentheses.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] Analyzer
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

N/A

## 📝 Notes for Reviewers

Test coverage added. There is an existing formatter issue concerning cast operands with a comment in redundant parentheses: `(int) (/* c */ $s)` formats to `(int) /* c */ $s` on the first pass, then `(int) /* c */$s` on the second, after which it is stable. The apparently-incorrect removal of the space is a pre-existing bug; this change just introduces one avenue where its existence leads to a required two-pass format. ~~I figured fixing or special-casing it was out of scope for this PR.~~ I have opened a separate PR for that issue: #2301