### PR TITLE
test(extension): wait on a deadline for background pool growth

### DIFF
--- a/crates/extension/src/pool.rs
+++ b/crates/extension/src/pool.rs
@@ -1184,6 +1184,26 @@ mod tests {
         pool.shutdown();
     }
 
+    /// Blocks until the pool has started at least `expected` workers.
+    ///
+    /// A deadline, not a yield count: what a yield budget is worth in wall time
+    /// is unrelated to how long a worker takes to start.
+    #[cfg(unix)]
+    fn wait_for_workers(pool: &WorkerPool, expected: usize) {
+        const TIMEOUT: Duration = Duration::from_secs(10);
+
+        let deadline = Instant::now() + TIMEOUT;
+        while pool.len() < expected {
+            assert!(
+                Instant::now() < deadline,
+                "the pool started {} of {expected} workers within {TIMEOUT:?}",
+                pool.len(),
+            );
+
+            std::thread::sleep(Duration::from_millis(1));
+        }
+    }
+
     #[cfg(unix)]
     #[test]
     fn prepares_half_of_adaptive_capacity_in_the_background() {
@@ -1197,14 +1217,9 @@ mod tests {
         );
 
         pool.prepare_capacity();
-        for _ in 0..10_000 {
-            if pool.len() == 4 {
-                break;
-            }
-            std::thread::yield_now();
-        }
+        wait_for_workers(&pool, 4);
 
-        assert_eq!(pool.len(), 4);
+        assert_eq!(pool.len(), 4, "half of the configured capacity, and no more");
         pool.shutdown();
     }
 


### PR DESCRIPTION

## 📌 What Does This PR Do?

Makes `prepares_half_of_adaptive_capacity_in_the_background` wait on a wall-clock deadline instead
of a fixed `yield_now()` budget. The test fails intermittently as written — one run in five of
`cargo test -p mago-extension --lib` on an untouched tree, and more often when the whole workspace
suite runs in parallel.

## 🔍 Context & Motivation

The test bounds its wait by a count of yields, but what it waits for is `prepare_capacity()`
spawning a process on another thread. Those quantities are unrelated, and each moves by an order of
magnitude with machine conditions, so whichever is larger decides the outcome.

<details>
<summary>Before / After, and the measurements behind it</summary>

```rust
// before
pool.prepare_capacity();
for _ in 0..10_000 {
    if pool.len() == 4 {
        break;
    }
    std::thread::yield_now();
}

// after
pool.prepare_capacity();
wait_for_workers(&pool, 4);
```

| Conditions | Time to reach 4 workers | Wall time for 10,000 yields |
| :--- | :--- | :--- |
| Idle | 633 µs | 2.65 ms |
| Process-spawn contention (12 `fork` loops) | 750 µs — **23.6 ms** | 8.9 ms — 276 ms |
| CPU saturation (200 spinners) | 19.9 ms | 354 s |

On an idle machine the margin is only about four. Heavy CPU load is not the trigger: every yield
then finds another runnable thread and actually context-switches, so the budget grows enormously.
The trigger is contention on process creation while CPUs are still free — the spawn slows to tens
of milliseconds while yields stay near 265 ns, which is the shape of a full
`cargo test --workspace`.

</details>

## 🛠️ Summary of Changes

- Add a `wait_for_workers()` test helper that polls `pool.len()` against a 10-second deadline,
  sleeping a millisecond between checks, and reports how far the pool got on timeout: `the pool
  started 3 of 4 workers within 10s`.
- Keep the `assert_eq!` after the wait, so growing past half capacity still fails.

## 📂 Affected Areas

- [x] Other: test only, inside `#[cfg(test)]`

## 🔗 Related Issues or PRs

No prior report: searched `flaky test`, `prepares_half_of_adaptive_capacity`, `prepare_capacity`,
`adaptive pool test` and `intermittent test failure` across open and closed issues and PRs. The
test arrived with #2192.

## 📝 Notes for Reviewers

Ten seconds is never spent on a healthy run, since the loop returns as soon as the count is up. If
you would rather `prepare_capacity()` returned its `JoinHandle` so the test could join instead of
polling, say so — I did not reach for it because it changes a public API for a test's benefit.

Validation:

- The test passed 12 consecutive runs under the fork-storm load that reproduces the failure.
- `just test`: no failures across the workspace.
- `just check`: PHP formatting/lint/analysis, Rust formatting, Clippy, and workspace check passed.
