### PR TITLE
fix(config): stop `extends` from breaking an extension-host command

### DIFF
--- a/docs/content/en/extensions/configuration.md
+++ b/docs/content/en/extensions/configuration.md
@@ -113,4 +113,6 @@ extends = "../mago.base.toml"
 enabled = false
 ```
 
+`command` is replaced rather than appended to, because it is an argv: a layer that declares its own command gets exactly that command, and a layer that does not keeps the inherited one. Every other key in the host table merges as usual.
+
 See [Configuration](/guide/configuration/) for path resolution and merge precedence.

--- a/docs/content/en/guide/configuration.md
+++ b/docs/content/en/guide/configuration.md
@@ -130,6 +130,8 @@ threads = 8
 excludes = ["build"]   # appended -> ["vendor", "node_modules", "build"]
 ```
 
+`extends` is part of the published JSON schema, so a file using it still validates against `vendor/carthage-software/mago/schema.json`.
+
 Cycles are detected via canonical-path tracking and surface a clear error rather than recursing forever. Diamond inheritance (A extends B and C, both extend D) processes D once and is fine. Layers can mix formats freely; each is parsed by its own driver and merged at a generic value level before the final document is validated against the schema.
 
 ## Global options

--- a/docs/content/en/guide/configuration.md
+++ b/docs/content/en/guide/configuration.md
@@ -112,6 +112,7 @@ Per top-level key:
 
 - Tables and objects are deep-merged. A child can override a single key inside a nested table without redefining the whole table.
 - Arrays such as `source.excludes` and per-rule `exclude` lists are concatenated, parent first. If a base config excludes `vendor/`, you keep that exclude and add your own.
+- `extension-hosts.<name>.command` is the exception: it is an argv, where each element's meaning comes from its position, so a layer that redeclares it **replaces** it. Concatenating two commands would start the parent's program with the child's path as a stray argument. Every other key inside the host table still merges normally, so a layer can change `workers` or `enabled` and keep the inherited command.
 - Scalars (strings, numbers, booleans) are overwritten by the child.
 
 ```toml

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -43,6 +43,9 @@
 //! Layers are merged later-wins. For each top-level key:
 //! - **Tables / objects**: deep-merged recursively.
 //! - **Arrays** (e.g. `source.excludes`): concatenated, parent first.
+//! - **Positional arrays** (`extension-hosts.<name>.command`): child replaces parent. An argv
+//!   derives each element's meaning from its position, so concatenating two of them produces a
+//!   command that runs the parent's program with the child's path as a stray argument.
 //! - **Scalars**: child overwrites parent.
 //!
 //! All layers parse into a generic `serde_json::Value` tree. The merged tree is deserialized
@@ -1133,6 +1136,41 @@ environment = { APP_ENV = "test" }
     }
 
     #[test]
+    fn test_extends_replaces_an_extension_host_command() {
+        let dir = temp_dir().join("extends-host-command");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        write_file(&dir.join("base.toml"), "[extension-hosts.acme]\ncommand = [\"php\", \"vendor/acme/worker.php\"]\n");
+        write_file(
+            &dir.join("mago.toml"),
+            "extends = \"base.toml\"\n[extension-hosts.acme]\ncommand = [\"php\", \".mago/worker.php\"]\n",
+        );
+
+        let config = load_isolated(&dir.join("mago.toml"));
+
+        // Concatenating would give ["php", "vendor/acme/worker.php", "php", ".mago/worker.php"],
+        // which silently starts the base layer's worker and drops the project's own.
+        assert_eq!(config.extension_hosts["acme"].command, vec!["php", ".mago/worker.php"]);
+    }
+
+    #[test]
+    fn test_extends_keeps_an_extension_host_command_it_does_not_redeclare() {
+        let dir = temp_dir().join("extends-host-command-inherited");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        write_file(&dir.join("base.toml"), "[extension-hosts.acme]\ncommand = [\"php\", \"vendor/acme/worker.php\"]\n");
+        write_file(&dir.join("mago.toml"), "extends = \"base.toml\"\n[extension-hosts.acme]\nworkers = 3\n");
+
+        let config = load_isolated(&dir.join("mago.toml"));
+        let host = &config.extension_hosts["acme"];
+
+        assert_eq!(host.command, vec!["php", "vendor/acme/worker.php"]);
+        assert_eq!(host.workers, 3);
+    }
+
+    #[test]
     fn test_extends_cycle_is_detected() {
         let dir = temp_dir().join("extends-cycle");
         let _ = fs::remove_dir_all(&dir);
@@ -1442,17 +1480,43 @@ fn resolve_extends_entry(entry: &str, base_dir: &Path) -> Result<Option<(PathBuf
 /// `target`'s. Arrays are concatenated (target first, source second). Scalars in `source`
 /// replace scalars in `target`.
 fn merge_into(target: &mut Value, source: Value) {
+    let mut path = Vec::new();
+    merge_value_into(target, source, &mut path);
+}
+
+/// Whether the array at `path` is positional rather than additive.
+///
+/// Concatenation is the right default for a set of independent entries —
+/// `source.excludes`, `analyzer.plugins`, a rule's `exclude` list — because a
+/// base layer adding one is exactly what inheritance is for. It is wrong for an
+/// argv, where every element's meaning comes from its position: appending one
+/// command to another yields `php a.php php b.php`, which runs the base layer's
+/// worker with the child's path as a stray argument and gives the child no way
+/// to say otherwise. Those arrays are replaced by the later layer, like scalars.
+fn is_positional_array(path: &[String]) -> bool {
+    // `extension-hosts.<name>.command`
+    path.len() == 3 && path[0] == "extension-hosts" && path[2] == "command"
+}
+
+fn merge_value_into(target: &mut Value, source: Value, path: &mut Vec<String>) {
     use serde_json::Value;
     match (target, source) {
         (Value::Object(t), Value::Object(s)) => {
             for (k, v) in s {
                 match t.get_mut(&k) {
-                    Some(existing) => merge_into(existing, v),
+                    Some(existing) => {
+                        path.push(k);
+                        merge_value_into(existing, v, path);
+                        path.pop();
+                    }
                     None => {
                         t.insert(k, v);
                     }
                 }
             }
+        }
+        (target @ Value::Array(_), source @ Value::Array(_)) if is_positional_array(path) => {
+            *target = source;
         }
         (Value::Array(t), Value::Array(s)) => {
             t.extend(s);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -43,9 +43,8 @@
 //! Layers are merged later-wins. For each top-level key:
 //! - **Tables / objects**: deep-merged recursively.
 //! - **Arrays** (e.g. `source.excludes`): concatenated, parent first.
-//! - **Positional arrays** (`extension-hosts.<name>.command`): child replaces parent. An argv
-//!   derives each element's meaning from its position, so concatenating two of them produces a
-//!   command that runs the parent's program with the child's path as a stray argument.
+//! - **Positional arrays** (`extension-hosts.<name>.command`): child replaces parent, since
+//!   appending to an argv produces a different command rather than a merged one.
 //! - **Scalars**: child overwrites parent.
 //!
 //! All layers parse into a generic `serde_json::Value` tree. The merged tree is deserialized
@@ -157,6 +156,16 @@ const _: () = {
     assert!(bytes.len() == 4 && bytes[0] == b'M' && bytes[1] == b'A' && bytes[2] == b'G' && bytes[3] == b'O');
 };
 
+/// Shape of the top-level `extends` directive, for the published JSON schema only.
+///
+/// Either one parent layer or a list of them, applied left to right.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+enum ExtendsDirective {
+    One(String),
+    Many(Vec<String>),
+}
+
 /// The main configuration structure for Mago CLI.
 ///
 /// Aggregates all settings: top-level scalars (`php-version`, `threads`, …) plus
@@ -172,6 +181,14 @@ pub struct Configuration {
     #[serde(rename = "$schema", skip_serializing)]
     #[schemars(rename = "$schema", with = "Option<String>", !skip_serializing)]
     _schema: Option<IgnoredAny>,
+    /// Configuration layers this file inherits from.
+    ///
+    /// Declared for the published JSON schema only, which is
+    /// `additionalProperties: false`. [`extract_extends`] strips the directive
+    /// from every layer, so this field is never populated.
+    #[serde(default, rename = "extends", skip_serializing)]
+    #[schemars(rename = "extends", with = "Option<ExtendsDirective>", !skip_serializing)]
+    _extends: Option<IgnoredAny>,
     /// The mago version this project is pinned to.
     ///
     /// Accepts three pin levels:
@@ -601,6 +618,7 @@ impl Configuration {
     pub fn from_workspace(workspace: PathBuf) -> Self {
         Self {
             _schema: None,
+            _extends: None,
             version: None,
             threads: *LOGICAL_CPUS,
             stack_size: DEFAULT_STACK_SIZE,
@@ -1171,6 +1189,22 @@ environment = { APP_ENV = "test" }
     }
 
     #[test]
+    fn test_schema_accepts_the_extends_directive() {
+        let schema = serde_json::to_value(schemars::schema_for!(Configuration)).unwrap();
+
+        // A directive missing from an `additionalProperties: false` schema is an error.
+        assert_eq!(schema["additionalProperties"], serde_json::json!(false));
+
+        let extends = &schema["properties"]["extends"];
+        assert!(!extends.is_null(), "`extends` must be part of the published schema");
+
+        let definition = &schema["$defs"]["ExtendsDirective"]["anyOf"];
+        assert_eq!(definition[0]["type"], "string");
+        assert_eq!(definition[1]["type"], "array");
+        assert_eq!(definition[1]["items"]["type"], "string");
+    }
+
+    #[test]
     fn test_extends_cycle_is_detected() {
         let dir = temp_dir().join("extends-cycle");
         let _ = fs::remove_dir_all(&dir);
@@ -1477,22 +1511,18 @@ fn resolve_extends_entry(entry: &str, base_dir: &Path) -> Result<Option<(PathBuf
 }
 
 /// Recursively merge `source` into `target`. Object keys from `source` override / merge with
-/// `target`'s. Arrays are concatenated (target first, source second). Scalars in `source`
-/// replace scalars in `target`.
+/// `target`'s. Arrays are concatenated (target first, source second), except the positional ones
+/// named by [`is_positional_array`], which `source` replaces. Scalars in `source` replace scalars
+/// in `target`.
 fn merge_into(target: &mut Value, source: Value) {
     let mut path = Vec::new();
     merge_value_into(target, source, &mut path);
 }
 
-/// Whether the array at `path` is positional rather than additive.
+/// Whether the array at `path` is an argv, whose elements derive their meaning
+/// from their position, rather than an additive set like `source.excludes`.
 ///
-/// Concatenation is the right default for a set of independent entries —
-/// `source.excludes`, `analyzer.plugins`, a rule's `exclude` list — because a
-/// base layer adding one is exactly what inheritance is for. It is wrong for an
-/// argv, where every element's meaning comes from its position: appending one
-/// command to another yields `php a.php php b.php`, which runs the base layer's
-/// worker with the child's path as a stray argument and gives the child no way
-/// to say otherwise. Those arrays are replaced by the later layer, like scalars.
+/// Positional arrays are replaced by the later layer, like scalars.
 fn is_positional_array(path: &[String]) -> bool {
     // `extension-hosts.<name>.command`
     path.len() == 3 && path[0] == "extension-hosts" && path[2] == "command"


### PR DESCRIPTION

## 📌 What Does This PR Do?

Two fixes to `extends`: `extension-hosts.<name>.command` is an argv, so a layer that redeclares it
now replaces it instead of appending to it; and `extends` is now part of the published JSON schema,
which is `additionalProperties: false`.

## 🔍 Context & Motivation

`merge_into()` concatenates every array, which is the documented and correct default for
`source.excludes`, `analyzer.plugins` and per-rule `exclude` lists — every array in the
configuration except one. An extension host's `command` is a program followed by literal arguments,
so concatenating two of them does not merge anything; it produces a different, wrong command, and
the project has no way to opt out.

Separately, `mago config --schema` lists 16 top-level properties and `extends` is not among them,
while `guide/configuration` recommends pointing an editor at
`vendor/carthage-software/mago/schema.json`.

<details>
<summary>Before / After</summary>

A package ships a host; a project, not knowing it is inherited, declares its own:

```toml
# base.toml
[extension-hosts.acme]
command = ["php", "vendor-pkg/extension.php"]
```

```toml
# mago.toml
extends = "base.toml"
[extension-hosts.acme]
command = ["php", ".mago/extensions.php"]
```

Before, the merged command is `["php", "vendor-pkg/extension.php", "php", ".mago/extensions.php"]`,
so `php` runs the *package's* worker with the project's path as a stray argument. With each worker
registering a differently-named extension:

```
$ mago extension list      # before
Registered extensions:
Probe Base (probe/from-the-package)

$ mago extension list      # after
Registered extensions:
Probe Project (probe/from-the-project)
```

No error, no warning, and no workaround: there was no way to replace an inherited array. A layer
that does *not* redeclare `command` still inherits it, and every other key in the host table merges
as before.

For the schema:

```
$ mago config --schema | jq '.properties | has("extends")'
false      # before
true       # after — anyOf: string, or array of string
```

</details>

## 🛠️ Summary of Changes

- **Bug Fix:** the merge carries the key path so it can tell a positional array from an additive
  one. `is_positional_array()` names the single case, `extension-hosts.<name>.command`.
- **Bug Fix:** `Configuration` declares `extends` for the schema, with an `ExtendsDirective` shape
  of `string | array<string>`. It is never deserialized, since `extract_extends()` strips the
  directive from every layer first — the same treatment `$schema` already gets.
- **Docs:** the merge-semantics list in `guide/configuration` gains the exception and a note that
  `extends` validates; `extensions/configuration` says what happens to `command` where hosts are
  documented; the `src/config/mod.rs` module docs match.

## 📂 Affected Areas

- [x] CLI
- [x] Documentation
- [x] Other: configuration loading (`src/config`)

## 🔗 Related Issues or PRs

`extends` comes from #1173 (*Allow Vendored / Shared Config*, closed completed), where the request
was for Prettier/ESLint/PHPStan-style merging. The concatenating default is deliberate and this PR
does not touch it: `test_extends_array_excludes_concat` passes unchanged. No prior report on the
command argv or the schema gap.

## 📝 Notes for Reviewers

The two fixes are separate commits and can be split into two PRs if you prefer.

**This changes merge semantics**, for one key. Anyone relying on the old behaviour was relying on a
command that cannot run, so I do not think it can break a working setup — but it is a behaviour
change and not only a bug fix, so it is your call whether it wants a note in the changelog.

I deliberately did not add a general escape hatch — a `!replace` marker letting any layer overwrite
any inherited array. That is a syntax decision that belongs to you rather than to a bug fix, and the
narrow version needs no new configuration surface: `command` is the only positional array today.

De-duplicating instead would turn `["php", "a.php", "php", "b.php"]` into
`["php", "a.php", "b.php"]`, still the wrong command. The problem is not repetition.

Validation:

- Three new tests: the command is replaced, an unredeclared command is still inherited, and the
  schema accepts both written forms of the directive.
- Reproduced both bugs against a real PHP host before and after, which is where the output above
  comes from.
- `just check`: passed. `just test`: the only failure is
  `pool::tests::prepares_half_of_adaptive_capacity_in_the_background`, which is a pre-existing flake
  unrelated to this change — it waits on a fixed `yield_now()` budget rather than a deadline, fixed
  separately in #2353. If CI here goes red on that test, it is not this PR.
