### PR TITLE
fix(orchestrator): use 4-byte emoji for guard progress bar

### DIFF
--- a/crates/orchestrator/src/service/guard.rs
+++ b/crates/orchestrator/src/service/guard.rs
@@ -80,7 +80,7 @@ impl GuardService {
     ///
     /// Returns [`OrchestratorError`] when guard pipelines fail or scanning encounters IO errors.
     pub fn run(self) -> Result<GuardResult, OrchestratorError> {
-        const GUARD_PROGRESS_PREFIX: &str = "🛡️  Guarding";
+        const GUARD_PROGRESS_PREFIX: &str = "🔒 Guarding";
 
         // Determine upfront which guards will be skipped due to missing config
         let skipped_perimeter = matches!(self.settings.should_run_perimeter(), Some(false));


### PR DESCRIPTION
## 📌 What Does This PR Do?

Replaces the shield emoji (🛡️) with a padlock (🔒) in the guard progress bar.

before: 
<img width="1621" height="520" alt="image" src="https://github.com/user-attachments/assets/58d2e466-7594-46b2-afea-d5c8e7237017" />

after: 

<img width="1618" height="83" alt="image" src="https://github.com/user-attachments/assets/745492f7-3ec0-4b0c-87ad-8321ebdcba1f" />


## 🔍 Context & Motivation

Same class of problem as #866, which fixed the analysis progress bar. The guard prefix was the last one still using a variation selector sequence.

## 🛠️ Summary of Changes

- **Bug Fix:** Changed the guard progress prefix from `🛡️  Guarding` (7 bytes, 2 chars) to `🔒 Guarding` (4 bytes, 1 char) in `GuardService::run`.

## 📂 Affected Areas

- [ ] Linter
- [ ] Formatter
- [ ] Analyzer
- [x] CLI
- [ ] Dependencies
- [ ] Documentation
- [ ] Other (please specify):

## 🔗 Related Issues or PRs

Follows #866.

## 📝 Notes for Reviewers

- Verified in the PHPStorm terminal with a release build, which is where the shield failed to render.
- Bar alignment is unchanged. `unicode-width` 0.2.2 already measured the shield plus selector as 2 columns, so the `{prefix:<16}` padding in `progress.rs` was never wrong. The double space went with it because the padlock needs no extra spacing.
- `🔬 Analyzing` and `🧹 Linting` were already single 4-byte characters, so no other prefix needed a change.
- Other 4-byte options if the padlock is not preferred: 🛟 🚧 🚨 🧱.
