### PR TITLE
fix(analyzer): preserve exact assertions across disjunctions

### DIFF
--- a/crates/analyzer/src/formula.rs
+++ b/crates/analyzer/src/formula.rs
@@ -144,6 +144,7 @@ where
         conditional_object_id,
         creating_object_id,
         artifacts,
+        formula_size_threshold,
     );
 
     if formula.len() > usize::from(formula_size_threshold) { None } else { Some(formula) }
@@ -472,8 +473,9 @@ fn add_conditional_assertion_clauses(
     conditional_object_id: Span,
     creating_object_id: Span,
     artifacts: &AnalysisArtifacts,
+    formula_size_threshold: u16,
 ) {
-    let assertions = collect_conditional_assertions(expression, when_true, artifacts);
+    let assertions = collect_conditional_assertions(expression, when_true, artifacts, formula_size_threshold);
     for (variable, assertion_set) in assertions {
         for assertions in assertion_set {
             let Some(first_assertion) = assertions.first() else {
@@ -502,8 +504,9 @@ fn collect_conditional_assertions(
     expression: &Expression,
     when_true: bool,
     artifacts: &AnalysisArtifacts,
+    formula_size_threshold: u16,
 ) -> WordMap<AssertionSet> {
-    collect_conditional_assertions_inner(expression, when_true, artifacts, false)
+    collect_conditional_assertions_inner(expression, when_true, artifacts, false, formula_size_threshold)
 }
 
 fn collect_conditional_assertions_inner(
@@ -511,6 +514,7 @@ fn collect_conditional_assertions_inner(
     when_true: bool,
     artifacts: &AnalysisArtifacts,
     include_non_equality: bool,
+    formula_size_threshold: u16,
 ) -> WordMap<AssertionSet> {
     let expression = unwrap_expression(expression);
     match expression {
@@ -530,36 +534,50 @@ fn collect_conditional_assertions_inner(
                 artifacts.if_false_assertions.get(&range).cloned().unwrap_or_default()
             }
         }
-        Expression::UnaryPrefix(unary) if unary.operator.is_not() => {
-            collect_conditional_assertions_inner(unary.operand, !when_true, artifacts, include_non_equality)
-        }
+        Expression::UnaryPrefix(unary) if unary.operator.is_not() => collect_conditional_assertions_inner(
+            unary.operand,
+            !when_true,
+            artifacts,
+            include_non_equality,
+            formula_size_threshold,
+        ),
         Expression::Assignment(assignment) if matches!(assignment.operator, AssignmentOperator::Assign(_)) => {
-            collect_conditional_assertions_inner(assignment.rhs, when_true, artifacts, include_non_equality)
+            collect_conditional_assertions_inner(
+                assignment.rhs,
+                when_true,
+                artifacts,
+                include_non_equality,
+                formula_size_threshold,
+            )
         }
-        Expression::Binary(binary) if matches!(binary.operator, BinaryOperator::And(_) | BinaryOperator::LowAnd(_)) => {
-            if !when_true {
-                return WordMap::default();
+        Expression::Binary(binary)
+            if matches!(
+                binary.operator,
+                BinaryOperator::And(_) | BinaryOperator::LowAnd(_) | BinaryOperator::Or(_) | BinaryOperator::LowOr(_)
+            ) =>
+        {
+            let mut assertions = collect_conditional_assertions_inner(
+                binary.lhs,
+                when_true,
+                artifacts,
+                include_non_equality,
+                formula_size_threshold,
+            );
+            let right_assertions = collect_conditional_assertions_inner(
+                binary.rhs,
+                when_true,
+                artifacts,
+                include_non_equality,
+                formula_size_threshold,
+            );
+
+            let is_conjunction = matches!(binary.operator, BinaryOperator::And(_) | BinaryOperator::LowAnd(_));
+            if is_conjunction == when_true {
+                extend_conditional_assertions(&mut assertions, right_assertions);
+            } else {
+                disjoin_conditional_assertions(&mut assertions, right_assertions, formula_size_threshold);
             }
 
-            let mut assertions =
-                collect_conditional_assertions_inner(binary.lhs, true, artifacts, include_non_equality);
-            extend_conditional_assertions(
-                &mut assertions,
-                collect_conditional_assertions_inner(binary.rhs, true, artifacts, include_non_equality),
-            );
-            assertions
-        }
-        Expression::Binary(binary) if matches!(binary.operator, BinaryOperator::Or(_) | BinaryOperator::LowOr(_)) => {
-            if when_true {
-                return WordMap::default();
-            }
-
-            let mut assertions =
-                collect_conditional_assertions_inner(binary.lhs, false, artifacts, include_non_equality);
-            extend_conditional_assertions(
-                &mut assertions,
-                collect_conditional_assertions_inner(binary.rhs, false, artifacts, include_non_equality),
-            );
             assertions
         }
         Expression::Binary(binary)
@@ -586,7 +604,13 @@ fn collect_conditional_assertions_inner(
             let include_non_equality = matches!(binary.operator, BinaryOperator::Identical(_)) == when_true
                 || artifacts.get_expression_type(other).is_some_and(|ty| ty.is_bool());
 
-            collect_conditional_assertions_inner(other, other_when_true, artifacts, include_non_equality)
+            collect_conditional_assertions_inner(
+                other,
+                other_when_true,
+                artifacts,
+                include_non_equality,
+                formula_size_threshold,
+            )
         }
         _ => WordMap::default(),
     }
@@ -596,6 +620,32 @@ fn extend_conditional_assertions(target: &mut WordMap<AssertionSet>, assertions:
     for (variable, assertion_set) in assertions {
         target.entry(variable).or_default().extend(assertion_set);
     }
+}
+
+fn disjoin_conditional_assertions(
+    target: &mut WordMap<AssertionSet>,
+    assertions: WordMap<AssertionSet>,
+    formula_size_threshold: u16,
+) {
+    target.retain(|variable, left| {
+        let Some(right) = assertions.get(variable) else {
+            return false;
+        };
+
+        if left.len().saturating_mul(right.len()) > usize::from(formula_size_threshold) {
+            return false;
+        }
+
+        // Either operand can establish the condition, so retain only shared variables
+        // and distribute OR over their conjunctions without negating one-way assertions.
+        *left = left
+            .iter()
+            .cartesian_product(right)
+            .map(|(left, right)| left.iter().chain(right).cloned().collect())
+            .collect();
+
+        !left.is_empty()
+    });
 }
 
 pub(crate) fn add_nullsafe_base_clauses<A>(
@@ -831,20 +881,21 @@ pub fn negate_or_synthesize<A>(
 where
     A: Arena,
 {
-    let negated_clauses = if collect_conditional_assertions(conditional, true, artifacts).is_empty() {
-        negate_formula(clauses, algebra_thresholds)
-    } else {
-        get_base_formula(
-            conditional.span(),
-            conditional.span(),
-            conditional,
-            assertion_context,
-            artifacts,
-            algebra_thresholds,
-            formula_size_threshold,
-        )
-        .and_then(|formula| negate_formula(formula, algebra_thresholds))
-    };
+    let negated_clauses =
+        if collect_conditional_assertions(conditional, true, artifacts, formula_size_threshold).is_empty() {
+            negate_formula(clauses, algebra_thresholds)
+        } else {
+            get_base_formula(
+                conditional.span(),
+                conditional.span(),
+                conditional,
+                assertion_context,
+                artifacts,
+                algebra_thresholds,
+                formula_size_threshold,
+            )
+            .and_then(|formula| negate_formula(formula, algebra_thresholds))
+        };
 
     match negated_clauses {
         Some(mut negated_clauses) => {
@@ -855,6 +906,7 @@ where
                 conditional.span(),
                 conditional.span(),
                 artifacts,
+                formula_size_threshold,
             );
 
             negated_clauses
@@ -969,4 +1021,52 @@ pub fn remove_clauses_with_mixed_variables(
             c
         })
         .collect::<Vec<Clause>>()
+}
+
+#[cfg(test)]
+mod tests {
+    use mago_codex::assertion::Assertion;
+    use mago_word::WordMap;
+    use mago_word::word;
+
+    use super::disjoin_conditional_assertions;
+
+    #[test]
+    fn conditional_assertion_disjunction_respects_formula_size_threshold() {
+        let range = word("$range");
+        let shared = word("$shared");
+        let left = WordMap::from_iter([
+            (range, vec![vec![Assertion::IsGreaterThan(0)], vec![Assertion::IsLessThan(10)]]),
+            (shared, vec![vec![Assertion::IsGreaterThan(5)]]),
+            (word("$left_only"), vec![vec![Assertion::Truthy]]),
+        ]);
+        let right = WordMap::from_iter([
+            (range, vec![vec![Assertion::IsGreaterThan(20)], vec![Assertion::IsLessThan(30)]]),
+            (shared, vec![vec![Assertion::IsGreaterThan(15)]]),
+            (word("$right_only"), vec![vec![Assertion::Truthy]]),
+        ]);
+        let shared_assertions = vec![vec![Assertion::IsGreaterThan(5), Assertion::IsGreaterThan(15)]];
+
+        let mut at_limit = left.clone();
+        disjoin_conditional_assertions(&mut at_limit, right.clone(), 4);
+        assert_eq!(
+            at_limit,
+            WordMap::from_iter([
+                (
+                    range,
+                    vec![
+                        vec![Assertion::IsGreaterThan(0), Assertion::IsGreaterThan(20)],
+                        vec![Assertion::IsGreaterThan(0), Assertion::IsLessThan(30)],
+                        vec![Assertion::IsLessThan(10), Assertion::IsGreaterThan(20)],
+                        vec![Assertion::IsLessThan(10), Assertion::IsLessThan(30)],
+                    ],
+                ),
+                (shared, shared_assertions.clone()),
+            ]),
+        );
+
+        let mut over_limit = left;
+        disjoin_conditional_assertions(&mut over_limit, right, 3);
+        assert_eq!(over_limit, WordMap::from_iter([(shared, shared_assertions)]));
+    }
 }

--- a/crates/analyzer/tests/cases/conditional_exact_assertions_disjunction.php
+++ b/crates/analyzer/tests/cases/conditional_exact_assertions_disjunction.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @template T
+ * @param T $expected
+ * @psalm-assert-if-true =T $value
+ */
+function equals_when_enabled(mixed $value, mixed $expected, bool $enabled): bool
+{
+    return $value === $expected && $enabled;
+}
+
+/** @psalm-assert-if-false =null $value */
+function is_non_null_or_disabled(?object $value, bool $enabled): bool
+{
+    return $value !== null || !$enabled;
+}
+
+/** @param null $_value */
+function takes_null(mixed $_value): void {}
+
+function true_assertions_narrow_only_the_true_branch(?object $value, bool $first, bool $second): object
+{
+    if (equals_when_enabled($value, null, $first) || equals_when_enabled($value, null, $second)) {
+        takes_null($value);
+
+        return new stdClass();
+    }
+
+    // @mago-expect analysis:nullable-return-statement,invalid-return-statement
+    return $value;
+}
+
+function false_assertions_narrow_only_the_false_branch(?object $value, bool $first, bool $second): object
+{
+    if (is_non_null_or_disabled($value, $first) && is_non_null_or_disabled($value, $second)) {
+        // @mago-expect analysis:nullable-return-statement,invalid-return-statement
+        return $value;
+    }
+
+    takes_null($value);
+
+    return new stdClass();
+}
+
+function combines_nested_conjunctions(
+    mixed $value,
+    int|object $int_or_object,
+    int|bool $int_or_bool,
+    float|object $float_or_object,
+    float|bool $float_or_bool,
+    bool $enabled,
+): int|float {
+    if (
+        equals_when_enabled($value, $int_or_object, $enabled) && equals_when_enabled($value, $int_or_bool, $enabled)
+        || equals_when_enabled($value, $float_or_object, $enabled)
+        && equals_when_enabled($value, $float_or_bool, $enabled)
+    ) {
+        return $value;
+    }
+
+    return 0;
+}

--- a/crates/analyzer/tests/cases/issue_2320.php
+++ b/crates/analyzer/tests/cases/issue_2320.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+/** @throws ReflectionException */
+function short_name(string $class): string
+{
+    if (namespace\class_exists($class) || namespace\interface_exists($class)) {
+        $class = new namespace\ReflectionClass($class)->getShortName();
+    }
+
+    return $class;
+}

--- a/crates/analyzer/tests/cases/strings_class_or_interface_exists_narrows.php
+++ b/crates/analyzer/tests/cases/strings_class_or_interface_exists_narrows.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-/** @param class-string|interface-string $class */
-function takes_class_or_interface_string(string $class): void
+/** @param class-string $class */
+function takes_class_string(string $class): void
 {
     echo $class;
 }
@@ -11,11 +11,11 @@ function takes_class_or_interface_string(string $class): void
 function narrows_disjunction(string $class): void
 {
     if (class_exists($class) || interface_exists($class)) {
-        takes_class_or_interface_string($class);
+        takes_class_string($class);
     }
 
     if (interface_exists($class) || class_exists($class)) {
-        takes_class_or_interface_string($class);
+        takes_class_string($class);
     }
 }
 
@@ -25,14 +25,14 @@ function narrows_after_early_return(string $class): void
         return;
     }
 
-    takes_class_or_interface_string($class);
+    takes_class_string($class);
 }
 
 function does_not_narrow_unchecked_alternative(string $class, bool $flag): void
 {
     if (class_exists($class) || $flag) {
         /** @mago-expect analysis:possibly-invalid-argument */
-        takes_class_or_interface_string($class);
+        takes_class_string($class);
     }
 }
 
@@ -40,6 +40,6 @@ function does_not_narrow_unchecked_alternative(string $class, bool $flag): void
 function preserves_class_string_when_checks_fail(string $class): void
 {
     if (!class_exists($class) && !interface_exists($class)) {
-        takes_class_or_interface_string($class);
+        takes_class_string($class);
     }
 }

--- a/crates/analyzer/tests/cases/strings_class_or_interface_exists_narrows.php
+++ b/crates/analyzer/tests/cases/strings_class_or_interface_exists_narrows.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/** @param class-string|interface-string $class */
+function takes_class_or_interface_string(string $class): void
+{
+    echo $class;
+}
+
+function narrows_disjunction(string $class): void
+{
+    if (class_exists($class) || interface_exists($class)) {
+        takes_class_or_interface_string($class);
+    }
+
+    if (interface_exists($class) || class_exists($class)) {
+        takes_class_or_interface_string($class);
+    }
+}
+
+function narrows_after_early_return(string $class): void
+{
+    if (!class_exists($class) && !interface_exists($class)) {
+        return;
+    }
+
+    takes_class_or_interface_string($class);
+}
+
+function does_not_narrow_unchecked_alternative(string $class, bool $flag): void
+{
+    if (class_exists($class) || $flag) {
+        /** @mago-expect analysis:possibly-invalid-argument */
+        takes_class_or_interface_string($class);
+    }
+}
+
+/** @param class-string $class */
+function preserves_class_string_when_checks_fail(string $class): void
+{
+    if (!class_exists($class) && !interface_exists($class)) {
+        takes_class_or_interface_string($class);
+    }
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -863,6 +863,7 @@ test_case!(finally_inherits_call_invalidations);
 test_case!(post_narrowing_check);
 test_case!(data_transformer_type);
 test_case!(symbol_existence_assertions);
+test_case!(conditional_exact_assertions_disjunction);
 test_case!(symbol_existence_edge_cases);
 test_case!(type_assert);
 test_case!(string_callable_template_inference);
@@ -1241,6 +1242,7 @@ test_case!(strings_concat_with_null_implicit);
 test_case!(strings_concat_with_bool_invalid);
 test_case!(strings_interpolation_of_non_stringable_object);
 test_case!(strings_class_exists_narrows_to_class_string);
+test_case!(strings_class_or_interface_exists_narrows);
 test_case!(strings_interface_exists_narrows);
 test_case!(strings_enum_exists_narrows);
 test_case!(strings_trait_exists_narrows);
@@ -2743,6 +2745,11 @@ test_case!(issue_2312);
 test_case!(issue_2315);
 test_case!(issue_2317);
 test_case!(issue_2318);
+test_case!(issue_2320, {
+    let mut settings = default_test_settings();
+    settings.version = mago_php_version::PHPVersion::PHP84;
+    settings
+});
 
 #[test]
 #[cfg_attr(miri, ignore)]


### PR DESCRIPTION
## 📌 What Does This PR Do?

Preserves `class-string` narrowing after `class_exists($class) || interface_exists($class)`, so passing the checked value to `ReflectionClass` no longer reports `possibly-invalid-argument`. This also handles the equivalent early-return guard using `!class_exists($class) && !interface_exists($class)`.

## 🔍 Context & Motivation

Both existence functions supply exact conditional assertions. The analyzer collects these separately to avoid inferring their inverse when a check fails, but the collector discarded them for a true OR condition or a false AND condition.

The regression test includes the issue's [playground example](https://mago.carthage.software/latest/en/playground/#01a06e1e-df34-637b-35b8-a093ebafaf44), including its `namespace\` calls and PHP 8.4 syntax.

## 🛠️ Summary of Changes

- Combine assertions for variables constrained by both alternatives, distributing OR over their assertion clauses.
- Preserve one-way assertion behavior and use the existing formula size threshold to bound expansion.
- Add regression coverage for both operand orders, early returns, unchecked alternatives, exact assertions on both truth branches, nested conditions, and the expansion limit.

## 📂 Affected Areas

- [x] Analyzer

## 🔗 Related Issues or PRs

Fixes #2320.

## 📝 Notes for Reviewers

The original reproduction and the OR/early-return regression fixture failed before the fix and pass afterward. Existing regressions for #2278 and #2287 also pass.

Validation:

- `just test` — passed (8,540 tests), including all 2,532 analyzer integration tests.
- `just check` — passed (PHP formatting, linting and analysis; Rust formatting, Clippy, and workspace check).
- `just build` — passed; the release binary also analyzes the playground regression without issues.
