### PR TITLE
fix(formatter): indent the continuation of a chain the formatter breaks itself

### DIFF
--- a/crates/formatter/src/internal/format/assignment.rs
+++ b/crates/formatter/src/internal/format/assignment.rs
@@ -263,7 +263,11 @@ where
             return Layout::NeverBreakAfterOperator;
         }
 
-        if is_breaking_expression(f, binary.rhs, false) {
+        // Keeping the right-hand side on the assignment line pays off only while the operator
+        // chain itself stays on one line and just its tail breaks. Once the left-hand side is
+        // another binary, the chain breaks at its own operators too, and its continuation lines
+        // end up flush with the assignment instead of indented under it.
+        if !binary.lhs.is_binary() && is_breaking_expression(f, binary.rhs, false) {
             return Layout::NeverBreakAfterOperator;
         }
     }

--- a/crates/formatter/tests/cases/broken_concatenation_chain_is_indented/after.php
+++ b/crates/formatter/tests/cases/broken_concatenation_chain_is_indented/after.php
@@ -1,0 +1,25 @@
+<?php
+
+class Demo
+{
+    public function run($targetDir, $idCustomer, $idDummyarticle)
+    {
+        if (true) {
+            if (true) {
+                foreach ($_FILES as $Fileid) {
+                    $targetFile =
+                        date('Y-m-d', time())
+                        . '_'
+                        . $idCustomer
+                        . '_'
+                        . $idDummyarticle
+                        . '_'
+                        . basename(
+                            $Fileid['name'],
+                        );
+                    $targetPath = $targetDir . $targetFile;
+                }
+            }
+        }
+    }
+}

--- a/crates/formatter/tests/cases/broken_concatenation_chain_is_indented/before.php
+++ b/crates/formatter/tests/cases/broken_concatenation_chain_is_indented/before.php
@@ -1,0 +1,18 @@
+<?php
+
+class Demo
+{
+    public function run($targetDir, $idCustomer, $idDummyarticle)
+    {
+        if (true) {
+            if (true) {
+                foreach ($_FILES as $Fileid) {
+                    $targetFile = date('Y-m-d', time()) . '_' . $idCustomer . '_' . $idDummyarticle . '_' . basename(
+                        $Fileid['name']
+                    );
+                    $targetPath = $targetDir . $targetFile;
+                }
+            }
+        }
+    }
+}

--- a/crates/formatter/tests/cases/broken_concatenation_chain_is_indented/settings.inc
+++ b/crates/formatter/tests/cases/broken_concatenation_chain_is_indented/settings.inc
@@ -1,0 +1,1 @@
+FormatSettings { preserve_breaking_argument_list: true, ..FormatSettings::default() }

--- a/crates/formatter/tests/mod.rs
+++ b/crates/formatter/tests/mod.rs
@@ -119,6 +119,7 @@ test_case!(inline_php);
 test_case!(inline_html_alignment);
 test_case!(inline_echo);
 test_case!(inline_php_closing_tag_idempotency);
+test_case!(broken_concatenation_chain_is_indented);
 test_case!(parameter_attributes);
 test_case!(parameter_attribute_on_new_line);
 test_case!(parameter_attribute_on_new_line_disabled);


### PR DESCRIPTION
Fixes #2368.

## Problem

When the formatter breaks an operator chain by itself, the continuation lines are not indented, so the chain runs flush with the assignment it belongs to:

```php
$targetFile = date('Y-m-d', time())
. '_'
. $idCustomer
. '_'
. basename($file['name']);
```

An already-broken chain, or the same chain under default settings, is printed the way one would expect:

```php
$targetFile =
    date('Y-m-d', time())
    . '_'
    . $idCustomer
    . '_'
    . basename($file['name']);
```

## Cause

`choose_layout` takes a shortcut for a binary right-hand side:

```rust
if let Expression::Binary(binary) = rhs_expression {
    …
    if is_breaking_expression(f, binary.rhs, false) {
        return Layout::NeverBreakAfterOperator;
    }
}
```

Keeping the right-hand side on the assignment line is right when only its tail breaks, for example a call that spreads its arguments. It is wrong when the chain itself breaks at its operators: the whole expression then sits at the indentation of the assignment, and the operators line up with the statement instead of under it.

The reproducer needs the last operand to be a call that is known to break. `preserve-breaking-argument-list = true` makes that happen for any call the author had already broken, which is why the shape shows up systematically in an existing code base and not under the defaults.

## Change

The shortcut now applies only while the left-hand side is not itself a binary, so a chain with more than one operator falls through to `should_break_after_operator`, which already returns `true` for a non-inlinable binary right-hand side. The result is `Layout::BreakAfterOperator`, the layout the pre-broken chain uses.

Default behaviour is unchanged: all 463 existing formatter cases pass untouched.

## Tests

- New case `broken_concatenation_chain_is_indented`, with `preserve_breaking_argument_list: true` so the trigger is part of the fixture.
- `cargo test --workspace`, `cargo fmt --check` and `cargo clippy -D warnings` are green.
- Checked against the code base that surfaced this, a 16k-file PHP 7.0 tree: the patched binary changes 12 files, each of them one of these chains, and nothing else. Besides concatenations it also fixes `||` chains whose last operand is a broken call.
