### PR TITLE
fix(analyzer): allow undefined class-alias destinations

### DIFF
--- a/crates/analyzer/src/context/block_flags.rs
+++ b/crates/analyzer/src/context/block_flags.rs
@@ -25,6 +25,8 @@ impl BlockContextFlags {
     /// class-like is in scope for name resolution, but the arguments are evaluated outside
     /// its body.
     pub const INSIDE_CLASS_LIKE_ATTRIBUTE: u32 = 1 << 18;
+    /// Set only while analyzing a literal `Name::class` used as a `class_alias()` destination.
+    pub const INSIDE_CLASS_ALIAS_DESTINATION: u32 = 1 << 19;
 
     #[inline]
     pub const fn new() -> Self {
@@ -149,6 +151,11 @@ impl BlockContextFlags {
     }
 
     #[inline(always)]
+    pub const fn inside_class_alias_destination(&self) -> bool {
+        self.contains(Self::INSIDE_CLASS_ALIAS_DESTINATION)
+    }
+
+    #[inline(always)]
     pub fn set_inside_conditional(&mut self, value: bool) {
         self.set(Self::INSIDE_CONDITIONAL, value);
     }
@@ -241,5 +248,10 @@ impl BlockContextFlags {
     #[inline(always)]
     pub fn set_inside_class_like_attribute(&mut self, value: bool) {
         self.set(Self::INSIDE_CLASS_LIKE_ATTRIBUTE, value);
+    }
+
+    #[inline(always)]
+    pub fn set_inside_class_alias_destination(&mut self, value: bool) {
+        self.set(Self::INSIDE_CLASS_ALIAS_DESTINATION, value);
     }
 }

--- a/crates/analyzer/src/invocation/analyzer.rs
+++ b/crates/analyzer/src/invocation/analyzer.rs
@@ -32,6 +32,8 @@ use mago_reporting::Annotation;
 use mago_reporting::Issue;
 use mago_span::HasSpan;
 use mago_span::Span;
+use mago_syntax::cst::Access;
+use mago_syntax::cst::ClassLikeConstantSelector;
 use mago_syntax::cst::Expression;
 use mago_word::Word;
 use mago_word::WordMap;
@@ -182,7 +184,23 @@ where
 
         let parameter = get_parameter_of_argument(&invocation.target, argument, *argument_offset);
 
-        analyze_and_store_argument_type(
+        // Restrict the exemption to a literal `Name::class` so it cannot hide errors in nested expressions.
+        let is_class_alias_destination = if parameter.is_some_and(|(offset, _)| offset == 1)
+            && let Expression::Access(Access::ClassConstant(access)) = argument_expression.unparenthesized()
+            && matches!(access.class, Expression::Identifier(_))
+            && let ClassLikeConstantSelector::Identifier(constant) = &access.constant
+            && constant.value.eq_ignore_ascii_case(b"class")
+            && let Some(FunctionLikeIdentifier::Function(name)) = invocation.target.get_function_like_identifier()
+            && name.as_bytes().eq_ignore_ascii_case(b"class_alias")
+        {
+            true
+        } else {
+            false
+        };
+        let was_inside_class_alias_destination = block_context.flags.inside_class_alias_destination();
+        block_context.flags.set_inside_class_alias_destination(is_class_alias_destination);
+
+        let analysis_result = analyze_and_store_argument_type(
             context,
             block_context,
             artifacts,
@@ -192,7 +210,10 @@ where
             &mut analyzed_argument_types,
             parameter.is_some_and(|p| p.1.is_by_reference()),
             None,
-        )?;
+        );
+
+        block_context.flags.set_inside_class_alias_destination(was_inside_class_alias_destination);
+        analysis_result?;
 
         if let Some(argument_type) = analyzed_argument_types.get(argument_offset)
             && let Some((_, parameter_ref)) = parameter

--- a/crates/analyzer/src/resolver/class_constant.rs
+++ b/crates/analyzer/src/resolver/class_constant.rs
@@ -190,6 +190,7 @@ where
     let class_string = match class_resolution.fqcn {
         Some(fq_class_id) => {
             if matches!(class_resolution.origin, ResolutionOrigin::Named { is_self: false, is_parent: false })
+                && !block_context.flags.inside_class_alias_destination()
                 && context.codebase.get_class_like(fq_class_id.as_bytes()).is_none()
             {
                 report_non_existent_class(context, fq_class_id, class_expr.span());

--- a/crates/analyzer/tests/cases/issue_2323.php
+++ b/crates/analyzer/tests/cases/issue_2323.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {
+    class Real {}
+
+    class_alias(Real::class, Alias::class);
+    \class_alias(Real::class, FullyQualifiedAlias::class);
+    class_alias(alias: NamedAlias::class, class: Real::class);
+    // @mago-format-ignore-next
+    CLASS_ALIAS(Real::class, (ParenthesizedAlias::class));
+
+    // @mago-expect analysis:non-existent-class-like
+    echo UnknownClass::class;
+
+    // @mago-expect analysis:non-existent-class-like
+    class_alias(UnknownSource::class, AliasFromUnknownSource::class);
+
+    // @mago-expect analysis:non-existent-class-like
+    class_alias(alias: NamedAliasFromUnknownSource::class, class: UnknownNamedSource::class);
+
+    /**
+     * @param non-empty-string $value
+     * @return non-empty-string
+     */
+    function identity(string $value): string
+    {
+        return $value;
+    }
+
+    // @mago-expect analysis:non-existent-class-like
+    class_alias(Real::class, identity(UnknownNestedClass::class));
+
+    function alias_from_missing_constant(): void
+    {
+        // @mago-expect analysis:non-existent-class-constant,no-value
+        class_alias(Real::class, Real::MISSING);
+    }
+}
+
+namespace Imported {
+    use function class_alias as create_alias;
+
+    create_alias(\Real::class, Alias::class);
+    class_alias(\Real::class, FallbackAlias::class);
+}
+
+namespace Custom {
+    function class_alias(string $class, string $alias): bool
+    {
+        return $class === $alias;
+    }
+
+    // @mago-expect analysis:non-existent-class-like
+    class_alias(\Real::class, Alias::class);
+}

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -2743,6 +2743,7 @@ test_case!(issue_2312);
 test_case!(issue_2315);
 test_case!(issue_2317);
 test_case!(issue_2318);
+test_case!(issue_2323);
 
 #[test]
 #[cfg_attr(miri, ignore)]


### PR DESCRIPTION
## 📌 What Does This PR Do?

Fixes the false `non-existent-class-like` diagnostic for `class_alias(Real::class, Alias::class)` when `Alias` is the name being created.

## 🔍 Context & Motivation

The general `::class` check required the alias destination to exist, even though `class_alias()` requires an unused destination name. This change exempts a direct `Name::class` expression passed to the built-in function’s `$alias` parameter.

## 🛠️ Summary of Changes

- Use the resolved function and mapped parameter to support qualified/imported calls and reordered named arguments.
- Scope the exemption with a spare bit in the existing context flags, with no new allocation or context storage. Restrict it to a literal class-name expression and restore it after argument analysis.
- Add a regression fixture covering the reported example and preserving diagnostics for missing source classes, ordinary class references/constants, nested calls, and namespaced functions named `class_alias`.

## 📂 Affected Areas

- [x] Analyzer

## 🔗 Related Issues or PRs

Fixes #2323.

## 📝 Notes for Reviewers

The initial regression fixture failed on main with four unexpected `non-existent-class-like` diagnostics. The fix leaves the separate existence-check policy and alias-symbol registration (#1364) unchanged.

Validation:

- Regression confirmed failing before the fix and passing afterward.
- `just test`: 8,537 tests passed, zero failures.
- `just check`: PHP formatting/lint/analysis, Rust formatting, Clippy, and workspace check passed.
- Exact issue reproduction analyzed with PHP 8.3 settings: no issues.
- `just build`: passed.
