### PR TITLE
fix(linter): stop `ambiguous-function-call` reporting a function this file declares

### DIFF
--- a/crates/linter/src/context.rs
+++ b/crates/linter/src/context.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use mago_allocator::prelude::*;
 
 use mago_collector::Collector;
@@ -30,6 +32,9 @@ where
     pub constant_expression_depth: usize,
     imports: ImportTracker,
     ancestors: Vec<'arena, Node<'ctx, 'arena>, A>,
+    /// Resolved names of the functions this file declares, filled as the walk
+    /// reaches each declaration.
+    declared_functions: HashSet<&'arena [u8]>,
 }
 
 impl<'ctx, 'arena, A> LintContext<'ctx, 'arena, A>
@@ -55,6 +60,7 @@ where
             constant_expression_depth: 0,
             imports: ImportTracker::new(),
             ancestors: Vec::with_capacity_in(32, arena),
+            declared_functions: HashSet::new(),
         }
     }
 
@@ -112,6 +118,20 @@ where
         self.resolved_names.is_imported(&position.position())
     }
 
+    /// Whether this file declares the function the name at `position` resolves to.
+    ///
+    /// An unqualified call inside a namespace resolves to the namespaced
+    /// candidate, so comparing resolved names answers the question without
+    /// reassembling any name by hand.
+    ///
+    /// Only declarations the walk has already passed are known, so a call that
+    /// precedes the declaration it resolves to answers `false` even though PHP
+    /// hoists top-level declarations. Conditional declarations are recorded too,
+    /// which errs toward staying quiet.
+    pub fn declares_function(&self, position: &impl HasPosition) -> bool {
+        self.declared_functions.contains(self.resolved_names.get(&position.position()))
+    }
+
     /// Retrieves the name associated with a given position in the code.
     ///
     /// # Panics
@@ -126,6 +146,10 @@ where
     pub(crate) fn push_ancestor(&mut self, node: Node<'ctx, 'arena>) {
         self.ancestors.push(node);
         self.imports.enter_node(node);
+
+        if let Node::Function(function) = node {
+            self.declared_functions.insert(self.resolved_names.get(&function.name.position()));
+        }
     }
 
     /// Called by the walker on node exit. Rules must not call this.

--- a/crates/linter/src/rule/consistency/ambiguous_function_call.rs
+++ b/crates/linter/src/rule/consistency/ambiguous_function_call.rs
@@ -80,6 +80,11 @@ impl LintRule for AmbiguousFunctionCallRule {
 
                 // OK: Explicitly namespaced
                 $value = namespace\my_function();
+
+                function shout(string $value): string { return $value; }
+
+                // OK: declared in this file, in this namespace
+                $shouted = shout("hello");
             "#},
             bad_example: indoc! {r#"
                 <?php
@@ -135,6 +140,12 @@ impl LintRule for AmbiguousFunctionCallRule {
         }
 
         if ctx.is_name_imported(identifier) {
+            return;
+        }
+
+        // A function this file declares in this namespace is resolved at compile
+        // time, so neither reason in the notes below applies to it.
+        if ctx.declares_function(identifier) {
             return;
         }
 

--- a/crates/linter/tests/ambiguous_function_call.rs
+++ b/crates/linter/tests/ambiguous_function_call.rs
@@ -1,0 +1,78 @@
+#![allow(clippy::needless_raw_strings, clippy::needless_raw_string_hashes)]
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use mago_allocator::LocalArena;
+use mago_database::file::File;
+use mago_linter::Linter;
+use mago_linter::integration::IntegrationSet;
+use mago_linter::registry::RuleRegistry;
+use mago_linter::settings::RulesSettings;
+use mago_linter::settings::Settings;
+use mago_names::resolver::NameResolver;
+use mago_syntax::parser::parse_file;
+
+fn codes(code: &str) -> Vec<String> {
+    let arena = LocalArena::new();
+    let file = File::ephemeral(Cow::Owned(b"test.php".to_vec()), Cow::Owned(code.as_bytes().to_vec()));
+    let program = parse_file(&arena, &file);
+    let resolved_names = NameResolver::new(&arena).resolve(program);
+    let settings =
+        Settings { integrations: IntegrationSet::all(), rules: RulesSettings::default(), ..Settings::default() };
+    let php_version = settings.php_version;
+    let registry = RuleRegistry::build(&settings, Some(&["ambiguous-function-call".to_string()]), true);
+    let linter = Linter::from_registry(&arena, Arc::new(registry), php_version);
+
+    linter.lint(&file, program, &resolved_names).iter().filter_map(|issue| issue.code.clone()).collect()
+}
+
+#[test]
+fn a_function_declared_in_the_same_namespace_is_not_ambiguous() {
+    let issues = codes(
+        r#"<?php
+
+namespace App;
+
+function shout(string $value): string { return $value; }
+
+echo shout('hi');
+"#,
+    );
+
+    assert!(issues.is_empty(), "expected no issue, got {issues:?}");
+}
+
+#[test]
+fn a_function_the_file_does_not_declare_is_still_ambiguous() {
+    let issues = codes(
+        r#"<?php
+
+namespace App;
+
+echo other('hi');
+"#,
+    );
+
+    assert_eq!(issues, vec!["ambiguous-function-call".to_string()]);
+}
+
+#[test]
+fn a_declaration_in_another_namespace_does_not_silence_the_call() {
+    // The guard compares resolved names, so `B\shout` is not answered by a
+    // declaration of `A\shout` sitting in the same file.
+    let issues = codes(
+        r#"<?php
+
+namespace A {
+    function shout(string $value): string { return $value; }
+}
+
+namespace B {
+    echo shout('hi');
+}
+"#,
+    );
+
+    assert_eq!(issues, vec!["ambiguous-function-call".to_string()]);
+}


### PR DESCRIPTION

## 📌 What Does This PR Do?

`ambiguous-function-call` reports an unqualified call to a function declared in the same file and
the same namespace. There is no ambiguity there, and the two spellings its help offers are both
wrong for that case — one of them makes another rule fire. This skips those calls.

## 🔍 Context & Motivation

PHP resolves such a call to the namespaced function at compile time, so neither reason the rule
gives applies: the fallback lookup does not happen, and a function "later added to the namespace"
is already added.

The help says to write `\shout(...)` or `use function shout;`. The first names a global function
that does not exist. The second silences this rule and makes **`no-redundant-use`** fire, so a
project that turns the rule on is left with `namespace\shout(...)` or the fully qualified name,
neither of which the help mentions.

<details>
<summary>Before / After</summary>

```php
<?php

namespace App;

function shout(string $value): string { return $value; }

echo shout('hi');
```

```console
$ mago lint --only ambiguous-function-call        # before
error[ambiguous-function-call]: Ambiguous function call detected.
  ┌─ src/same_file.php:7:6
  = Help: Make the call explicit: for global functions, use `\shout(...)` or add a
    `use function shout;` statement.

$ mago lint --only ambiguous-function-call        # after
No issues found.
```

Following the help makes the other rule fire:

```php
use function App\shout;
```

```console
$ mago lint --only ambiguous-function-call,no-redundant-use
warning[no-redundant-use]: Redundant import: `shout` is already in the current namespace `App`.
```

</details>

## 🛠️ Summary of Changes

- **Bug Fix:** the rule skips a call whose resolved name this file declares, placed next to the
  existing `ctx.is_name_imported()` guard.
- `LintContext` records the resolved name of each function declaration as the walk reaches it, and
  answers `declares_function()`. The call and the declaration resolve to the same name, so the
  comparison needs no name reassembly — and a declaration in a *different* namespace of the same
  file correctly does not silence the call.
- The rule's `good_example` gains the case, so `test_all_rule_examples` covers it.

## 📂 Affected Areas

- [x] Linter

## 🔗 Related Issues or PRs

No prior report: searched `ambiguous-function-call`, `no-redundant-use` and
`ambiguous function same file` across open and closed issues and PRs.

## 📝 Notes for Reviewers

**One case deliberately left out.** Declarations are recorded as the walk passes them, so a call
that *precedes* the declaration it resolves to still reports, even though PHP hoists unconditional
top-level declarations. Covering it needs the whole file up front — a pre-pass, or a lazily built
index on `LintContext`. I left it out to keep this the size of the bug reported, and it is a false
positive that remains rather than a new one. Say the word and I will add the index.

A conditionally declared function is recorded too, which errs toward staying quiet rather than
reporting a call that may be fine.

Validation:

- Three tests in `crates/linter/tests/ambiguous_function_call.rs`: the same-namespace declaration is
  silent, an undeclared name still reports, and a declaration in another namespace of the same file
  does not silence the call.
- `just test`: no failures across the workspace. `just check`: PHP formatting/lint/analysis, Rust
  formatting, Clippy, and workspace check passed — including the repo's own `mago lint`, which runs
  this rule at `error`.
