### PR TITLE
fix(formatter): normalise spacing between unary-prefixed comment & operand

### DIFF
--- a/crates/formatter/src/internal/format/expression.rs
+++ b/crates/formatter/src/internal/format/expression.rs
@@ -286,6 +286,14 @@ where
 {
     fn format(&'arena self, f: &mut FormatterState<'_, 'arena, A>) -> Document<'arena, A> {
         wrap!(f, self, UnaryPrefix, {
+            // Prevent block comments between operator and operand running straight into the operand.
+            let operand = unwrap_parenthesized(self.operand);
+            let separator = if f.has_comment(operand.span(), CommentFlags::LEADING | CommentFlags::BLOCK) {
+                Document::soft_space()
+            } else {
+                Document::empty()
+            };
+
             let operator = self.operator.format(f);
             let operand_trailing_comments = if let Expression::Parenthesized(p) = self.operand {
                 f.print_trailing_comments_between_nodes(p.left_parenthesis, p.expression.span())
@@ -295,9 +303,9 @@ where
 
             match operand_trailing_comments {
                 Some(operand_trailing_comments) => Document::Group(Group::new(
-                    vec_in![f.arena; operator, operand_trailing_comments, self.operand.format(f)],
+                    vec_in![f.arena; operator, operand_trailing_comments, separator, self.operand.format(f)],
                 )),
-                None => Document::Group(Group::new(vec_in![f.arena; operator, self.operand.format(f)])),
+                None => Document::Group(Group::new(vec_in![f.arena; operator, separator, self.operand.format(f)])),
             }
         })
     }

--- a/crates/formatter/tests/cases/unary_prefix_block_comment/after.php
+++ b/crates/formatter/tests/cases/unary_prefix_block_comment/after.php
@@ -1,0 +1,34 @@
+<?php
+
+// Cast followed by a block comment
+$a = (int) /* c */ $s;
+
+// Cast with the comment inside redundant parentheses
+$b = (int) /* c */ $s;
+
+// Cast followed by a block comment, with a parenthesised operand that keeps its parentheses
+$c = (bool) /* c */ ($x && $y);
+
+// Comment inside parentheses that are kept
+$d = ! /* c */ ($x && $y);
+
+// Every spacing possibility around the comment
+$e = - /* c */ $n;
+$f = - /* c */ $n;
+$g = - /* c */ $n;
+$h = - /* c */ $n;
+
+// Other prefix operators
+$i = ~ /* c */ $n;
+$j = ++ /* c */ $n;
+$k = @ /* c */ f();
+
+// Multiple comments
+$l = (int) /* a */ /* b */ $s;
+
+// Inline `@var`
+$m = (string) /** @var numeric-string $s */ $s;
+
+// Line comments are unaffected
+$n = (int) $s; // c
+$o = !($x && $y); // c

--- a/crates/formatter/tests/cases/unary_prefix_block_comment/before.php
+++ b/crates/formatter/tests/cases/unary_prefix_block_comment/before.php
@@ -1,0 +1,37 @@
+<?php
+
+// Cast followed by a block comment
+$a = (int) /* c */ $s;
+
+// Cast with the comment inside redundant parentheses
+$b = (int) (/* c */ $s);
+
+// Cast followed by a block comment, with a parenthesised operand that keeps its parentheses
+$c = (bool) /* c */ ($x && $y);
+
+// Comment inside parentheses that are kept
+$d = !(/* c */ $x && $y);
+
+// Every spacing possibility around the comment
+$e = -/* c */ $n;
+$f = - /* c */ $n;
+$g = - /* c */$n;
+$h = -/* c */$n;
+
+// Other prefix operators
+$i = ~ /* c */ $n;
+$j = ++ /* c */ $n;
+$k = @ /* c */ f();
+
+// Multiple comments
+$l = (int) /* a */ /* b */ $s;
+
+// Inline `@var`
+$m = (string) /** @var numeric-string $s */ $s;
+
+// Line comments are unaffected
+$n = (int) // c
+    $s;
+$o = !( // c
+    $x && $y
+);

--- a/crates/formatter/tests/cases/unary_prefix_block_comment/settings.inc
+++ b/crates/formatter/tests/cases/unary_prefix_block_comment/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings::default()

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -330,6 +330,7 @@ test_case!(null_type_hint_question_reorders_null_last);
 test_case!(comment_placement_binary);
 test_case!(comment_placement_conditional);
 test_case!(comment_placement_conditional_preserve);
+test_case!(unary_prefix_block_comment);
 test_case!(fits_line_suffix);
 
 // A special test case for regressions in the Psl codebase


### PR DESCRIPTION
## 📌 What Does This PR Do?

Prevents the formatter stripping whitespace between a block comment and value when both follow a unary prefix operator.

## 🔍 Context & Motivation

Currently whitespace between a block comment and a value is normalised to one space by the formatter (e.g. `$a = /* b */ $c`), _unless_ there is a unary operator before the comment (e.g. `$a = ! /* b */ $c`) where it instead removes the whitespace:

```php
<?php
$a = (int) /* c */ $s;
$b = (int) /* c */ ($x && $y);
$c = - /* c */ $s;
$d = ~ /* c */ $s;
$e = ++ /* c */ $s;
$f = (int) /* a */ /* b */ $s;
```

becomes:

```php
<?php
$a = (int) /* c */$s;
$b = (int) /* c */($x && $y);
$c = - /* c */$s;
$d = ~ /* c */$s;
$e = ++ /* c */$s;
$f = (int) /* a *//* b */ $s; // Whitespace is removed after the first comment encountered
```

[(Playground)](https://mago.carthage.software/1.47.4/en/playground/#01a062c9-79e5-be45-e159-5255e55a7add) – click Format to see the whitespace be removed.

This PR ensures whitespace is the same with or without a unary prefix operator.

## 🛠️ Summary of Changes

- **Bug Fix:** Fixed unary-prefixed comment whitespace removal.

## 📂 Affected Areas

- [ ] Linter
- [x] Formatter
- [ ] Analyzer
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Some of the test cases reproduce the comments-being-moved-outside-parentheses issue fixed in #2300 – if that is merged I will update this PR's tests accordingly.

## 📝 Notes for Reviewers

Test coverage added.