### PR TITLE
fix(analyzer): infer integer exception codes and preserve PDO types

### DIFF
--- a/crates/analyzer/tests/cases/issue_2356.php
+++ b/crates/analyzer/tests/cases/issue_2356.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/** @throws LogicException */
+function chainCaughtThrowable(): void
+{
+    try {
+    } catch (Throwable $exception) {
+        // PDOException can supply a string code, so this can throw a TypeError at runtime.
+        // @mago-expect analysis:possibly-invalid-argument
+        throw new LogicException('Encountered unexpected exception', $exception->getCode(), $exception);
+    }
+}
+
+function throwableCode(Throwable $exception): int|string
+{
+    return $exception->getCode();
+}
+
+function exceptionCode(Exception $exception): int|string
+{
+    return $exception->getCode();
+}
+
+function pdoExceptionCode(PDOException $exception): int|string
+{
+    return $exception->getCode();
+}
+
+function chainException(Exception $exception): LogicException
+{
+    // @mago-expect analysis:possibly-invalid-argument
+    return new LogicException($exception->getMessage(), $exception->getCode(), $exception);
+}
+
+function chainPdoException(PDOException $exception): LogicException
+{
+    // @mago-expect analysis:possibly-invalid-argument
+    return new LogicException($exception->getMessage(), $exception->getCode(), $exception);
+}
+
+function pdoExceptionStringCode(PDOException $exception): string
+{
+    // PDOException codes can also be integers.
+    // @mago-expect analysis:invalid-return-statement
+    return $exception->getCode();
+}
+
+function chainError(Error $error): LogicException
+{
+    return new LogicException($error->getMessage(), $error->getCode(), $error);
+}
+
+function chainTypeError(TypeError $error): LogicException
+{
+    return new LogicException($error->getMessage(), $error->getCode(), $error);
+}
+
+function chainWithIntegerCode(Throwable $exception): LogicException
+{
+    $code = $exception->getCode();
+    if (is_int($code)) {
+        return new LogicException($exception->getMessage(), $code, $exception);
+    }
+
+    return new LogicException($exception->getMessage() . ' (' . $code . ')', 0, $exception);
+}
+
+function chainWithCastCode(Throwable $exception): LogicException
+{
+    return new LogicException($exception->getMessage(), (int) $exception->getCode(), $exception);
+}
+
+function chainWithDefaultCode(Throwable $exception): LogicException
+{
+    return new LogicException($exception->getMessage(), previous: $exception);
+}

--- a/crates/analyzer/tests/cases/issue_2356.php
+++ b/crates/analyzer/tests/cases/issue_2356.php
@@ -7,18 +7,16 @@ function chainCaughtThrowable(): void
 {
     try {
     } catch (Throwable $exception) {
-        // PDOException can supply a string code, so this can throw a TypeError at runtime.
-        // @mago-expect analysis:possibly-invalid-argument
         throw new LogicException('Encountered unexpected exception', $exception->getCode(), $exception);
     }
 }
 
-function throwableCode(Throwable $exception): int|string
+function throwableCode(Throwable $exception): int
 {
     return $exception->getCode();
 }
 
-function exceptionCode(Exception $exception): int|string
+function exceptionCode(Exception $exception): int
 {
     return $exception->getCode();
 }
@@ -30,7 +28,6 @@ function pdoExceptionCode(PDOException $exception): int|string
 
 function chainException(Exception $exception): LogicException
 {
-    // @mago-expect analysis:possibly-invalid-argument
     return new LogicException($exception->getMessage(), $exception->getCode(), $exception);
 }
 
@@ -57,7 +54,7 @@ function chainTypeError(TypeError $error): LogicException
     return new LogicException($error->getMessage(), $error->getCode(), $error);
 }
 
-function chainWithIntegerCode(Throwable $exception): LogicException
+function chainWithIntegerCode(PDOException $exception): LogicException
 {
     $code = $exception->getCode();
     if (is_int($code)) {
@@ -67,7 +64,7 @@ function chainWithIntegerCode(Throwable $exception): LogicException
     return new LogicException($exception->getMessage() . ' (' . $code . ')', 0, $exception);
 }
 
-function chainWithCastCode(Throwable $exception): LogicException
+function chainWithCastCode(PDOException $exception): LogicException
 {
     return new LogicException($exception->getMessage(), (int) $exception->getCode(), $exception);
 }
@@ -75,4 +72,87 @@ function chainWithCastCode(Throwable $exception): LogicException
 function chainWithDefaultCode(Throwable $exception): LogicException
 {
     return new LogicException($exception->getMessage(), previous: $exception);
+}
+
+function runtimeExceptionCode(RuntimeException $exception): int
+{
+    return $exception->getCode();
+}
+
+final class CustomException extends Exception {}
+
+function customExceptionCode(CustomException $exception): int
+{
+    return $exception->getCode();
+}
+
+final class CustomPdoException extends PDOException {}
+
+function chainCustomPdoException(CustomPdoException $exception): LogicException
+{
+    // @mago-expect analysis:possibly-invalid-argument
+    return new LogicException($exception->getMessage(), $exception->getCode(), $exception);
+}
+
+function nullableThrowableCode(?Throwable $exception): ?int
+{
+    return $exception?->getCode();
+}
+
+function nullablePdoExceptionCode(?PDOException $exception): int|string|null
+{
+    return $exception?->getCode();
+}
+
+/** @return Closure(): int */
+function throwableCodeCallable(Throwable $exception): Closure
+{
+    return $exception->getCode(...);
+}
+
+/** @return Closure(): int */
+function exceptionCodeCallable(Exception $exception): Closure
+{
+    return $exception->getCode(...);
+}
+
+/** @return Closure(): (int|string) */
+function pdoExceptionCodeCallable(PDOException $exception): Closure
+{
+    return $exception->getCode(...);
+}
+
+/** @return Closure(): int */
+function pdoExceptionIntegerCodeCallable(PDOException $exception): Closure
+{
+    // @mago-expect analysis:invalid-return-statement
+    return $exception->getCode(...);
+}
+
+function pdoExceptionHasCode(PDOException $exception): bool
+{
+    if ($exception->getCode() === 42) {
+        return true;
+    }
+
+    return false;
+}
+
+final class InvalidPdoExceptionOverride extends PDOException
+{
+    // @mago-expect analysis:override-final-method
+    public function getCode(): int|string
+    {
+        return 0;
+    }
+}
+
+function narrowPdoException(Throwable $exception): LogicException
+{
+    if ($exception instanceof PDOException) {
+        // @mago-expect analysis:possibly-invalid-argument
+        return new LogicException($exception->getMessage(), $exception->getCode(), $exception);
+    }
+
+    return new LogicException($exception->getMessage(), $exception->getCode(), $exception);
 }

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -2761,7 +2761,11 @@ test_case!(issue_2333);
 test_case!(issue_2336);
 test_case!(issue_2341);
 test_case!(issue_2352);
-test_case!(issue_2356);
+test_case!(issue_2356, {
+    let mut settings = default_test_settings();
+    settings.allow_side_effects_in_conditions = false;
+    settings
+});
 
 #[test]
 #[cfg_attr(miri, ignore)]

--- a/crates/analyzer/tests/mod.rs
+++ b/crates/analyzer/tests/mod.rs
@@ -2761,6 +2761,7 @@ test_case!(issue_2333);
 test_case!(issue_2336);
 test_case!(issue_2341);
 test_case!(issue_2352);
+test_case!(issue_2356);
 
 #[test]
 #[cfg_attr(miri, ignore)]

--- a/crates/prelude/assets/extensions/core.php
+++ b/crates/prelude/assets/extensions/core.php
@@ -121,6 +121,8 @@ interface Throwable extends Stringable
     public function getMessage(): string;
 
     /**
+     * Exception descendants such as PDOException can return string codes.
+     *
      * @return int|string
      */
     public function getCode();
@@ -162,6 +164,8 @@ class Exception implements Throwable
     final public function getMessage(): string {}
 
     /**
+     * Descendants such as PDOException can return string codes through this final method.
+     *
      * @return int|string
      *
      * @mutation-free

--- a/crates/prelude/assets/extensions/core.php
+++ b/crates/prelude/assets/extensions/core.php
@@ -121,9 +121,7 @@ interface Throwable extends Stringable
     public function getMessage(): string;
 
     /**
-     * Exception descendants such as PDOException can return string codes.
-     *
-     * @return int|string
+     * @return int
      */
     public function getCode();
 
@@ -164,9 +162,7 @@ class Exception implements Throwable
     final public function getMessage(): string {}
 
     /**
-     * Descendants such as PDOException can return string codes through this final method.
-     *
-     * @return int|string
+     * @return int
      *
      * @mutation-free
      */

--- a/crates/prelude/assets/extensions/pdo.php
+++ b/crates/prelude/assets/extensions/pdo.php
@@ -5,6 +5,15 @@ namespace {
     {
         public ?array $errorInfo;
         protected $code;
+
+        /**
+         * Models the inherited final method's PDO-specific return type.
+         *
+         * @return int|string
+         *
+         * @mutation-free
+         */
+        final public function getCode() {}
     }
 
     class PDO


### PR DESCRIPTION
## 📌 What Does This PR Do?

Addresses #2356 by inferring `int` for `Throwable::getCode()` and `Exception::getCode()`. The following exception-chaining pattern now passes analysis instead of reporting `possibly-invalid-argument` for the code parameter:

```php
function wrap(Throwable $exception): LogicException
{
    return new LogicException('Unexpected exception', $exception->getCode(), $exception);
}
```

Calls resolved to `PDOException`, including subclasses and values narrowed with `instanceof`, retain `int|string` and the corresponding argument warning.

## 🔍 Context & Motivation

The [PHP manual](https://www.php.net/manual/en/throwable.getcode.php) shows an `int` method synopsis but also documents string codes in descendants. This change adopts the integer contract for generic `Throwable` and `Exception` references and models PDO separately.

**Limitation:** a PDO exception referenced as generic `Throwable` or `Exception` can still return a string at runtime. This change can suppress a real warning in that case; it does not make unchecked chaining runtime-safe.

## 🛠️ Summary of Changes

- Change the core `Throwable` and `Exception` return annotations to `int`.
- Specialize PDO's inherited `getCode()` method in analysis metadata, preserving `int|string`, finality, and mutation-free calls.
- Add regressions for chaining, inheritance, nullsafe calls, first-class callables, PDO narrowing, side-effect checks, and final-method validation.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [x] Analyzer
- [ ] CLI
- [ ] Dependencies
- [ ] Documentation
- [x] Other: built-in PHP stubs

## 🔗 Related Issues or PRs

Fixes #2356.

## 📝 Notes for Reviewers

- `just build`, `just test`, and `just check` passed; **8,579 tests passed**.
- The rebuilt release CLI reports no issues for the original playground source.
- LLVM coverage: **9/9 regions (100%)** in the changed Rust test function. PHP stubs and fixtures are analyzer input; this figure is not PHP runtime coverage.
- **6/6 mutation checks passed**, covering the return contracts and PDO's final and mutation-free metadata.
- The PDO stub specializes an inherited final method for analysis; it does not represent a runtime PHP override.
